### PR TITLE
fix(toggle/toast/textarea/message/dropdown-v2): added root selector to get light mode by default

### DIFF
--- a/core/src/components/dropdown-v2/dropdown-vars.scss
+++ b/core/src/components/dropdown-v2/dropdown-vars.scss
@@ -1,3 +1,4 @@
+:root,
 .sdds-mode-light {
   --sdds-dropdown-bg: var(--sdds-grey-50);
   --sdds-dropdown-border-bottom: var(--sdds-grey-600);

--- a/core/src/components/message/message-vars.scss
+++ b/core/src/components/message/message-vars.scss
@@ -1,34 +1,26 @@
-html,
-:root {
+:root,
+.sdds-mode-light {
   --sdds-message-color: var(--sdds-grey-958);
   --sdds-message-background-primary: var(--sdds-grey-50);
   --sdds-message-background-secondary: var(--sdds-white);
   --sdds-message-background: var(--sdds-message-background-primary);
   --sdds-message-type-error-background: var(--sdds-red-50);
 
-  .sdds-mode-light {
-    --sdds-message-color: var(--sdds-grey-958);
-    --sdds-message-background-primary: var(--sdds-grey-50);
-    --sdds-message-background-secondary: var(--sdds-white);
+  .sdds-mode-variant-primary {
     --sdds-message-background: var(--sdds-message-background-primary);
-    --sdds-message-type-error-background: var(--sdds-red-50);
-
-    .sdds-mode-variant-primary {
-      --sdds-message-background: var(--sdds-message-background-primary);
-    }
-
-    .sdds-mode-variant-secondary {
-      --sdds-message-background: var(--sdds-message-background-secondary);
-    }
   }
 
-  .sdds-mode-dark {
-    --sdds-message-color: var(--sdds-grey-50);
-    --sdds-message-background-primary: var(--sdds-grey-900);
-    --sdds-message-background-secondary: var(--sdds-grey-868);
-    --sdds-message-background: var(--sdds-message-background-primary);
-    --sdds-message-type-error-background: rgb(255 35 64 / 24%);
+  .sdds-mode-variant-secondary {
+    --sdds-message-background: var(--sdds-message-background-secondary);
   }
+}
+
+.sdds-mode-dark {
+  --sdds-message-color: var(--sdds-grey-50);
+  --sdds-message-background-primary: var(--sdds-grey-900);
+  --sdds-message-background-secondary: var(--sdds-grey-868);
+  --sdds-message-background: var(--sdds-message-background-primary);
+  --sdds-message-type-error-background: rgb(255 35 64 / 24%);
 
   .sdds-mode-variant-primary {
     --sdds-message-background: var(--sdds-message-background-primary);

--- a/core/src/components/textarea/textarea-vars.scss
+++ b/core/src/components/textarea/textarea-vars.scss
@@ -1,3 +1,4 @@
+.root,
 .sdds-mode-light {
   --sdds-textarea-background-primary: var(--sdds-grey-50);
   --sdds-textarea-background-secondary: var(--sdds-white);

--- a/core/src/components/toast/toast-vars.scss
+++ b/core/src/components/toast/toast-vars.scss
@@ -1,5 +1,4 @@
 :root,
-html,
 .sdds-mode-light {
   --sdds-toast-background-color: var(--sdds-grey-958);
   --sdds-toast-headline-color: var(--sdds-grey-50);

--- a/core/src/components/toggle/toggle-vars.scss
+++ b/core/src/components/toggle/toggle-vars.scss
@@ -1,3 +1,4 @@
+:root,
 .sdds-mode-light {
   --sdds-toggle-switch: var(--sdds-white);
   --sdds-toggle-switch-disabled: var(--sdds-grey-200);


### PR DESCRIPTION
**Describe pull-request**  
Added root selector to get light mode by default. We were missing this on some components, which lead to variables being undefined if the user had not put sdds-mode-light as class anywhere.


**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1757


**How to test**  
1. Check out branch
2. Remove the wrapping sdds-mode-light class
3. Check that the toggle is using light mode by default.

**Suggested test steps**
- [ ] Dark/light mode and variants 

