### PR TITLE
fix(globals): corrected rules for global background and color

### DIFF
--- a/core/src/global/global.scss
+++ b/core/src/global/global.scss
@@ -71,11 +71,13 @@ body {
   color: var(--tds-grey-958);
   background-color: var(--tds-white);
 
+  &.tds-mode-variant-primary,
   & .tds-mode-variant-primary {
     color: var(--tds-grey-958);
     background-color: var(--tds-white);
   }
 
+  &.tds-mode-variant-secondary,
   & .tds-mode-variant-secondary {
     color: var(--tds-grey-958);
     background-color: var(--tds-grey-50);
@@ -86,11 +88,13 @@ body {
   color: var(--tds-grey-100);
   background-color: var(--tds-grey-958);
 
+  &.tds-mode-variant-primary,
   & .tds-mode-variant-primary {
     color: var(--tds-grey-100);
     background-color: var(--tds-grey-958);
   }
 
+  &.tds-mode-variant-secondary,
   & .tds-mode-variant-secondary {
     color: var(--tds-grey-100);
     background-color: var(--tds-grey-900);


### PR DESCRIPTION
**Describe pull-request**  
Corrected the rules for global background and color.

In the old solution the mode-variants were taking precedence, resulting in dark mode being useless if mode-variant was used.

**Solving issue**  
Fixes: -

**How to test**  
1. Check out branch
2. Do link to react-demo-page
3. Remove everything in index.css from line 18 - 30.
4. Make sure dark/light and primary/secondary works as inteded.
