### PR TITLE
feat(footer): slot alignment

### DIFF
--- a/core/src/components/footer/footer-group/footer-group.scss
+++ b/core/src/components/footer/footer-group/footer-group.scss
@@ -56,8 +56,8 @@
     display: flex;
     gap: 8px;
 
-    &.left,
-    &.right {
+    &.start,
+    &.end {
       gap: 24px;
     }
 
@@ -67,11 +67,11 @@
   }
 
   @media all and (max-width: 992px) {
-    [role='list'].left:not(.top-part-child) {
+    [role='list'].start:not(.top-part-child) {
       flex-direction: column;
 
-      &.left,
-      &.right {
+      &.start,
+      &.end {
         gap: 8px;
       }
     }

--- a/core/src/components/footer/footer-group/footer-group.tsx
+++ b/core/src/components/footer/footer-group/footer-group.tsx
@@ -16,7 +16,7 @@ export class TdsFooterGroup {
   @State() open: boolean = false;
 
   /** If the group is placed in the main part of the Footer,
-   * it can have either stat or end as a slot position otherwise undefined. */
+   * it can have either start or end as a slot position otherwise undefined. */
   private slotPosition: 'start' | 'end' = null;
 
   /** Indicates if a group is part of the top part of the Footer. */

--- a/core/src/components/footer/footer-group/footer-group.tsx
+++ b/core/src/components/footer/footer-group/footer-group.tsx
@@ -16,8 +16,8 @@ export class TdsFooterGroup {
   @State() open: boolean = false;
 
   /** If the group is placed in the main part of the Footer,
-   * it can have either left or right as a slot position otherwise undefined. */
-  private slotPosition: 'left' | 'right' = null;
+   * it can have either stat or end as a slot position otherwise undefined. */
+  private slotPosition: 'start' | 'end' = null;
 
   /** Indicates if a group is part of the top part of the Footer. */
   private topPartGroup: boolean = false;
@@ -25,7 +25,7 @@ export class TdsFooterGroup {
   connectedCallback() {
     this.topPartGroup = this.host.parentElement.slot === 'top';
     if (!this.topPartGroup) {
-      this.slotPosition = this.host.parentElement.slot === 'main-right' ? 'right' : 'left';
+      this.slotPosition = this.host.parentElement.slot === 'end' ? 'end' : 'start';
     }
   }
 

--- a/core/src/components/footer/footer.scss
+++ b/core/src/components/footer/footer.scss
@@ -3,16 +3,13 @@
 
   $grid-lg: 992px;
 
-  .footer-top {
+  slot[name='top']::slotted(*) {
     background-color: var(--tds-footer-top-background);
     padding: 40px;
-
-    ::slotted(*) {
-      display: grid;
-      grid-template-columns: 1fr 1fr 1fr 1fr;
-      row-gap: 40px;
-      width: 100%;
-    }
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    row-gap: 40px;
+    width: 100%;
   }
 
   .footer-main {
@@ -26,9 +23,9 @@
     justify-content: space-between;
   }
 
-  .footer-bottom-right,
-  .footer-bottom-left {
-    ::slotted(*) {
+  slot[name='start'],
+  slot[name='end'] {
+    &::slotted(*) {
       display: flex;
       column-gap: 24px;
     }
@@ -66,13 +63,10 @@
   }
 
   @media all and (max-width: $grid-lg) {
-    .footer-top {
+    slot[name='top']::slotted(*) {
+      display: block;
+      width: 100%;
       padding: 0;
-
-      ::slotted(*) {
-        display: block;
-        width: 100%;
-      }
     }
 
     .footer-main {
@@ -85,9 +79,9 @@
       padding: 24px 0;
     }
 
-    .footer-bottom-left {
-      ::slotted(*) {
-        flex-direction: column;
+    slot[name='end'] {
+      &::slotted(*) {
+        flex-direction: row;
         gap: 8px;
       }
     }

--- a/core/src/components/footer/footer.scss
+++ b/core/src/components/footer/footer.scss
@@ -7,7 +7,7 @@
     background-color: var(--tds-footer-top-background);
     padding: 40px;
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-template-columns: repeat(4, 1fr);
     row-gap: 40px;
     width: 100%;
   }

--- a/core/src/components/footer/footer.stories.tsx
+++ b/core/src/components/footer/footer.stories.tsx
@@ -62,8 +62,9 @@ const Template = ({ topPart, modeVariant }) =>
     <tds-footer
     ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}
     >
-      ${topPart
-      ? `
+      ${
+        topPart
+          ? `
       <div slot="top">
         <tds-footer-group title-text="Title">
           <tds-footer-item >
@@ -114,9 +115,9 @@ const Template = ({ topPart, modeVariant }) =>
         </tds-footer-group>
       </div>
       `
-      : ''
-    }
-      <div slot="main-left">
+          : ''
+      }
+      <div slot="start">
         <tds-footer-group>
           <tds-footer-item >
             <a href="#"> Link text</a>
@@ -132,7 +133,7 @@ const Template = ({ topPart, modeVariant }) =>
           </tds-footer-item>
         </tds-footer-group>
       </div>
-      <div slot="main-right">
+      <div slot="end">
         <tds-footer-group>
           <tds-footer-item >
             <a href="#"> <tds-icon name="truck"></tds-icon></a>

--- a/core/src/components/footer/footer.tsx
+++ b/core/src/components/footer/footer.tsx
@@ -4,8 +4,8 @@ import { hasSlot } from '../../utils/utils';
 
 /**
  * @slot top - Slot for the top part of the Footer.
- * @slot left - Slot for left side of the Footers main part.
- * @slot right - Slot for right side of the Footers main part.
+ * @slot start - Slot for start (left side) of the Footers main part.
+ * @slot end - Slot for end (right side) of the Footers main part.
  */
 @Component({
   tag: 'tds-footer',

--- a/core/src/components/footer/footer.tsx
+++ b/core/src/components/footer/footer.tsx
@@ -1,6 +1,12 @@
-import { Component, h, State, Element } from '@stencil/core';
+import { Component, h, Element } from '@stencil/core';
 import { Host, Prop } from '@stencil/core/internal';
+import { hasSlot } from '../../utils/utils';
 
+/**
+ * @slot top - Slot for the top part of the Footer.
+ * @slot left - Slot for left side of the Footers main part.
+ * @slot right - Slot for right side of the Footers main part.
+ */
 @Component({
   tag: 'tds-footer',
   styleUrl: 'footer.scss',
@@ -12,30 +18,18 @@ export class TdsFooter {
   /** Mode variant of the component, based on current mode. */
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
-  /** Indicates whether the Footer has a top part. */
-  @State() hasTopPart: boolean;
-
-  connectedCallback() {
-    this.hasTopPart = Array.from(this.host.children).some((element) => element.slot === 'top');
-  }
-
   render() {
+    const usesTopSlot = hasSlot('top', this.host);
+    const usesStartSlot = hasSlot('start', this.host);
+    const usesEndSlot = hasSlot('end', this.host);
     return (
       <Host class={`${this.modeVariant ? `tds-mode-variant-${this.modeVariant}` : ''}`}>
         <footer>
-          {this.hasTopPart && (
-            <div class="footer-top">
-              <slot name="top"></slot>
-            </div>
-          )}
+          {usesTopSlot && <slot name="top"></slot>}
           <div class="footer-main">
             <div class="footer-main-top">
-              <div class="footer-bottom-left">
-                <slot name="main-left"></slot>
-              </div>
-              <div class="footer-bottom-right">
-                <slot name="main-right"></slot>
-              </div>
+              {usesStartSlot && <slot name="start"></slot>}
+              {usesEndSlot && <slot name="end"></slot>}
             </div>
             <div class="footer-main-bottom">
               <small class="copyright">Copyright &#169; {new Date().getFullYear()} Scania</small>

--- a/core/src/components/footer/readme.md
+++ b/core/src/components/footer/readme.md
@@ -12,6 +12,15 @@
 | `modeVariant` | `mode-variant` | Mode variant of the component, based on current mode. | `"primary" \| "secondary"` | `null`  |
 
 
+## Slots
+
+| Slot      | Description                                   |
+| --------- | --------------------------------------------- |
+| `"left"`  | Slot for left side of the Footers main part.  |
+| `"right"` | Slot for right side of the Footers main part. |
+| `"top"`   | Slot for the top part of the Footer.          |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/footer/readme.md
+++ b/core/src/components/footer/readme.md
@@ -14,11 +14,11 @@
 
 ## Slots
 
-| Slot      | Description                                   |
-| --------- | --------------------------------------------- |
-| `"left"`  | Slot for left side of the Footers main part.  |
-| `"right"` | Slot for right side of the Footers main part. |
-| `"top"`   | Slot for the top part of the Footer.          |
+| Slot      | Description                                          |
+| --------- | ---------------------------------------------------- |
+| `"end"`   | Slot for end (right side) of the Footers main part.  |
+| `"start"` | Slot for start (left side) of the Footers main part. |
+| `"top"`   | Slot for the top part of the Footer.                 |
 
 
 ----------------------------------------------

--- a/core/src/components/header/header-dropdown-list-user/readme.md
+++ b/core/src/components/header/header-dropdown-list-user/readme.md
@@ -21,7 +21,6 @@
 | ------------- | ----------------------- |
 | `"header"`    | Slot for the header.    |
 | `"thumbnail"` | Slot for the thumbnail. |
-| `"thumbnail"` | Slot for the thumbnail. |
 
 
 ----------------------------------------------


### PR DESCRIPTION
**Describe pull-request**  
 - Aligned the naming of the slots in the footer
 - Added docs for slots in readme.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-2021

**How to test**  
1. Go to Footer
2. Check in Notes
3. Check the slots section
4. Test the top part controls
5. Make sure the styling is correct.

How do we feel about naming here? Are the slots named correctly?

