### PR TITLE
fix(chip): css selector for gap

### DIFF
--- a/core/src/components/chip/chip.scss
+++ b/core/src/components/chip/chip.scss
@@ -6,15 +6,15 @@
   align-items: center;
 }
 
-:host([size='sm']) {
-  ::slotted(*) {
-    gap: 6px;
-  }
-}
-
-:host([size='lg']) {
+:host {
   ::slotted(*) {
     gap: 8px;
+  }
+
+  &[size='sm'] {
+    ::slotted(*) {
+      gap: 6px;
+    }
   }
 }
 


### PR DESCRIPTION
**Describe pull-request**  
The former css selector didn't allow for people to use the default size (not setting size="lg/sm") on the component. This fixes that, sets the gap to 8px by default and 6px if size="sm".

**How to test**  
1. Go to Chip
2. Test the controls for size in combination with/without an icon.



