### PR TITLE
feat(accordion): align slot naming

### DIFF
--- a/core/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/core/src/components/accordion/accordion-item/accordion-item.tsx
@@ -1,5 +1,9 @@
 import { Component, Event, EventEmitter, h, Host, Method, Prop } from '@stencil/core';
 
+/**
+ * @slot header - Slot for the Accordion Item header.
+ */
+
 @Component({
   tag: 'tds-accordion-item',
   styleUrl: 'accordion-item.scss',
@@ -62,7 +66,7 @@ export class TdsAccordionItem {
           >
             <div class="tds-accordion-title">
               {this.header}
-              <slot name="accordion-item-header"></slot>
+              <slot name="header"></slot>
             </div>
             <div class="tds-accordion-icon">
               <tds-icon name="chevron_down" size="16px"></tds-icon>

--- a/core/src/components/accordion/accordion-item/readme.md
+++ b/core/src/components/accordion/accordion-item/readme.md
@@ -36,6 +36,13 @@ Type: `Promise<void>`
 
 
 
+## Slots
+
+| Slot       | Description                         |
+| ---------- | ----------------------------------- |
+| `"header"` | Slot for the Accordion Item header. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/accordion/accordion.stories.tsx
+++ b/core/src/components/accordion/accordion.stories.tsx
@@ -87,7 +87,7 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant }) => {
         Lorem ipsum doler sit amet.
       </tds-accordion-item>
       <tds-accordion-item ${affixAttr} ${disabledAttr} ${paddingResetAttr} expanded>
-        <div slot="accordion-item-header">Second item</div>
+        <div slot="header">Second item</div>
         This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header.
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis laoreet vestibulum fermentum.
       </tds-accordion-item>


### PR DESCRIPTION
**Describe pull-request**  
Align slot naming as per convention. 

**Solving issue**  
Fixes: [DTS-1950](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?assignee=63ff6d6c314f5088138187f0&selectedIssue=DTS-1950)

**How to test**  
1. Go to Storybook link
2. Check in Components -> Accordion
3. Check Notes tab -> Accordion Item, verify label name is correct. 

[DTS-1950]: https://tegel.atlassian.net/browse/DTS-1950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ