### PR TITLE
docs(icon size): updated icon size control to be select instead of range

### DIFF
--- a/core/src/components/icon/icon-font.stories.tsx
+++ b/core/src/components/icon/icon-font.stories.tsx
@@ -33,11 +33,9 @@ export default {
       name: 'Size in pixels',
       description: 'Set the size of the icon',
       control: {
-        type: 'range',
-        min: 16,
-        max: 100,
-        step: 4,
+        type: 'select',
       },
+      options: [16, 20, 24, 32],
     },
   },
   args: {

--- a/core/src/components/icon/icon-font.stories.tsx
+++ b/core/src/components/icon/icon-font.stories.tsx
@@ -55,6 +55,4 @@ const IconFontTemplate = (args) =>
   <i class="sdds-icon ${args.icon}"></i>
   `);
 
-export const Native = IconFontTemplate.bind({});
-
-Native.args = {};
+export const WebFont = IconFontTemplate.bind({});

--- a/core/src/components/icon/icon-web-component.stories.tsx
+++ b/core/src/components/icon/icon-web-component.stories.tsx
@@ -33,11 +33,9 @@ export default {
       name: 'Size in pixels',
       description: 'Set the size of the icon',
       control: {
-        type: 'range',
-        min: 16,
-        max: 100,
-        step: 4,
+        type: 'select',
       },
+      options: [16, 20, 24, 32],
     },
   },
   args: {
@@ -52,5 +50,3 @@ const IconTemplate = (args) =>
   `);
 
 export const WebComponent = IconTemplate.bind({});
-
-WebComponent.args = {};


### PR DESCRIPTION
**Describe pull-request**  
Update icon size controls to be a select instead of range.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1758

**How to test**  
1. Go to storybook
2. Check in Foundations -> Icons
3. Check the controls for the size.