### PR TITLE
feat(logotype): used prefix const

### DIFF
--- a/core/src/global/_logotypes.scss
+++ b/core/src/global/_logotypes.scss
@@ -6,7 +6,7 @@ $logotypes: ('wordmark', 'wordmark-white', 'symbol', 'logotype');
 :root,
 html {
   @each $key in $logotypes {
-    --sdds-background-image-scania-#{$key}-png: url(#{$cdn}#{$folder}/scania_#{$key}/scania-#{$key}.png);
-    --sdds-background-image-scania-#{$key}-svg: url(#{$cdn}#{$folder}/scania_#{$key}/scania-#{$key}.svg);
+    --#{$prefix}-background-image-scania-#{$key}-png: url(#{$cdn}#{$folder}/scania_#{$key}/scania-#{$key}.png);
+    --#{$prefix}-background-image-scania-#{$key}-svg: url(#{$cdn}#{$folder}/scania_#{$key}/scania-#{$key}.svg);
   }
 }


### PR DESCRIPTION
**Describe pull-request**  
Made the logotype variables use the prefix const.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1616

Could be tested by validating the the old scss variables doesn't exist any more. The footer uses the scania wordmark, which will not show since the variable has changed.
