### PR TITLE
fix(breadcrumbs): last element and disabled corrections

### DIFF
--- a/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
+++ b/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
@@ -17,13 +17,12 @@
     @include tds-focus-state;
   }
 
-  &.disabled,
   &.current,
   [aria-current='page'] {
     ::slotted(*) {
       pointer-events: none;
       cursor: default;
-      color: var(--tds-breadcrumb-color-disabled);
+      color: var(--tds-breadcrumb-color-current);
     }
 
     &:hover {

--- a/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
+++ b/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
@@ -45,7 +45,7 @@
   }
 }
 
-:host(.last) {
+:host(:last-of-type) {
   ::slotted(*)::after {
     display: none;
   }

--- a/core/src/components/breadcrumbs/breadcrumb/breadcrumb.tsx
+++ b/core/src/components/breadcrumbs/breadcrumb/breadcrumb.tsx
@@ -9,16 +9,9 @@ export class TdsBreadcrumb {
   /** Boolean for the current link */
   @Prop() current: boolean = false;
 
-  /** Toggle the disabled state for the Breadcrumb */
-  @Prop() disabled: boolean = false;
-
   render() {
     return (
-      <div
-        role="listitem"
-        class={`${this.current ? 'current' : ''} 
-        ${this.disabled ? 'disabled' : ''}`}
-      >
+      <div role="listitem" class={`${this.current ? 'current' : ''}`}>
         <slot />
       </div>
     );

--- a/core/src/components/breadcrumbs/breadcrumb/readme.md
+++ b/core/src/components/breadcrumbs/breadcrumb/readme.md
@@ -7,10 +7,9 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                                  | Type      | Default |
-| ---------- | ---------- | -------------------------------------------- | --------- | ------- |
-| `current`  | `current`  | Boolean for the current link                 | `boolean` | `false` |
-| `disabled` | `disabled` | Toggle the disabled state for the Breadcrumb | `boolean` | `false` |
+| Property  | Attribute | Description                  | Type      | Default |
+| --------- | --------- | ---------------------------- | --------- | ------- |
+| `current` | `current` | Boolean for the current link | `boolean` | `false` |
 
 
 ----------------------------------------------

--- a/core/src/components/breadcrumbs/breadcrumbs-vars.scss
+++ b/core/src/components/breadcrumbs/breadcrumbs-vars.scss
@@ -3,7 +3,7 @@
   --tds-breadcrumb-color: var(--tds-grey-900);
   --tds-breadcrumb-color-hover: var(--tds-grey-700);
   --tds-breadcrumb-color-focus: var(--tds-grey-700);
-  --tds-breadcrumb-color-disabled: var(--tds-grey-500);
+  --tds-breadcrumb-color-current: var(--tds-grey-500);
   --tds-breadcrumb-separator-color: var(--tds-grey-500);
 }
 
@@ -11,6 +11,6 @@
   --tds-breadcrumb-color: var(--tds-grey-300);
   --tds-breadcrumb-color-hover: var(--tds-grey-500);
   --tds-breadcrumb-color-focus: var(--tds-grey-500);
-  --tds-breadcrumb-color-disabled: var(--tds-grey-700);
+  --tds-breadcrumb-color-current: var(--tds-grey-700);
   --tds-breadcrumb-separator-color: var(--tds-grey-700);
 }

--- a/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -8,10 +8,6 @@ import { Component, h, Element } from '@stencil/core';
 export class TdsBreadcrumbs {
   @Element() el: HTMLElement;
 
-  connectedCallback() {
-    this.el.children[this.el.children.length - 1].classList.add('last');
-  }
-
   render() {
     return (
       <nav>


### PR DESCRIPTION
**Describe pull-request**  
Removed the logic for checking and added a last class to the last breadcumb and instead implemented CSS to handle this. Also removed the disabled prop since it's only used to show "current" in design.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-2042, https://tegel.atlassian.net/browse/DTS-2043

**How to test**  
1. Go to Breadbrumb
2. Check that the styling is correct for all items.
