### PR TITLE
feat(link): display:inline and updated component to use shadowDOM

### DIFF
--- a/core/src/components/link/link.scss
+++ b/core/src/components/link/link.scss
@@ -1,38 +1,41 @@
-.tds-link-component {
-  all: unset;
-  cursor: pointer;
-  outline: none;
-  color: var(--tds-link);
-  text-decoration: underline;
+:host {
+  display: inline;
 
-  &.active,
-  &:active {
+  ::slotted(*) {
+    all: unset;
+    cursor: pointer;
+    outline: none;
     color: var(--tds-link);
     text-decoration: underline;
-    text-decoration-color: var(--tds-link);
   }
 
-  &:hover {
-    color: var(--tds-link-hover);
-    text-decoration: underline;
-    text-decoration-color: var(--tds-link-hover);
-  }
-
-  &:visited {
-    color: var(--tds-link-visited);
-    text-decoration-color: var(--tds-link-visited);
-  }
-
-  &:focus {
+  ::slotted(*:focus-visible) {
     color: var(--tds-link-focus);
     text-decoration: none;
     outline: 2px solid var(--tds-link-focus);
     outline-offset: -2px;
   }
+
+  ::slotted(*:active) {
+    color: var(--tds-link);
+    text-decoration: underline;
+    text-decoration-color: var(--tds-link);
+  }
+
+  ::slotted(*:hover) {
+    color: var(--tds-link-hover);
+    text-decoration: underline;
+    text-decoration-color: var(--tds-link-hover);
+  }
+
+  ::slotted(*:visited) {
+    color: var(--tds-link-visited);
+    text-decoration-color: var(--tds-link-visited);
+  }
 }
 
 .disabled {
-  .tds-link-component {
+  ::slotted(*) {
     color: var(--tds-link-disabled);
     text-decoration-color: var(--tds-link-disabled);
     pointer-events: none;
@@ -40,14 +43,14 @@
 }
 
 .no-underline {
-  .tds-link-component {
+  ::slotted(*) {
     text-decoration: none;
   }
 }
 
 .no-underline {
   &:hover {
-    .tds-link-component {
+    ::slotted(*) {
       text-decoration: none;
     }
   }

--- a/core/src/components/link/link.tsx
+++ b/core/src/components/link/link.tsx
@@ -3,7 +3,7 @@ import { Component, h, Prop, Element } from '@stencil/core';
 @Component({
   tag: 'tds-link',
   styleUrl: 'link.scss',
-  shadow: false,
+  shadow: true,
 })
 export class TdsLink {
   @Element() host: HTMLElement;


### PR DESCRIPTION
**Describe pull-request**  
Sets the display of the link to inline so that it can be used in text blocks. Also did shadowDOM; true and updated the css.

**Solving issue**  
Fixes: 

**How to test**  
1. Checkout the branch
2. Add the link in flowing text
3. Check that the styling and behaviour is correct.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

