### PR TITLE
fix: update color and grid path

### DIFF
--- a/core/src/global/global.scss
+++ b/core/src/global/global.scss
@@ -6,7 +6,7 @@
 //@import '../theme/core/logotype/vars.scss';
 
 // Colors
-@import '../../../color';
+@import '../../../color/color';
 
 
 // Typography
@@ -15,7 +15,7 @@
 @import 'scania-fonts-selectors';
 
 // Grid
-@import '../../../grid/dist/css/grid.css';
+@import '../../../grid/grid';
 
 // Vars
 @import '_variables.scss';


### PR DESCRIPTION
- Fixes wrong color css path that caused build to crash
- Updates the path to use unbuilt scss files to not require building other packages.