### PR TITLE
feat(table): slot alignment

### DIFF
--- a/core/src/components/table/table-body-row-expandable/readme.md
+++ b/core/src/components/table/table-body-row-expandable/readme.md
@@ -12,6 +12,13 @@
 | `colSpan` | `col-span` | In case that automatic count of columns does not work, user can manually set this one. Take in mind that expandable control is column too | `number` | `null`  |
 
 
+## Slots
+
+| Slot           | Description                |
+| -------------- | -------------------------- |
+| `"expand-row"` | Slot for the expanded row. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -17,6 +17,10 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
   'noMinWidth',
   'modeVariant',
 ];
+
+/**
+ * @slot expand-row - Slot for the expanded row.
+ */
 @Component({
   tag: 'tds-table-body-row-expandable',
   styleUrl: 'table-body-row-expandable.scss',

--- a/core/src/components/table/table-component-batch-actions.stories.tsx
+++ b/core/src/components/table/table-component-batch-actions.stories.tsx
@@ -126,7 +126,9 @@ export default {
     compactDesign: false,
     responsiveDesign: false,
     batchArea: formatHtmlPreview(
-      '<div slot="end"><button class="tds-table__actionbar-btn"><tds-icon class="tds-table__actionbar-btn-icon" name="settings" size="20px"></tds-icon> </button><tds-button  type="primary" size="sm" text="Download"></tds-button></div>',
+      '<div slot="end"><tds-button type="ghost" size="sm">
+    <tds-icon slot="icon" class="tds-btn-icon" size="16px" name="settings"></tds-icon>
+  </tds-button><tds-button  type="primary" size="sm" text="Download"></tds-button></div>',
     ),
     verticalDivider: false,
     noMinWidth: false,

--- a/core/src/components/table/table-component-batch-actions.stories.tsx
+++ b/core/src/components/table/table-component-batch-actions.stories.tsx
@@ -126,9 +126,9 @@ export default {
     compactDesign: false,
     responsiveDesign: false,
     batchArea: formatHtmlPreview(
-      '<div slot="end"><tds-button type="ghost" size="sm">
-    <tds-icon slot="icon" class="tds-btn-icon" size="16px" name="settings"></tds-icon>
-  </tds-button><tds-button  type="primary" size="sm" text="Download"></tds-button></div>',
+      `<div slot="end"><tds-button type="ghost" size="sm">
+      <tds-icon slot="icon" class="tds-btn-icon" size="16px" name="settings"></tds-icon>
+    </tds-button><tds-button  type="primary" size="sm" text="Download"></tds-button></div>`,
     ),
     verticalDivider: false,
     noMinWidth: false,

--- a/core/src/components/table/table-component-batch-actions.stories.tsx
+++ b/core/src/components/table/table-component-batch-actions.stories.tsx
@@ -126,7 +126,7 @@ export default {
     compactDesign: false,
     responsiveDesign: false,
     batchArea: formatHtmlPreview(
-      '<button slot="tds-table__actionbar" class="tds-table__actionbar-btn"><tds-icon class="tds-table__actionbar-btn-icon" name="settings" size="20px"></tds-icon> </button><tds-button slot="tds-table__actionbar" type="primary" size="sm" text="Download"></tds-button>',
+      '<div slot="end"><button class="tds-table__actionbar-btn"><tds-icon class="tds-table__actionbar-btn-icon" name="settings" size="20px"></tds-icon> </button><tds-button  type="primary" size="sm" text="Download"></tds-button></div>',
     ),
     verticalDivider: false,
     noMinWidth: false,

--- a/core/src/components/table/table-header-cell/readme.md
+++ b/core/src/components/table/table-header-cell/readme.md
@@ -20,7 +20,7 @@
 
 | Event           | Description                                                                                                                                                          | Type                                                                                      |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "desc" \| "asc"; }>` |
+| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
 
 
 ----------------------------------------------

--- a/core/src/components/table/table-toolbar/readme.md
+++ b/core/src/components/table/table-toolbar/readme.md
@@ -20,6 +20,26 @@
 | `tdsFilterChange` | Used for sending users' input to the main parent tds-table the component, can also be listened to in order to implement custom sorting logic. | `CustomEvent<{ tableId: string; query: string; }>` |
 
 
+## Slots
+
+| Slot    | Description                                         |
+| ------- | --------------------------------------------------- |
+| `"end"` | Slot the the end (right side) of the Table Toolbar. |
+
+
+## Dependencies
+
+### Depends on
+
+- [tds-icon](../../icon)
+
+### Graph
+```mermaid
+graph TD;
+  tds-table-toolbar --> tds-icon
+  style tds-table-toolbar fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/table/table-toolbar/readme.md
+++ b/core/src/components/table/table-toolbar/readme.md
@@ -24,7 +24,7 @@
 
 | Slot    | Description                                         |
 | ------- | --------------------------------------------------- |
-| `"end"` | Slot the the end (right side) of the Table Toolbar. |
+| `"end"` | Slot the end (right side) of the Table Toolbar. |
 
 
 ## Dependencies

--- a/core/src/components/table/table-toolbar/table-toolbar.scss
+++ b/core/src/components/table/table-toolbar/table-toolbar.scss
@@ -26,7 +26,8 @@
     text-align: left;
   }
 
-  .tds-table__actionbar {
+  .tds-table__actionbar,
+  slot[name='end']::slotted(*) {
     display: flex;
     align-self: center;
     gap: 8px;

--- a/core/src/components/table/table-toolbar/table-toolbar.tsx
+++ b/core/src/components/table/table-toolbar/table-toolbar.tsx
@@ -18,7 +18,7 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
 ];
 
 /**
- * @slot end  - Slot the the end (right side) of the Table Toolbar.
+ * @slot end  - Slot the end (right side) of the Table Toolbar.
  */
 @Component({
   tag: 'tds-table-toolbar',

--- a/core/src/components/table/table-toolbar/table-toolbar.tsx
+++ b/core/src/components/table/table-toolbar/table-toolbar.tsx
@@ -18,7 +18,7 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
 ];
 
 /**
- * @slot end  - Slot the end (right side) of the Table Toolbar.
+ * @slot end  - Slot for the end (right side) of the Table Toolbar.
  */
 @Component({
   tag: 'tds-table-toolbar',

--- a/core/src/components/table/table-toolbar/table-toolbar.tsx
+++ b/core/src/components/table/table-toolbar/table-toolbar.tsx
@@ -17,6 +17,9 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
   'verticalDividers',
 ];
 
+/**
+ * @slot end  - Slot the the end (right side) of the Table Toolbar.
+ */
 @Component({
   tag: 'tds-table-toolbar',
   styleUrl: 'table-toolbar.scss',
@@ -130,18 +133,11 @@ export class TdsTableToolbar {
                   onKeyUp={(event) => this.searchFunction(event)}
                 />
                 <span class="tds-table__searchbar-icon">
-                  <svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-                    <path
-                      fill-rule="evenodd"
-                      clip-rule="evenodd"
-                      d="M12.942 1.985c-6.051 0-10.957 4.905-10.957 10.957 0 6.051 4.906 10.957 10.957 10.957 2.666 0 5.109-.952 7.008-2.534l8.332 8.331a1 1 0 1 0 1.414-1.414l-8.331-8.331a10.912 10.912 0 0 0 2.534-7.01c0-6.05-4.905-10.956-10.957-10.956ZM3.985 12.942a8.957 8.957 0 1 1 17.914 0 8.957 8.957 0 0 1-17.914 0Z"
-                      fill="currentColor"
-                    />
-                  </svg>
+                  <tds-icon name="search" size="20px"></tds-icon>
                 </span>
               </div>
             )}
-            <slot name="tds-table__actionbar" />
+            <slot name="end" />
           </div>
         </div>
       </Host>


### PR DESCRIPTION
**Describe pull-request**  
Aligns slot names for the table.

Table toolbar: 
 - Renamed "tds-table__actionbar" slot to "end"
 - Updated CSS rule to enable people to pass in a container as the slot.
 - Used tds icon instead of hardcoded svg.

Table  expanded row:
 - Docs for slots

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-2025

**How to test**  
1. Go to Table -> Filter/Batch Actions
2. Check the styling of the search and the batch actions
