### PR TITLE
fix(components): changed from hostelement to htmlelement

### DIFF
--- a/.github/CODE_STYLE.md
+++ b/.github/CODE_STYLE.md
@@ -60,7 +60,7 @@ Our component files (e.g. button.tsx) should follow the following structure, in 
   shadow: true,
 })
 export class SddsComponent {
-  @Element() host: HostElement;
+  @Element() host: HTMLElement;
 
   /** Comment explaining the use of the the prop */
   @Prop() prop: string;

--- a/core/src/components/banner/sdds-banner.tsx
+++ b/core/src/components/banner/sdds-banner.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, Event, EventEmitter, Method, Element } from '@stencil/core';
-import { HostElement, State } from '@stencil/core/internal';
+import { State } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-banner',
@@ -7,6 +7,8 @@ import { HostElement, State } from '@stencil/core/internal';
   shadow: true,
 })
 export class SddsBanner {
+  @Element() host: HTMLElement;
+
   /** Name of the icon for the component. For error and information type the icon is predefined. */
   @Prop() icon: string;
 
@@ -31,8 +33,6 @@ export class SddsBanner {
   @State() hasSubheader: boolean;
 
   @State() hasLink: boolean;
-
-  @Element() host: HostElement;
 
   /** Sends unique banner identifier when the close button is pressed. */
   @Event({

--- a/core/src/components/block/sdds-block.tsx
+++ b/core/src/components/block/sdds-block.tsx
@@ -1,5 +1,4 @@
 import { Component, h, Prop, Element } from '@stencil/core';
-import { HostElement } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-block',
@@ -7,10 +6,10 @@ import { HostElement } from '@stencil/core/internal';
   shadow: true,
 })
 export class SddsBlock {
+  @Element() host: HTMLElement;
+
   /** Mode variant of the component, based on current mode. */
   @Prop() modeVariant: 'primary' | 'secondary' = null;
-
-  @Element() host: HostElement;
 
   children: Array<HTMLSddsBlockElement>;
 
@@ -30,7 +29,9 @@ export class SddsBlock {
   render() {
     return (
       <div
-        class={`sdds-block-webcomponent ${this.modeVariant !== null ? `sdds-mode-variant-${this.modeVariant}`: ''}`}
+        class={`sdds-block-webcomponent ${
+          this.modeVariant !== null ? `sdds-mode-variant-${this.modeVariant}` : ''
+        }`}
       >
         <slot></slot>
       </div>

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -1,5 +1,4 @@
 import { Component, Element, h, Host, Prop, State } from '@stencil/core';
-import { HostElement } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-button',
@@ -7,6 +6,8 @@ import { HostElement } from '@stencil/core/internal';
   shadow: true,
 })
 export class SddsButton {
+  @Element() host: HTMLElement;
+
   // TODO: Make this mandatory prop. Send warning to user if empty and it is not icon only version of button.
   /** Text inside a button */
   @Prop() text: string = '';
@@ -26,8 +27,6 @@ export class SddsButton {
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
   @State() onlyIcon: boolean = false;
-
-  @Element() host: HostElement;
 
   componentWillLoad() {
     if (this.text === '') {

--- a/core/src/components/checkbox/sdds-checkbox.tsx
+++ b/core/src/components/checkbox/sdds-checkbox.tsx
@@ -1,5 +1,4 @@
 import { Component, h, Prop, Event, EventEmitter, Method, Element } from '@stencil/core';
-import { HostElement } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-checkbox',
@@ -8,6 +7,8 @@ import { HostElement } from '@stencil/core/internal';
   scoped: true,
 })
 export class SddsCheckbox {
+  @Element() host: HTMLElement;
+
   /** Name for the checkbox's input element. */
   @Prop() name: string;
 
@@ -25,8 +26,6 @@ export class SddsCheckbox {
 
   /** Value for the checkbox */
   @Prop() value: string;
-
-  @Element() host: HostElement;
 
   /** Toggles the checked value of the component. */
   @Method()

--- a/core/src/components/dropdown-v2/dropdown-option-v2/dropdown-option-v2.tsx
+++ b/core/src/components/dropdown-v2/dropdown-option-v2/dropdown-option-v2.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, State, Element, Event } from '@stencil/core';
-import { EventEmitter, HostElement, Method } from '@stencil/core/internal';
+import { EventEmitter, Method } from '@stencil/core/internal';
 import { SddsCheckboxCustomEvent } from '../../../components';
 
 @Component({
@@ -10,7 +10,7 @@ import { SddsCheckboxCustomEvent } from '../../../components';
   },
 })
 export class SddsDropdownOptionV2 {
-  @Element() host: HostElement;
+  @Element() host: HTMLElement;
 
   /** Value for the dropdown option. */
   @Prop() value: string;

--- a/core/src/components/dropdown-v2/dropdown-v2.tsx
+++ b/core/src/components/dropdown-v2/dropdown-v2.tsx
@@ -1,13 +1,5 @@
 import { Component, Host, h, Element, State } from '@stencil/core';
-import {
-  Event,
-  EventEmitter,
-  HostElement,
-  Listen,
-  Method,
-  Prop,
-  Watch,
-} from '@stencil/core/internal';
+import { Event, EventEmitter, Listen, Method, Prop, Watch } from '@stencil/core/internal';
 import {
   appendChildElement,
   appendHiddenInput,
@@ -21,7 +13,7 @@ import {
   shadow: true,
 })
 export class SddsDropdownV2 {
-  @Element() host: HostElement;
+  @Element() host: HTMLElement;
 
   /** Name for the dropdowns input element. */
   @Prop() name: string;

--- a/core/src/components/footer/webcomponent/sdds-footer-group/sdds-footer-group.tsx
+++ b/core/src/components/footer/webcomponent/sdds-footer-group/sdds-footer-group.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, Element } from '@stencil/core';
-import { HostElement, State } from '@stencil/core/internal';
+import { State } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-footer-group',
@@ -7,7 +7,7 @@ import { HostElement, State } from '@stencil/core/internal';
   shadow: true,
 })
 export class SddsFooterGroup {
-  @Element() host: HostElement;
+  @Element() host: HTMLElement;
 
   /** Title text for the link group, only valid on top part of footer. */
   @Prop() titleText: string;

--- a/core/src/components/footer/webcomponent/sdds-footer-item/sdds-footer-item.tsx
+++ b/core/src/components/footer/webcomponent/sdds-footer-item/sdds-footer-item.tsx
@@ -1,13 +1,11 @@
 import { Component, Element, h } from '@stencil/core';
-import { HostElement } from '@stencil/core/internal';
-
 @Component({
   tag: 'sdds-footer-item',
   styleUrl: 'sdds-footer-item.scss',
   shadow: true,
 })
 export class SddsFooterItem {
-  @Element() host: HostElement;
+  @Element() host: HTMLElement;
 
   private parentIsTopPart: boolean = false;
 

--- a/core/src/components/footer/webcomponent/sdds-footer.tsx
+++ b/core/src/components/footer/webcomponent/sdds-footer.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State, Element } from '@stencil/core';
-import { Host, HostElement, Prop } from '@stencil/core/internal';
+import { Host, Prop } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-footer',
@@ -7,7 +7,7 @@ import { Host, HostElement, Prop } from '@stencil/core/internal';
   shadow: true,
 })
 export class SddsFooter {
-  @Element() host: HostElement;
+  @Element() host: HTMLElement;
 
   /** Mode variant of the component, based on current mode. */
   @Prop() modeVariant: 'primary' | 'secondary' = null;

--- a/core/src/components/link/sdds-link.tsx
+++ b/core/src/components/link/sdds-link.tsx
@@ -1,19 +1,17 @@
 import { Component, h, Prop, Element } from '@stencil/core';
-import { HostElement } from '@stencil/core/internal';
-
 @Component({
   tag: 'sdds-link',
   styleUrl: 'sdds-link.scss',
   shadow: false,
 })
 export class SddsLink {
+  @Element() host: HTMLElement;
+
   /** Disables the link */
   @Prop() disabled: boolean = false;
 
   /** Displays the link with an underline. */
   @Prop() underline: boolean = true;
-
-  @Element() host: HostElement;
 
   connectedCallback() {
     this.host.children[0].classList.add('sdds-link-component');

--- a/core/src/components/radio-button/radio-button.tsx
+++ b/core/src/components/radio-button/radio-button.tsx
@@ -1,5 +1,4 @@
 import { Component, h, Prop, Event, EventEmitter, Element } from '@stencil/core';
-import { HostElement } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-radio-button',
@@ -8,6 +7,8 @@ import { HostElement } from '@stencil/core/internal';
   scoped: true,
 })
 export class RadioButton {
+  @Element() host: HTMLElement;
+
   /** Name of radio button, used for reference. */
   @Prop() name: string;
 
@@ -33,8 +34,6 @@ export class RadioButton {
 
   /** Decides if the radio button is disabled or not. */
   @Prop() disabled: boolean = false;
-
-  @Element() host: HostElement;
 
   /** Sends unique radio button identifier and status when it is checked. If no ID is specified a random one will be generated. To use this listener don't use the randomized ID, use a specific one of your choosing. */
   @Event({

--- a/core/src/components/stepper/sdds-stepper.tsx
+++ b/core/src/components/stepper/sdds-stepper.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, Element, Event } from '@stencil/core';
-import { EventEmitter, HostElement, Watch } from '@stencil/core/internal';
+import { EventEmitter, Watch } from '@stencil/core/internal';
 
 type SddsStepperProps = {
   orientation: 'horizontal' | 'vertical';
@@ -19,7 +19,7 @@ export type InternalSddsStepperPropChange = {
   shadow: true,
 })
 export class SddsStepper {
-  @Element() host: HostElement;
+  @Element() host: HTMLElement;
 
   /** The orientation the children are layed out. */
   @Prop() orientation: 'horizontal' | 'vertical' = 'horizontal';

--- a/core/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/core/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, State, Element, h, Prop, Event, EventEmitter } from '@stencil/core';
-import { HostElement, Method } from '@stencil/core/internal';
+import { Method } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-inline-tabs',
@@ -7,6 +7,8 @@ import { HostElement, Method } from '@stencil/core/internal';
   shadow: true,
 })
 export class InlineTabsFullbleed {
+  @Element() host: HTMLElement;
+
   /** Variant of the tabs, primary= on white, secondary= on grey50 */
   @Prop() modeVariant: 'primary' | 'secondary' = 'primary';
 
@@ -16,8 +18,6 @@ export class InlineTabsFullbleed {
   /** Sets the selected tab.
    * If this is set all tab changes needs to be handled by the user. */
   @Prop({ reflect: true }) selectedIndex: number;
-
-  @Element() host: HostElement;
 
   @State() showLeftScroll: boolean = false;
 
@@ -127,9 +127,9 @@ export class InlineTabsFullbleed {
     this.children = this.children.map((item, index) => {
       item.addEventListener('click', () => {
         const sddsChangeEvent = this.sddsChange.emit({
-          selectedTabIndex: this.children.indexOf(item)
+          selectedTabIndex: this.children.indexOf(item),
         });
-        if(!sddsChangeEvent.defaultPrevented) {
+        if (!sddsChangeEvent.defaultPrevented) {
           if (!item.disabled) {
             this.children.forEach((element) => element.setSelected(false));
             item.setSelected(true);

--- a/core/src/components/toast/sdds-toast.tsx
+++ b/core/src/components/toast/sdds-toast.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, Element, Event, EventEmitter } from '@stencil/core';
-import { HostElement, Method, State } from '@stencil/core/internal';
+import { Method, State } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-toast',
@@ -7,6 +7,8 @@ import { HostElement, Method, State } from '@stencil/core/internal';
   shadow: true,
 })
 export class SddsToast {
+  @Element() host: HTMLElement;
+
   /** ID for the toast. Randomly generated if not specified. */
   @Prop() toastId: string = crypto.randomUUID();
 
@@ -24,8 +26,6 @@ export class SddsToast {
 
   /** ARIA role for the toast. */
   @Prop() toastRole: 'alert' | 'log' | 'status' = 'alert';
-
-  @Element() host: HostElement;
 
   @State() hasSubheader: boolean;
 

--- a/core/src/components/toggle/sdds-toggle.tsx
+++ b/core/src/components/toggle/sdds-toggle.tsx
@@ -1,6 +1,4 @@
 import { Component, h, Prop, Event, Element, EventEmitter, Method } from '@stencil/core';
-import { HostElement } from '@stencil/core/internal';
-
 @Component({
   tag: 'sdds-toggle',
   styleUrl: 'sdds-toggle.scss',
@@ -8,6 +6,8 @@ import { HostElement } from '@stencil/core/internal';
   scoped: true,
 })
 export class SddsToggle {
+  @Element() host: HTMLElement;
+
   /** Sets the toggle as checked */
   @Prop({ reflect: true }) checked: boolean = false;
 
@@ -28,8 +28,6 @@ export class SddsToggle {
 
   /** ID of the toggles input element, if not specifed it's randomly generated */
   @Prop() toggleId: string = crypto.randomUUID();
-
-  @Element() host: HostElement;
 
   /** Toggles the toggle. */
   @Method()


### PR DESCRIPTION
**Describe pull-request**  
Removed HostElement import from `'@stencil/core/internal';` as it is no longer a part of it. Changed it to using htmlelement instead. Also moved declaration to top of file as per styleguide.

**Solving issue**  
Fixes: [DTS-1669](https://tegel.atlassian.net/browse/DTS-1669)

**How to test**  
_Add description how to test if possible_
1. Go to...
2. Check in...
3. Run ...

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


[DTS-1669]: https://tegel.atlassian.net/browse/DTS-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ