### PR TITLE
fix(button): locked in disabled state

### DIFF
--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -188,6 +188,14 @@ button {
   }
 }
 
+:host(tds-button[disabled]) {
+  pointer-events: none;
+
+  ::slotted([slot='icon']) {
+    pointer-events: none;
+  }
+}
+
 :host(tds-button[fullbleed]) {
   width: 100%;
   justify-content: center;

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -1,5 +1,5 @@
-import { Component, Element, h, Host, Prop, State } from '@stencil/core';
-import { disableClickOnElement } from '../../utils/utils';
+import { Component, Element, h, Host, Prop, State, Watch } from '@stencil/core';
+import { disableClickOnElement, enableClickOnElement } from '../../utils/utils';
 
 @Component({
   tag: 'tds-button',
@@ -33,16 +33,34 @@ export class TdsButton {
   connectedCallback() {
     this.slotElement = this.host.children ? this.host.children[0] : null;
     if (this.disabled) {
-      disableClickOnElement(this.host);
-      if (this.slotElement?.slot === 'icon') {
-        disableClickOnElement(this.slotElement);
-      }
+      this.disableComponent();
     }
 
     if (!this.text) {
       this.onlyIcon = true;
       this.host.setAttribute('only-icon', '');
     }
+  }
+
+  disableComponent() {
+    disableClickOnElement(this.host);
+    if (this.slotElement?.slot === 'icon') {
+      disableClickOnElement(this.slotElement);
+    }
+  }
+
+  enableComponent() {
+    enableClickOnElement(this.host);
+    if (this.slotElement?.slot === 'icon') {
+      enableClickOnElement(this.slotElement);
+    }
+  }
+
+  @Watch('disabled')
+  updateValue(newValue: boolean) {
+    if (newValue === true) {
+      this.enableComponent();
+    } else this.disableComponent();
   }
 
   render() {

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -1,5 +1,4 @@
-import { Component, Element, h, Host, Prop, State, Watch } from '@stencil/core';
-import { disableClickOnElement, enableClickOnElement } from '../../utils/utils';
+import { Component, Element, h, Host, Prop, State } from '@stencil/core';
 
 @Component({
   tag: 'tds-button',
@@ -28,39 +27,11 @@ export class TdsButton {
 
   @State() onlyIcon: boolean = false;
 
-  @State() slotElement: Element;
-
   connectedCallback() {
-    this.slotElement = this.host.children ? this.host.children[0] : null;
-    if (this.disabled) {
-      this.disableComponent();
-    }
-
     if (!this.text) {
       this.onlyIcon = true;
       this.host.setAttribute('only-icon', '');
     }
-  }
-
-  disableComponent() {
-    disableClickOnElement(this.host);
-    if (this.slotElement?.slot === 'icon') {
-      disableClickOnElement(this.slotElement);
-    }
-  }
-
-  enableComponent() {
-    enableClickOnElement(this.host);
-    if (this.slotElement?.slot === 'icon') {
-      enableClickOnElement(this.slotElement);
-    }
-  }
-
-  @Watch('disabled')
-  updateValue(newValue: boolean) {
-    if (newValue === true) {
-      this.enableComponent();
-    } else this.disableComponent();
   }
 
   render() {

--- a/core/src/utils/utils.ts
+++ b/core/src/utils/utils.ts
@@ -416,3 +416,11 @@ export const disableClickOnElement = (element: Element) => {
     event.stopPropagation();
   });
 };
+
+export const enableClickOnElement = (element: Element) => {
+  const clickHandler = (event: Event) => {
+    event.stopPropagation();
+  };
+
+  element.removeEventListener('click', clickHandler);
+};

--- a/core/src/utils/utils.ts
+++ b/core/src/utils/utils.ts
@@ -403,24 +403,3 @@ export function isFocusable(element: HTMLElement): boolean {
 
   return false;
 }
-
-/**
- * Disables click on a element by adding an event listener
- * and then preventing default and stopping propogation.
- * @param {Element} element The element where the click should be
- * disabled.
- * */
-export const disableClickOnElement = (element: Element) => {
-  element.addEventListener('click', (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-  });
-};
-
-export const enableClickOnElement = (element: Element) => {
-  const clickHandler = (event: Event) => {
-    event.stopPropagation();
-  };
-
-  element.removeEventListener('click', clickHandler);
-};


### PR DESCRIPTION
**Describe pull-request**  
Possible fix for the forever-lasting disabled state of the button.

**Solving issue**  
When the button is set statically to a disabled state on the initial load, it seems to remain in it.
connectedCallback is run only once, on the initial load so the component is not aware of the change of "disabled" prop change. We add click listener on it, but do not remove it which makes the button remain in the disabled state even when disabled is false.
Martin and I took a look and proposed a solution where we remove logic that sets it disabled via stoppingPropagation and preventingDefault. Now button uses only CSS rule of pointer-events:none and we leave it up to user to stopPorpagation or preventDefault. 

**How to test**  
Not sure if is this testable without a release, suggestion is to try via linking or packing.
