### PR TITLE
docs(slots): documentation for slot naming convention

### DIFF
--- a/.github/CODE_STYLE.md
+++ b/.github/CODE_STYLE.md
@@ -122,7 +122,7 @@ export class TdsComponent {
 ## Slots
 
 Slots are used throughout many of our components. Some of these are named slots, and in that case they should follow
-to following convention: The slot should always be named to represent it position/use case. For example this could be
+the following convention: The slot should always be named to represent its position/use case. For example this could be
 'bottom', 'label' or 'end'.
 
 ## Events

--- a/.github/CODE_STYLE.md
+++ b/.github/CODE_STYLE.md
@@ -118,6 +118,13 @@ export class TdsComponent {
 
 ```
 
+
+## Slots
+
+Slots are used throughout many of our components. Some of these are named slots, and in that case they should follow
+to following convention: The slot should always be named to represent it position/use case. For example this could be
+'bottom', 'label' or 'end'.
+
 ## Events
 The tegel components emit custom events to allow the users to repond to changes/updates in the components. These are all named using the 
 tds-prefix. This is done in order to not have conflicting events and to make it clear to the user the specified event is something that is emitted

--- a/core/src/stories/Migration/Migration.stories.mdx
+++ b/core/src/stories/Migration/Migration.stories.mdx
@@ -26,7 +26,7 @@ For @scania/tegel we have taken another look at the naming convention of our slo
 a number on inconsistencies. To align on this we have now decided on a naming convention that goes for all of our 
 named slot. 
 
-The slot should always be named to represent its position/use case.. This could for example be 'bottom', 'label' or 
+The slot should always be named to represent its position/use case. This could for example be 'bottom', 'label' or 
 'suffix'.
 
 These components have been affected by these updated:

--- a/core/src/stories/Migration/Migration.stories.mdx
+++ b/core/src/stories/Migration/Migration.stories.mdx
@@ -29,7 +29,7 @@ named slot.
 The slot should always be named to represent its position/use case. This could for example be 'bottom', 'label' or 
 'suffix'.
 
-These components have been affected by these updated:
+These components have been updated:
 
  - Accordion
  - Button

--- a/core/src/stories/Migration/Migration.stories.mdx
+++ b/core/src/stories/Migration/Migration.stories.mdx
@@ -20,6 +20,41 @@ or not it is a custom event. We have now settled on a naming convention for all 
 Both **external**, events we expect you as a user to interact with, and **internal**, events that are used within
 our components to update state/react to changes. 
 
+## Slot name convention
+
+For @scania/tegel we have taken another look at the naming convention of our slot names. With this we discovered
+a number on inconsistencies. To align on this we have now decided on a naming convention that goes for all of our 
+named slot. 
+
+The slot should always be named to represent it position/use case. This could for example be 'bottom', 'label' or 
+'suffix'.
+
+These components have been affected by these updated:
+
+ - Accordion
+ - Button
+ - Card
+ - Checkbox
+ - Chip
+ - Dropdown
+ - Footer
+ - Footer
+ - Header
+ - Message
+ - Modal
+ - Radio Button
+ - Side Menu
+ - Stepper
+ - Table
+ - Text Field
+ - Toast
+ - Toggle
+
+ #### What action is required?
+
+Make sure all slots that are being used follow the convention. 
+
+
 ## Prefix change
 Furthermore we decided to rename the previously used 'sdds'-prefix to 'tds'. 
 This occurred as a result of a deliberate choice to facilitate the transition to the new Tegel package and prevent conflicts with previously used components.

--- a/core/src/stories/Migration/Migration.stories.mdx
+++ b/core/src/stories/Migration/Migration.stories.mdx
@@ -26,7 +26,7 @@ For @scania/tegel we have taken another look at the naming convention of our slo
 a number on inconsistencies. To align on this we have now decided on a naming convention that goes for all of our 
 named slot. 
 
-The slot should always be named to represent it position/use case. This could for example be 'bottom', 'label' or 
+The slot should always be named to represent its position/use case.. This could for example be 'bottom', 'label' or 
 'suffix'.
 
 These components have been affected by these updated:


### PR DESCRIPTION
**Describe pull-request**  
Added section for naming convention in migration docs & in our CODE_STYLES.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-2033

**How to test**  
1. Go to migration docs
2. Check the slot naming conventions
