### PR TITLE
fix(tabs): no event emitted on disabled tabs

### DIFF
--- a/core/src/components/tabs/folder-tabs/folder-tabs.tsx
+++ b/core/src/components/tabs/folder-tabs/folder-tabs.tsx
@@ -146,12 +146,11 @@ export class TdsFolderTabs {
     this.children = Array.from(this.host.children) as Array<HTMLTdsFolderTabElement>;
     this.children = this.children.map((item, index) => {
       item.addEventListener('click', () => {
-        const tdsChangeEvent = this.tdsChange.emit({
-          selectedTabIndex: this.children.indexOf(item),
-        });
-
-        if (!tdsChangeEvent.defaultPrevented) {
-          if (!item.disabled) {
+        if (!item.disabled) {
+          const tdsChangeEvent = this.tdsChange.emit({
+            selectedTabIndex: this.children.indexOf(item),
+          });
+          if (!tdsChangeEvent.defaultPrevented) {
             this.children.forEach((element) => element.setSelected(false));
             item.setSelected(true);
             this.selectedIndex = index;

--- a/core/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/core/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -126,11 +126,11 @@ export class TdsInlineTabs {
   addEventListenerToTabs = () => {
     this.children = this.children.map((item, index) => {
       item.addEventListener('click', () => {
-        const tdsChangeEvent = this.tdsChange.emit({
-          selectedTabIndex: this.children.indexOf(item),
-        });
-        if (!tdsChangeEvent.defaultPrevented) {
-          if (!item.disabled) {
+        if (!item.disabled) {
+          const tdsChangeEvent = this.tdsChange.emit({
+            selectedTabIndex: this.children.indexOf(item),
+          });
+          if (!tdsChangeEvent.defaultPrevented) {
             this.children.forEach((element) => element.setSelected(false));
             item.setSelected(true);
             this.selectedIndex = index;

--- a/core/src/components/tabs/navigation-tabs/navigation-tabs.tsx
+++ b/core/src/components/tabs/navigation-tabs/navigation-tabs.tsx
@@ -135,11 +135,11 @@ export class TdsNavigationTabs {
     this.children = Array.from(this.host.children) as Array<HTMLTdsNavigationTabElement>;
     this.children = this.children.map((item, index) => {
       item.addEventListener('click', () => {
-        const tdsChangeEvent = this.tdsChange.emit({
-          selectedTabIndex: this.children.indexOf(item),
-        });
-        if (!tdsChangeEvent.defaultPrevented) {
-          if (!item.disabled) {
+        if (!item.disabled) {
+          const tdsChangeEvent = this.tdsChange.emit({
+            selectedTabIndex: this.children.indexOf(item),
+          });
+          if (!tdsChangeEvent.defaultPrevented) {
             this.children.forEach((element) => element.setSelected(false));
             item.setSelected(true);
             this.selectedIndex = index;


### PR DESCRIPTION
**Describe pull-request**  
Adds an if check for disabled state in the event handler for click. This makes sure that the tdsChange is only emitted if the tab in not disabled. This also enables a tab to disabled/enabled in runtime and the functionality will still work. 

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1835

**How to test**  
1. Go to Folder/Inline/Navigation Tabs
2. Try clicking the disabled tab.
3. Make sure it doesn't change the content.

