### PR TITLE
fix(button): made the button non-clickable when disabled

### DIFF
--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -1,4 +1,4 @@
-@import './button-vars.scss';
+@import './button-vars';
 @import '../../mixins/box-sizing';
 
 .sdds-on-white-bg {
@@ -324,6 +324,7 @@ i.sdds-btn-icon[slot='icon'] {
   ::slotted([slot='icon']) {
     width: var(--sdds-spacing-element-20);
     height: var(--sdds-spacing-element-20);
+    pointer-events: none;
   }
 
   .sdds-btn-sm {

--- a/core/src/components/button/button.stories.tsx
+++ b/core/src/components/button/button.stories.tsx
@@ -199,6 +199,11 @@ const WebComponentTemplate = ({
         }
     </sdds-button>
   </div>
+  <script>
+        document.querySelector('sdds-button').addEventListener('click', (event) => {
+          console.log(event)
+        })
+  </script>
   `,
   );
 };

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -39,13 +39,14 @@ export class SddsButton {
     return (
       <Host class={`${this.modeVariant !== null ? `sdds-mode-variant-${this.modeVariant}` : ''}`}>
         <button
+          disabled={this.disabled}
           class={`sdds-btn sdds-btn-${this.type} 
-        ${`sdds-btn-${this.size}`}
-        ${this.disabled ? 'disabled' : ''}
-        ${this.fullbleed ? 'sdds-btn-fullbleed' : ''}
-        ${this.onlyIcon ? 'sdds-btn-only-icon' : ''}`}
+          ${`sdds-btn-${this.size}`}
+          ${this.disabled ? 'disabled' : ''}
+          ${this.fullbleed ? 'sdds-btn-fullbleed' : ''}
+          ${this.onlyIcon ? 'sdds-btn-only-icon' : ''}`}
         >
-          <span class="sdds-btn-text">{this.text}</span>
+          {this.text}
           <slot name="icon" />
         </button>
       </Host>


### PR DESCRIPTION
**Describe pull-request**  
* Removed the underlying slot in the button
* Added pointer-events non to the sdds-icon slot
* Made the underlying button disabled

Note: This PR only make the icon non-clickable using CSS. We should add some underlying JS to make it a bit more secure.

**Solving issue**  
Fixes: #

**How to test**  
1. Go to storybook link below
2. Check in Components -> Button
3. Click the button and check the log for the event
4. Disable the button
5. Click the button and check that there are no new logs

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events