### PR TITLE
docs(textarea): singular capital case

### DIFF
--- a/core/src/components/textarea/readme.md
+++ b/core/src/components/textarea/readme.md
@@ -7,33 +7,33 @@
 
 ## Properties
 
-| Property        | Attribute        | Description                              | Type                                  | Default      |
-| --------------- | ---------------- | ---------------------------------------- | ------------------------------------- | ------------ |
-| `autoFocus`     | `auto-focus`     | Control of autofocus                     | `boolean`                             | `false`      |
-| `cols`          | `cols`           | Textarea cols attribute                  | `number`                              | `undefined`  |
-| `disabled`      | `disabled`       | Set input in disabled state              | `boolean`                             | `false`      |
-| `helper`        | `helper`         | Helper text                              | `string`                              | `undefined`  |
-| `label`         | `label`          | Label text                               | `string`                              | `''`         |
-| `labelPosition` | `label-position` | Position of the label for the textfield. | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
-| `maxLength`     | `max-length`     | Max length of input                      | `number`                              | `undefined`  |
-| `modeVariant`   | `mode-variant`   | Mode variant of the textarea             | `"primary" \| "secondary"`            | `null`       |
-| `name`          | `name`           | Name attribute                           | `string`                              | `''`         |
-| `noMinWidth`    | `no-min-width`   | Unset minimum width of 208px.            | `boolean`                             | `false`      |
-| `placeholder`   | `placeholder`    | Placeholder text                         | `string`                              | `''`         |
-| `readOnly`      | `read-only`      | Set input in readonly state              | `boolean`                             | `false`      |
-| `rows`          | `rows`           | Textarea rows attribute                  | `number`                              | `undefined`  |
-| `state`         | `state`          | Error state of input                     | `"default" \| "error" \| "success"`   | `'default'`  |
-| `value`         | `value`          | Value of the input text                  | `string`                              | `''`         |
+| Property        | Attribute        | Description                             | Type                                  | Default      |
+| --------------- | ---------------- | --------------------------------------- | ------------------------------------- | ------------ |
+| `autoFocus`     | `auto-focus`     | Control of autofocus                    | `boolean`                             | `false`      |
+| `cols`          | `cols`           | Textarea cols attribute                 | `number`                              | `undefined`  |
+| `disabled`      | `disabled`       | Set input in disabled state             | `boolean`                             | `false`      |
+| `helper`        | `helper`         | Helper text                             | `string`                              | `undefined`  |
+| `label`         | `label`          | Label text                              | `string`                              | `''`         |
+| `labelPosition` | `label-position` | Position of the label for the Textarea. | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
+| `maxLength`     | `max-length`     | Max length of input                     | `number`                              | `undefined`  |
+| `modeVariant`   | `mode-variant`   | Mode variant of the Textarea            | `"primary" \| "secondary"`            | `null`       |
+| `name`          | `name`           | Name attribute                          | `string`                              | `''`         |
+| `noMinWidth`    | `no-min-width`   | Unset minimum width of 208px.           | `boolean`                             | `false`      |
+| `placeholder`   | `placeholder`    | Placeholder text                        | `string`                              | `''`         |
+| `readOnly`      | `read-only`      | Set input in readonly state             | `boolean`                             | `false`      |
+| `rows`          | `rows`           | Textarea rows attribute                 | `number`                              | `undefined`  |
+| `state`         | `state`          | Error state of input                    | `"default" \| "error" \| "success"`   | `'default'`  |
+| `value`         | `value`          | Value of the input text                 | `string`                              | `''`         |
 
 
 ## Events
 
 | Event       | Description                   | Type                      |
 | ----------- | ----------------------------- | ------------------------- |
-| `tdsBlur`   | Blur event for the textarea   | `CustomEvent<FocusEvent>` |
-| `tdsChange` | Change event for the textarea | `CustomEvent<any>`        |
-| `tdsFocus`  | Focus event for the textarea  | `CustomEvent<FocusEvent>` |
-| `tdsInput`  | Input event for the textarea  | `CustomEvent<InputEvent>` |
+| `tdsBlur`   | Blur event for the Textarea   | `CustomEvent<FocusEvent>` |
+| `tdsChange` | Change event for the Textarea | `CustomEvent<any>`        |
+| `tdsFocus`  | Focus event for the Textarea  | `CustomEvent<FocusEvent>` |
+| `tdsInput`  | Input event for the Textarea  | `CustomEvent<InputEvent>` |
 
 
 ## Dependencies

--- a/core/src/components/textarea/textarea.stories.tsx
+++ b/core/src/components/textarea/textarea.stories.tsx
@@ -102,7 +102,7 @@ export default {
     },
     readonly: {
       name: 'Read only',
-      description: 'Sets the textarea to read-only state.',
+      description: 'Sets the Textarea to read-only state.',
       control: {
         type: 'boolean',
       },
@@ -112,7 +112,7 @@ export default {
     },
     disabled: {
       name: 'Disabled',
-      description: 'Disables the textarea.',
+      description: 'Disables the Textarea.',
       control: {
         type: 'boolean',
       },

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -25,7 +25,7 @@ export class TdsTextarea {
   /** Textarea rows attribute */
   @Prop() rows: number;
 
-  /** Position of the label for the textfield. */
+  /** Position of the label for the Textarea. */
   @Prop() labelPosition: 'inside' | 'outside' | 'no-label' = 'no-label';
 
   /** Placeholder text */
@@ -46,7 +46,7 @@ export class TdsTextarea {
   /** Max length of input */
   @Prop() maxLength: number;
 
-  /** Mode variant of the textarea */
+  /** Mode variant of the Textarea */
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
   /** Control of autofocus */
@@ -58,7 +58,7 @@ export class TdsTextarea {
   /** Listen to the focus state of the input */
   @State() focusInput;
 
-  /** Change event for the textarea */
+  /** Change event for the Textarea */
   @Event({
     eventName: 'tdsChange',
     composed: true,
@@ -71,7 +71,7 @@ export class TdsTextarea {
     this.tdsChange.emit(event);
   }
 
-  /** Blur event for the textarea */
+  /** Blur event for the Textarea */
   @Event({
     eventName: 'tdsBlur',
     composed: true,
@@ -85,7 +85,7 @@ export class TdsTextarea {
     this.focusInput = false;
   }
 
-  /** Input event for the textarea */
+  /** Input event for the Textarea */
   @Event({
     eventName: 'tdsInput',
     composed: true,
@@ -100,7 +100,7 @@ export class TdsTextarea {
     this.value = event.target.value;
   }
 
-  /** Focus event for the textarea */
+  /** Focus event for the Textarea */
   @Event({
     eventName: 'tdsFocus',
     composed: true,
@@ -109,7 +109,7 @@ export class TdsTextarea {
   })
   tdsFocus: EventEmitter<FocusEvent>;
 
-  /* Set the input as focus when clicking the whole textfield with suffix/prefix */
+  /* Set the input as focus when clicking the whole textarea with suffix/prefix */
   handleFocus(event): void {
     this.textEl.focus();
     this.focusInput = true;


### PR DESCRIPTION
**Describe pull-request**  
Making sure Textarea is spelled in a capital case.

**Solving issue**  
Fixes: DTS-1329

**How to test**  
1. Check if all textarea is mentioned as "Textarea" in docs files

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
