### PR TITLE
feat(header): brand link

### DIFF
--- a/core/src/components/header/header-brand-symbol/header-brand-symbol.scss
+++ b/core/src/components/header/header-brand-symbol/header-brand-symbol.scss
@@ -5,12 +5,14 @@
     display: none;
   }
 
-  tds-header-item a {
-    background-image: var(--tds-background-image-scania-symbol-svg),
-      var(--tds-background-image-scania-symbol-png);
-    background-size: 30px auto;
-    background-position: center;
-    background-repeat: no-repeat;
+  tds-header-item {
+    ::slotted(*) {
+      background-image: var(--tds-background-image-scania-symbol-svg),
+        var(--tds-background-image-scania-symbol-png);
+      background-size: 30px auto;
+      background-position: center;
+      background-repeat: no-repeat;
+    }
   }
 
   @media (min-width: 992px) {

--- a/core/src/components/header/header-brand-symbol/header-brand-symbol.tsx
+++ b/core/src/components/header/header-brand-symbol/header-brand-symbol.tsx
@@ -1,5 +1,4 @@
 import { Component, Element, h, Host } from '@stencil/core';
-import { inheritAriaAttributes } from '../../../utils/utils';
 
 @Component({
   tag: 'tds-header-brand-symbol',
@@ -10,13 +9,10 @@ export class TdsHeaderBrandSymbol {
   @Element() host: HTMLElement;
 
   render() {
-    const inheritedLinkProps = {
-      ...inheritAriaAttributes(this.host),
-    };
     return (
       <Host>
         <tds-header-item>
-          <slot {...inheritedLinkProps}></slot>
+          <slot></slot>
         </tds-header-item>
       </Host>
     );

--- a/core/src/components/header/header-brand-symbol/header-brand-symbol.tsx
+++ b/core/src/components/header/header-brand-symbol/header-brand-symbol.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, Host, Prop } from '@stencil/core';
+import { Component, Element, h, Host } from '@stencil/core';
 import { inheritAriaAttributes } from '../../../utils/utils';
 
 @Component({
@@ -9,9 +9,6 @@ import { inheritAriaAttributes } from '../../../utils/utils';
 export class TdsHeaderBrandSymbol {
   @Element() host: HTMLElement;
 
-  /** The href for the logo link. */
-  @Prop() linkHref: string = 'https://www.scania.com';
-
   render() {
     const inheritedLinkProps = {
       ...inheritAriaAttributes(this.host),
@@ -19,7 +16,7 @@ export class TdsHeaderBrandSymbol {
     return (
       <Host>
         <tds-header-item>
-          <a {...inheritedLinkProps} href={this.linkHref}></a>
+          <slot {...inheritedLinkProps}></slot>
         </tds-header-item>
       </Host>
     );

--- a/core/src/components/header/header-brand-symbol/readme.md
+++ b/core/src/components/header/header-brand-symbol/readme.md
@@ -5,13 +5,6 @@
 <!-- Auto Generated Below -->
 
 
-## Properties
-
-| Property   | Attribute   | Description                 | Type     | Default                    |
-| ---------- | ----------- | --------------------------- | -------- | -------------------------- |
-| `linkHref` | `link-href` | The href for the logo link. | `string` | `'https://www.scania.com'` |
-
-
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/header/header.stories.tsx
+++ b/core/src/components/header/header.stories.tsx
@@ -71,7 +71,8 @@ const Template = () =>
     </tds-header-launcher>
 
 
-    <tds-header-brand-symbol slot="end" link-href="https://scania.com" aria-label="Scania - red gryphon on blue shield">
+    <tds-header-brand-symbol slot="end" aria-label="Scania - red gryphon on blue shield">
+      <a href="https://scania.com"></a>
     </tds-header-brand-symbol>
 
   </tds-header>

--- a/core/src/components/header/header.stories.tsx
+++ b/core/src/components/header/header.stories.tsx
@@ -71,8 +71,8 @@ const Template = () =>
     </tds-header-launcher>
 
 
-    <tds-header-brand-symbol slot="end" aria-label="Scania - red gryphon on blue shield">
-      <a href="https://scania.com"></a>
+    <tds-header-brand-symbol slot="end">
+      <a aria-label="Scania - red gryphon on blue shield" href="https://scania.com"></a>
     </tds-header-brand-symbol>
 
   </tds-header>

--- a/core/src/components/side-menu/side-menu.stories.tsx
+++ b/core/src/components/side-menu/side-menu.stories.tsx
@@ -131,8 +131,8 @@ const Template = ({ persistent, collapsible }) =>
 
       <i style="color:white">Header items omitted for brevity. See patterns/navigation</i>
 
-      <tds-header-brand-symbol slot="end" aria-label="Scania - red gryphon on blue shield">
-        <a href="https://scania.com"></a>
+      <tds-header-brand-symbol slot="end">
+        <a aria-label="Scania - red gryphon on blue shield" href="https://scania.com"></a>
       </tds-header-brand-symbol>
     </tds-header>
 

--- a/core/src/components/side-menu/side-menu.stories.tsx
+++ b/core/src/components/side-menu/side-menu.stories.tsx
@@ -131,7 +131,8 @@ const Template = ({ persistent, collapsible }) =>
 
       <i style="color:white">Header items omitted for brevity. See patterns/navigation</i>
 
-      <tds-header-brand-symbol slot="end" link-href="https://scania.com" aria-label="Scania - red gryphon on blue shield">
+      <tds-header-brand-symbol slot="end" aria-label="Scania - red gryphon on blue shield">
+        <a href="https://scania.com"></a>
       </tds-header-brand-symbol>
     </tds-header>
 

--- a/core/src/stories/patterns/navigation/navigation-basic.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-basic.stories.tsx
@@ -76,8 +76,8 @@ const Template = () =>
       </tds-header-launcher-list>
     </tds-header-launcher>
   
-    <tds-header-brand-symbol slot="end" aria-label="Scania - red gryphon on blue shield">
-      <a href="https://scania.com"></a>
+    <tds-header-brand-symbol slot="end">
+      <a aria-label="Scania - red gryphon on blue shield" href="https://scania.com"></a>
     </tds-header-brand-symbol>
 
   </tds-header>

--- a/core/src/stories/patterns/navigation/navigation-basic.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-basic.stories.tsx
@@ -76,7 +76,8 @@ const Template = () =>
       </tds-header-launcher-list>
     </tds-header-launcher>
   
-    <tds-header-brand-symbol slot="end" link-href="https://design.scania.com" aria-label="Scania - red gryphon on blue shield">
+    <tds-header-brand-symbol slot="end" aria-label="Scania - red gryphon on blue shield">
+      <a href="https://scania.com"></a>
     </tds-header-brand-symbol>
 
   </tds-header>

--- a/core/src/stories/patterns/navigation/navigation-fewitems.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-fewitems.stories.tsx
@@ -183,7 +183,8 @@ const Template = () =>
           </tds-header-dropdown-list>
         </tds-header-dropdown>
 
-        <tds-header-brand-symbol slot="end" href="https://design.scania.com" aria-label="Scania - red gryphon on blue shield">
+        <tds-header-brand-symbol slot="end" aria-label="Scania - red gryphon on blue shield">
+          <a href="https://scania.com"></a>
         </tds-header-brand-symbol>
 
       </tds-header>

--- a/core/src/stories/patterns/navigation/navigation-fewitems.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-fewitems.stories.tsx
@@ -183,8 +183,8 @@ const Template = () =>
           </tds-header-dropdown-list>
         </tds-header-dropdown>
 
-        <tds-header-brand-symbol slot="end" aria-label="Scania - red gryphon on blue shield">
-          <a href="https://scania.com"></a>
+        <tds-header-brand-symbol slot="end">
+          <a aria-label="Scania - red gryphon on blue shield" href="https://scania.com"></a>
         </tds-header-brand-symbol>
 
       </tds-header>

--- a/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
@@ -154,8 +154,8 @@ const Template = ({ dummyHtml }) =>
       </tds-header-dropdown>
       
       
-      <tds-header-brand-symbol slot="end" aria-label="Scania - red gryphon on blue shield">
-        <a href="https://scania.com"></a>
+      <tds-header-brand-symbol slot="end">
+        <a aria-label="Scania - red gryphon on blue shield" href="https://scania.com"></a>
       </tds-header-brand-symbol>
 
     </tds-header>

--- a/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
@@ -154,7 +154,8 @@ const Template = ({ dummyHtml }) =>
       </tds-header-dropdown>
       
       
-      <tds-header-brand-symbol slot="end" link-href="https://design.scania.com" aria-label="Scania - red gryphon on blue shield">
+      <tds-header-brand-symbol slot="end" aria-label="Scania - red gryphon on blue shield">
+        <a href="https://scania.com"></a>
       </tds-header-brand-symbol>
 
     </tds-header>

--- a/core/src/stories/patterns/navigation/navigation-user-menu.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-user-menu.stories.tsx
@@ -102,8 +102,8 @@ const Template = () =>
           </tds-header-dropdown-list>
         </tds-header-dropdown>
 
-        <tds-header-brand-symbol slot="end" aria-label="Scania - red gryphon on blue shield">
-          <a href="https://scania.com"></a>
+        <tds-header-brand-symbol slot="end">
+          <a aria-label="Scania - red gryphon on blue shield" href="https://scania.com"></a>
         </tds-header-brand-symbol>
 
       </tds-header>

--- a/core/src/stories/patterns/navigation/navigation-user-menu.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-user-menu.stories.tsx
@@ -102,7 +102,8 @@ const Template = () =>
           </tds-header-dropdown-list>
         </tds-header-dropdown>
 
-        <tds-header-brand-symbol slot="end" link-href="https://design.scania.com" aria-label="Scania - red gryphon on blue shield">
+        <tds-header-brand-symbol slot="end" aria-label="Scania - red gryphon on blue shield">
+          <a href="https://scania.com"></a>
         </tds-header-brand-symbol>
 
       </tds-header>


### PR DESCRIPTION
**Describe pull-request**  
Updated the header-brand-symbol to use slot instead of prop for link. This is to allow for framework routers.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1780

**How to test**  
1. Go to storybook
2. Check in Components -> Header
3. Test and check the style of the brand-symbol (top right corner.)

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
