### PR TITLE
chore(toggle): use singular Capital Case where possible

### DIFF
--- a/core/src/components/toggle/readme.md
+++ b/core/src/components/toggle/readme.md
@@ -9,12 +9,12 @@
 
 | Property   | Attribute   | Description                                                              | Type           | Default               |
 | ---------- | ----------- | ------------------------------------------------------------------------ | -------------- | --------------------- |
-| `checked`  | `checked`   | Sets the toggle as checked                                               | `boolean`      | `false`               |
-| `disabled` | `disabled`  | Sets the toggle in a disabled state                                      | `boolean`      | `false`               |
-| `headline` | `headline`  | Headline for the toggle                                                  | `string`       | `undefined`           |
+| `checked`  | `checked`   | Sets the Toggle as checked                                               | `boolean`      | `false`               |
+| `disabled` | `disabled`  | Sets the Toggle in a disabled state                                      | `boolean`      | `false`               |
+| `headline` | `headline`  | Headline for the Toggle                                                  | `string`       | `undefined`           |
 | `name`     | `name`      | Name of the toggles input element                                        | `string`       | `undefined`           |
-| `required` | `required`  | Make the toggle required                                                 | `boolean`      | `false`               |
-| `size`     | `size`      | Size of the toggle                                                       | `"lg" \| "sm"` | `'lg'`                |
+| `required` | `required`  | Make the Toggle required                                                 | `boolean`      | `false`               |
+| `size`     | `size`      | Size of the Toggle                                                       | `"lg" \| "sm"` | `'lg'`                |
 | `toggleId` | `toggle-id` | ID of the toggles input element, if not specifed it's randomly generated | `string`       | `crypto.randomUUID()` |
 
 
@@ -22,14 +22,14 @@
 
 | Event        | Description                                                   | Type                                                   |
 | ------------ | ------------------------------------------------------------- | ------------------------------------------------------ |
-| `sddsToggle` | Sends unique toggle identifier and status when it is toggled. | `CustomEvent<{ toggleId: string; checked: boolean; }>` |
+| `sddsToggle` | Sends unique Toggle identifier and status when it is toggled. | `CustomEvent<{ toggleId: string; checked: boolean; }>` |
 
 
 ## Methods
 
 ### `toggle() => Promise<{ toggleId: string; checked: boolean; }>`
 
-Toggles the toggle.
+Toggles the Toggle.
 
 #### Returns
 

--- a/core/src/components/toggle/sdds-toggle.stories.tsx
+++ b/core/src/components/toggle/sdds-toggle.stories.tsx
@@ -23,7 +23,7 @@ export default {
   argTypes: {
     size: {
       name: 'Size',
-      description: 'Sets the size of the toggle.',
+      description: 'Sets the size of the Toggle.',
       control: {
         type: 'radio',
       },
@@ -34,7 +34,7 @@ export default {
     },
     headline: {
       name: 'Headline',
-      description: 'Sets the headline, displayed above the toggle.',
+      description: 'Sets the headline, displayed above the Toggle.',
       control: {
         type: 'text',
       },
@@ -48,7 +48,7 @@ export default {
     },
     checked: {
       name: 'Checked',
-      description: 'Sets the toggle as checked.',
+      description: 'Sets the Toggle as checked.',
       control: {
         type: 'boolean',
       },
@@ -58,7 +58,7 @@ export default {
     },
     disabled: {
       name: 'Disabled',
-      description: 'Disables the toggle.',
+      description: 'Disables the Toggle.',
       control: {
         type: 'boolean',
       },

--- a/core/src/components/toggle/sdds-toggle.tsx
+++ b/core/src/components/toggle/sdds-toggle.tsx
@@ -8,28 +8,28 @@ import { Component, h, Prop, Event, Element, EventEmitter, Method } from '@stenc
 export class SddsToggle {
   @Element() host: HTMLElement;
 
-  /** Sets the toggle as checked */
+  /** Sets the Toggle as checked */
   @Prop({ reflect: true }) checked: boolean = false;
 
-  /** Make the toggle required */
+  /** Make the Toggle required */
   @Prop() required: boolean = false;
 
-  /** Size of the toggle */
+  /** Size of the Toggle */
   @Prop() size: 'sm' | 'lg' = 'lg';
 
   /** Name of the toggles input element */
   @Prop() name: string;
 
-  /** Headline for the toggle */
+  /** Headline for the Toggle */
   @Prop() headline: string;
 
-  /** Sets the toggle in a disabled state */
+  /** Sets the Toggle in a disabled state */
   @Prop() disabled: boolean = false;
 
   /** ID of the toggles input element, if not specifed it's randomly generated */
   @Prop() toggleId: string = crypto.randomUUID();
 
-  /** Toggles the toggle. */
+  /** Toggles the Toggle. */
   @Method()
   async toggle() {
     this.checked = !this.checked;
@@ -39,7 +39,7 @@ export class SddsToggle {
     };
   }
 
-  /** Sends unique toggle identifier and status when it is toggled. */
+  /** Sends unique Toggle identifier and status when it is toggled. */
   @Event({
     eventName: 'sddsToggle',
     composed: true,

--- a/core/src/components/toggle/sdds-toggle.tsx
+++ b/core/src/components/toggle/sdds-toggle.tsx
@@ -26,7 +26,7 @@ export class SddsToggle {
   /** Sets the Toggle in a disabled state */
   @Prop() disabled: boolean = false;
 
-  /** ID of the toggles input element, if not specifed it's randomly generated */
+  /** ID of the Toggle's input element, if not specified it's randomly generated */
   @Prop() toggleId: string = crypto.randomUUID();
 
   /** Toggles the Toggle. */


### PR DESCRIPTION
**Describe pull-request**  
Updated comments and docs to always use singular capitalized case when referencing the component.

**Solving issue**  
Part of: https://tegel.atlassian.net/browse/DTS-1329

**How to test**  
1. Go to storybook
2. Check in Components -> Toggle
3. Make sure it is always referenced with singular capital case (Toggle)

