### PR TITLE
fix(button): updated margin-left on sdds-icon inside btn, removed rules for fullbleed

### DIFF
--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -360,44 +360,25 @@ i.sdds-btn-icon[slot='icon'] {
 
   .sdds-btn-sm {
     ::slotted([slot='icon']) {
-      margin-left: var(--sdds-spacing-element-24);
+      margin-left: var(--sdds-spacing-element-12);
       width: var(--sdds-spacing-element-16);
       height: var(--sdds-spacing-element-16);
-    }
-
-    &.sdds-btn-fullbleed {
-      ::slotted([slot='icon']) {
-        margin-left: var(--sdds-spacing-element-12);
-      }
     }
   }
 
   .sdds-btn-md {
     ::slotted([slot='icon']) {
-      margin-left: var(--sdds-spacing-element-20);
+      margin-left: var(--sdds-spacing-element-16);
       width: var(--sdds-spacing-element-20);
       height: var(--sdds-spacing-element-20);
-    }
-
-    &.sdds-btn-fullbleed {
-      ::slotted([slot='icon']) {
-        margin-left: var(--sdds-spacing-element-16);
-      }
     }
   }
 
   .sdds-btn-lg {
     ::slotted([slot='icon']) {
-      // TODO - This should be a var value
-      margin-left: 28px;
+      margin-left: var(--sdds-spacing-element-20);
       width: var(--sdds-spacing-element-20);
       height: var(--sdds-spacing-element-20);
-    }
-
-    &.sdds-btn-fullbleed {
-      ::slotted([slot='icon']) {
-        margin-left: var(--sdds-spacing-element-16);
-      }
     }
   }
 }


### PR DESCRIPTION
**Describe pull-request**  
Updated the margin-left value on the sdds-icon in the button to represent the latest changes in figma. Removed the fullbleed specific icon margin rules since they should always be the same.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1550

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Button
3. Add an icon and make sure it has the correct margin-left.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events