### PR TITLE
fix(side-menu): slots

### DIFF
--- a/core/src/components/side-menu/readme.md
+++ b/core/src/components/side-menu/readme.md
@@ -23,13 +23,13 @@
 
 ## Slots
 
-| Slot             | Description                                                                            |
-| ---------------- | -------------------------------------------------------------------------------------- |
-| `"UNNAMED-SLOT"` | Used for nesting upper/top content in Side menu                                        |
-| `"close-button"` | Used for injection of tds-side-menu-close-button that is show when in mobile view      |
-| `"end"`          | Used for items that are presented at the bottom of the side menu, eg. profile settings |
-| `"overlay"`      | Used of injection of tds-side-menu-overlay                                             |
-| `"sticky-end"`   | Used for tds-side-menu-collapse-button component                                       |
+| Slot             | Description                                                                                                                                                  |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `"<default>"`    | <b>Unnamed slot.</b> Used for nesting main content of Side Menu, e.g. <code><tds-side-menu-item></code> and <code><tds-side-menu-dropdown></code> components |
+| `"close-button"` | Used for injection of tds-side-menu-close-button that is show when in mobile view                                                                            |
+| `"end"`          | Used for items that are presented at the bottom of the Side Menu, e.g. profile settings                                                                      |
+| `"overlay"`      | Used of injection of tds-side-menu-overlay                                                                                                                   |
+| `"sticky-end"`   | Used for tds-side-menu-collapse-button component                                                                                                             |
 
 
 ----------------------------------------------

--- a/core/src/components/side-menu/readme.md
+++ b/core/src/components/side-menu/readme.md
@@ -1,22 +1,5 @@
 # tds-side-menu
 
-### Side Menu is a component that consists of these sub-components:
-
- - side-menu-user-label
- - side-menu-user-image
- - side-menu-user
- - side-menu-overlay
- - side-menu-item
- - side-menu-dropdown
- - side-menu-dropdown-list
- - side-menu-dropdown-list-item
- - side-menu-collapse-button
- - side-menu-close-button
-
-Some of the upper mentioned subcomponents are not listed under <i>Notes</i> tab
-because either they are used only internally or they have no props or events but serve as wrappers.
-Their purpose is to improve code readability and present hierarchy structure.
-
 <!-- Auto Generated Below -->
 
 

--- a/core/src/components/side-menu/readme.md
+++ b/core/src/components/side-menu/readme.md
@@ -21,6 +21,17 @@
 | `tdsCollapse` | Event that is emitted when the Side Menu is collapsed. | `CustomEvent<{ collapsed: boolean; }>` |
 
 
+## Slots
+
+| Slot             | Description                                                                            |
+| ---------------- | -------------------------------------------------------------------------------------- |
+| `"UNNAMED-SLOT"` | Used for nesting upper/top content in Side menu                                        |
+| `"close-button"` | Used for injection of tds-side-menu-close-button that is show when in mobile view      |
+| `"end"`          | Used for items that are presented at the bottom of the side menu, eg. profile settings |
+| `"overlay"`      | Used of injection of tds-side-menu-overlay                                             |
+| `"sticky-end"`   | Used for tds-side-menu-collapse-button component                                       |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/side-menu/readme.md
+++ b/core/src/components/side-menu/readme.md
@@ -1,6 +1,21 @@
 # tds-side-menu
 
+### Side Menu is a component that consists of these sub-components:
 
+ - side-menu-user-label
+ - side-menu-user-image
+ - side-menu-user
+ - side-menu-overlay
+ - side-menu-item
+ - side-menu-dropdown
+ - side-menu-dropdown-list
+ - side-menu-dropdown-list-item
+ - side-menu-collapse-button
+ - side-menu-close-button
+
+Some of the upper mentioned subcomponents are not listed under <i>Notes</i> tab
+because either they are used only internally or they have no props or events but serve as wrappers.
+Their purpose is to improve code readability and present hierarchy structure.
 
 <!-- Auto Generated Below -->
 

--- a/core/src/components/side-menu/side-menu-collapse-button/readme.md
+++ b/core/src/components/side-menu/side-menu-collapse-button/readme.md
@@ -12,6 +12,13 @@
 | `tdsCollapse` | Event that is broadcast when the collapse button is clicked. Prevent it from disabling automatic collapsing, and set the collapsed prop on the Side Menu yourself. | `CustomEvent<{ collapsed: boolean; }>` |
 
 
+## Slots
+
+| Slot             | Description          |
+| ---------------- | -------------------- |
+| `"UNNAMED-SLOT"` | IS IT REALLY NEEDED? |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/side-menu/side-menu-collapse-button/readme.md
+++ b/core/src/components/side-menu/side-menu-collapse-button/readme.md
@@ -14,9 +14,9 @@
 
 ## Slots
 
-| Slot             | Description          |
-| ---------------- | -------------------- |
-| `"UNNAMED-SLOT"` | IS IT REALLY NEEDED? |
+| Slot          | Description                                                               |
+| ------------- | ------------------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> Used for injecting text presented in collapse button |
 
 
 ## Dependencies

--- a/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -1,6 +1,10 @@
 import { Component, Element, h, Host, Listen, State, Event, EventEmitter } from '@stencil/core';
 import { CollapseEvent } from '../side-menu';
 
+/**
+ * @slot UNNAMED-SLOT - IS IT REALLY NEEDED?
+ * */
+
 @Component({
   tag: 'tds-side-menu-collapse-button',
   styleUrl: 'side-menu-collapse-button.scss',

--- a/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -2,7 +2,7 @@ import { Component, Element, h, Host, Listen, State, Event, EventEmitter } from 
 import { CollapseEvent } from '../side-menu';
 
 /**
- * @slot UNNAMED-SLOT - IS IT REALLY NEEDED?
+ * @slot <default>  - <b>Unnamed slot.</b> Used for injecting text presented in collapse button
  * */
 
 @Component({

--- a/core/src/components/side-menu/side-menu-dropdown-list-item/readme.md
+++ b/core/src/components/side-menu/side-menu-dropdown-list-item/readme.md
@@ -12,6 +12,13 @@
 | `selected` | `selected` | If the item should appear selected. | `boolean` | `false` |
 
 
+## Slots
+
+| Slot | Description                                                                    |
+| ---- | ------------------------------------------------------------------------------ |
+|      | UNNAMED-SLOT - Used for injecting a native HTML elements like a link or button |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/side-menu/side-menu-dropdown-list-item/readme.md
+++ b/core/src/components/side-menu/side-menu-dropdown-list-item/readme.md
@@ -14,9 +14,9 @@
 
 ## Slots
 
-| Slot | Description                                                                    |
-| ---- | ------------------------------------------------------------------------------ |
-|      | UNNAMED-SLOT - Used for injecting a native HTML elements like a link or button |
+| Slot          | Description                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> Used for injecting native <code>button</code> and <code>link</code> elements |
 
 
 ----------------------------------------------

--- a/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
+++ b/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
@@ -1,6 +1,9 @@
 import { Component, Element, h, Host, Listen, Prop, State } from '@stencil/core';
 import { CollapseEvent } from '../side-menu';
 
+/**
+ * @slot - UNNAMED-SLOT - Used for injecting a native HTML elements like a link or button
+ * */
 @Component({
   tag: 'tds-side-menu-dropdown-list-item',
   styleUrl: 'side-menu-dropdown-list-item.scss',

--- a/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
+++ b/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
@@ -2,7 +2,7 @@ import { Component, Element, h, Host, Listen, Prop, State } from '@stencil/core'
 import { CollapseEvent } from '../side-menu';
 
 /**
- * @slot - UNNAMED-SLOT - Used for injecting a native HTML elements like a link or button
+ * @slot <default>  - <b>Unnamed slot.</b> Used for injecting native <code>button</code> and <code>link</code> elements
  * */
 @Component({
   tag: 'tds-side-menu-dropdown-list-item',

--- a/core/src/components/side-menu/side-menu-dropdown-list/readme.md
+++ b/core/src/components/side-menu/side-menu-dropdown-list/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot | Description                                                                        |
+| ---- | ---------------------------------------------------------------------------------- |
+|      | UNNAMED-SLOT - Used for injection of tds-side-menu-dropdown-list-item subcomponent |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/side-menu/side-menu-dropdown-list/readme.md
+++ b/core/src/components/side-menu/side-menu-dropdown-list/readme.md
@@ -7,9 +7,9 @@
 
 ## Slots
 
-| Slot | Description                                                                        |
-| ---- | ---------------------------------------------------------------------------------- |
-|      | UNNAMED-SLOT - Used for injection of tds-side-menu-dropdown-list-item subcomponent |
+| Slot          | Description                                                                                           |
+| ------------- | ----------------------------------------------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> Used for injection of <code>tds-side-menu-dropdown-list-item</code> subcomponent |
 
 
 ----------------------------------------------

--- a/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
+++ b/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
@@ -1,6 +1,9 @@
 import { Component, Host, h, Listen, Element, State } from '@stencil/core';
 import { CollapseEvent } from '../side-menu';
 
+/**
+ * @slot - UNNAMED-SLOT - Used for injection of tds-side-menu-dropdown-list-item subcomponent
+ * */
 @Component({
   tag: 'tds-side-menu-dropdown-list',
   styleUrl: 'side-menu-dropdown-list.scss',

--- a/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
+++ b/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
@@ -2,7 +2,7 @@ import { Component, Host, h, Listen, Element, State } from '@stencil/core';
 import { CollapseEvent } from '../side-menu';
 
 /**
- * @slot - UNNAMED-SLOT - Used for injection of tds-side-menu-dropdown-list-item subcomponent
+ * @slot <default>  - <b>Unnamed slot.</b> Used for injection of <code>tds-side-menu-dropdown-list-item</code> subcomponent
  * */
 @Component({
   tag: 'tds-side-menu-dropdown-list',

--- a/core/src/components/side-menu/side-menu-dropdown/readme.md
+++ b/core/src/components/side-menu/side-menu-dropdown/readme.md
@@ -16,11 +16,11 @@
 
 ## Slots
 
-| Slot             | Description                                                     |
-| ---------------- | --------------------------------------------------------------- |
-| `"UNNAMED-SLOT"` | Used for nesting another side-menu subcomponent                 |
-| `"button-icon"`  | Used for injecting the icon that compliments the dropdown title |
-| `"button-label"` | Used for injecting the text, aka dropdown title                 |
+| Slot             | Description                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| `"<default>"`    | <b>Unnamed slot.</b> Used for injection of <code>tds-side-menu-dropdown-list</code> subcomponent |
+| `"button-icon"`  | Used for injecting the icon that compliments the dropdown title                                  |
+| `"button-label"` | Used for injecting the text, aka dropdown title                                                  |
 
 
 ## Dependencies

--- a/core/src/components/side-menu/side-menu-dropdown/readme.md
+++ b/core/src/components/side-menu/side-menu-dropdown/readme.md
@@ -14,6 +14,14 @@
 | `selected`    | `selected`     | If the button that opens the dropdown should appear selected.                                     | `boolean` | `false`     |
 
 
+## Slots
+
+| Slot             | Description                                                     |
+| ---------------- | --------------------------------------------------------------- |
+| `"button-icon"`  | Used for injecting the icon that compliments the dropdown title |
+| `"button-label"` | Used for injecting the text, aka dropdown title                 |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/side-menu/side-menu-dropdown/readme.md
+++ b/core/src/components/side-menu/side-menu-dropdown/readme.md
@@ -18,6 +18,7 @@
 
 | Slot             | Description                                                     |
 | ---------------- | --------------------------------------------------------------- |
+| `"UNNAMED-SLOT"` | Used for nesting another side-menu subcomponent                 |
 | `"button-icon"`  | Used for injecting the icon that compliments the dropdown title |
 | `"button-label"` | Used for injecting the text, aka dropdown title                 |
 

--- a/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -4,7 +4,7 @@ import { CollapseEvent } from '../side-menu';
 /**
  * @slot button-icon - Used for injecting the icon that compliments the dropdown title
  * @slot button-label - Used for injecting the text, aka dropdown title
- * @slot UNNAMED-SLOT - Used for nesting another side-menu subcomponent
+ * @slot <default>  - <b>Unnamed slot.</b> Used for injection of <code>tds-side-menu-dropdown-list</code> subcomponent
  * */
 @Component({
   tag: 'tds-side-menu-dropdown',

--- a/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -1,6 +1,10 @@
 import { Component, Element, Fragment, h, Host, Listen, Prop, State } from '@stencil/core';
 import { CollapseEvent } from '../side-menu';
 
+/**
+ * @slot button-icon - Used for injecting the icon that compliments the dropdown title
+ * @slot button-label - Used for injecting the text, aka dropdown title
+ * */
 @Component({
   tag: 'tds-side-menu-dropdown',
   styleUrl: 'side-menu-dropdown.scss',

--- a/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -4,6 +4,7 @@ import { CollapseEvent } from '../side-menu';
 /**
  * @slot button-icon - Used for injecting the icon that compliments the dropdown title
  * @slot button-label - Used for injecting the text, aka dropdown title
+ * @slot UNNAMED-SLOT - Used for nesting another side-menu subcomponent
  * */
 @Component({
   tag: 'tds-side-menu-dropdown',

--- a/core/src/components/side-menu/side-menu-item/readme.md
+++ b/core/src/components/side-menu/side-menu-item/readme.md
@@ -13,6 +13,13 @@
 | `selected` | `selected` | If the item should appear selected.                                                                                          | `boolean` | `false` |
 
 
+## Slots
+
+| Slot | Description                                                       |
+| ---- | ----------------------------------------------------------------- |
+|      | UNNAMED-SLOT - used for injecting native button and link elements |
+
+
 ## Dependencies
 
 ### Used by

--- a/core/src/components/side-menu/side-menu-item/readme.md
+++ b/core/src/components/side-menu/side-menu-item/readme.md
@@ -15,9 +15,9 @@
 
 ## Slots
 
-| Slot | Description                                                       |
-| ---- | ----------------------------------------------------------------- |
-|      | UNNAMED-SLOT - used for injecting native button and link elements |
+| Slot          | Description                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> Used for injecting native <code>button</code> and <code>link</code> elements |
 
 
 ## Dependencies

--- a/core/src/components/side-menu/side-menu-item/side-menu-item.tsx
+++ b/core/src/components/side-menu/side-menu-item/side-menu-item.tsx
@@ -3,7 +3,7 @@ import { CollapseEvent } from '../side-menu';
 import { dfs } from '../../../utils/utils';
 
 /**
- * @slot - UNNAMED-SLOT - used for injecting native button and link elements
+ * @slot <default>  - <b>Unnamed slot.</b> Used for injecting native <code>button</code> and <code>link</code> elements
  * */
 @Component({
   tag: 'tds-side-menu-item',

--- a/core/src/components/side-menu/side-menu-item/side-menu-item.tsx
+++ b/core/src/components/side-menu/side-menu-item/side-menu-item.tsx
@@ -2,6 +2,9 @@ import { Component, h, Host, Element, Listen, Prop, State } from '@stencil/core'
 import { CollapseEvent } from '../side-menu';
 import { dfs } from '../../../utils/utils';
 
+/**
+ * @slot - UNNAMED-SLOT - used for injecting native button and link elements
+ * */
 @Component({
   tag: 'tds-side-menu-item',
   styleUrl: 'side-menu-item.scss',

--- a/core/src/components/side-menu/side-menu-user-image/readme.md
+++ b/core/src/components/side-menu/side-menu-user-image/readme.md
@@ -15,9 +15,9 @@
 
 ## Slots
 
-| Slot             | Description                   |
-| ---------------- | ----------------------------- |
-| `"UNNAMED-SLOT"` | TO BE CHECKED IF IT IS NEEDED |
+| Slot                                                                                                                            | Description |
+| ------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `"<default> - <b>Unnamed slot.</b> Used as alternative to props to inject <code><img...</code> element directly into the DOM."` |             |
 
 
 ## Dependencies

--- a/core/src/components/side-menu/side-menu-user-image/readme.md
+++ b/core/src/components/side-menu/side-menu-user-image/readme.md
@@ -13,6 +13,13 @@
 | `src`    | `src`     | The image source.   | `string` | `undefined` |
 
 
+## Slots
+
+| Slot             | Description                   |
+| ---------------- | ----------------------------- |
+| `"UNNAMED-SLOT"` | TO BE CHECKED IF IT IS NEEDED |
+
+
 ## Dependencies
 
 ### Used by

--- a/core/src/components/side-menu/side-menu-user-image/side-menu-user-image.tsx
+++ b/core/src/components/side-menu/side-menu-user-image/side-menu-user-image.tsx
@@ -2,6 +2,12 @@ import { Component, h, Host, Prop } from '@stencil/core';
 
 // TODO this component is just for the dropdown detecting that it should
 // change layout
+// FIXME: Can the logic for it be directly integrated in side-menu-user instead?
+
+/**
+ * @slot UNNAMED-SLOT - TO BE CHECKED IF IT IS NEEDED
+ * */
+
 @Component({
   tag: 'tds-side-menu-user-image',
   styleUrl: 'side-menu-user-image.scss',

--- a/core/src/components/side-menu/side-menu-user-image/side-menu-user-image.tsx
+++ b/core/src/components/side-menu/side-menu-user-image/side-menu-user-image.tsx
@@ -5,7 +5,8 @@ import { Component, h, Host, Prop } from '@stencil/core';
 // FIXME: Can the logic for it be directly integrated in side-menu-user instead?
 
 /**
- * @slot UNNAMED-SLOT - TO BE CHECKED IF IT IS NEEDED
+ * @slot <default> -
+ * <b>Unnamed slot.</b> Used as alternative to props to inject <code><img...</code> element directly into the DOM.
  * */
 
 @Component({

--- a/core/src/components/side-menu/side-menu-user/readme.md
+++ b/core/src/components/side-menu/side-menu-user/readme.md
@@ -15,6 +15,13 @@
 | `subheading`           | `subheading` | The subheading text. | `string` | `undefined` |
 
 
+## Slots
+
+| Slot      | Description                                                                                                   |
+| --------- | ------------------------------------------------------------------------------------------------------------- |
+| `"image"` | Used as alternative to imgSrc and imgAlt props. Offers injecting <code>HTML</code> directly into a component. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/side-menu/side-menu-user/readme.md
+++ b/core/src/components/side-menu/side-menu-user/readme.md
@@ -17,9 +17,9 @@
 
 ## Slots
 
-| Slot      | Description                                                                                                   |
-| --------- | ------------------------------------------------------------------------------------------------------------- |
-| `"image"` | Used as alternative to imgSrc and imgAlt props. Offers injecting <code>HTML</code> directly into a component. |
+| Slot                                                                                                                            | Description |
+| ------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `"<default> - <b>Unnamed slot.</b> Used as alternative to props to inject <code><img...</code> element directly into the DOM."` |             |
 
 
 ## Dependencies

--- a/core/src/components/side-menu/side-menu-user/readme.md
+++ b/core/src/components/side-menu/side-menu-user/readme.md
@@ -17,9 +17,9 @@
 
 ## Slots
 
-| Slot                                                                                                                            | Description |
-| ------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| `"<default> - <b>Unnamed slot.</b> Used as alternative to props to inject <code><img...</code> element directly into the DOM."` |             |
+| Slot          | Description                                                                                                     |
+| ------------- | --------------------------------------------------------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> Used as alternative to props to inject <code><img...</code> element directly into the DOM. |
 
 
 ## Dependencies

--- a/core/src/components/side-menu/side-menu-user/side-menu-user.tsx
+++ b/core/src/components/side-menu/side-menu-user/side-menu-user.tsx
@@ -1,8 +1,7 @@
 import { Component, h, Host, Prop } from '@stencil/core';
 
 /**
- * @slot <default> -
- * <b>Unnamed slot.</b> Used as alternative to props to inject <code><img...</code> element directly into the DOM.
+ * @slot <default> - <b>Unnamed slot.</b> Used as alternative to props to inject <code><img...</code> element directly into the DOM.
  * */
 
 @Component({

--- a/core/src/components/side-menu/side-menu-user/side-menu-user.tsx
+++ b/core/src/components/side-menu/side-menu-user/side-menu-user.tsx
@@ -1,5 +1,8 @@
 import { Component, h, Host, Prop } from '@stencil/core';
 
+/**
+ * @slot image - Used as alternative to imgSrc and imgAlt props. Offers injecting <code>HTML</code> directly into a component.
+ * */
 @Component({
   tag: 'tds-side-menu-user',
   styleUrl: 'side-menu-user.scss',

--- a/core/src/components/side-menu/side-menu-user/side-menu-user.tsx
+++ b/core/src/components/side-menu/side-menu-user/side-menu-user.tsx
@@ -1,8 +1,10 @@
 import { Component, h, Host, Prop } from '@stencil/core';
 
 /**
- * @slot image - Used as alternative to imgSrc and imgAlt props. Offers injecting <code>HTML</code> directly into a component.
+ * @slot <default> -
+ * <b>Unnamed slot.</b> Used as alternative to props to inject <code><img...</code> element directly into the DOM.
  * */
+
 @Component({
   tag: 'tds-side-menu-user',
   styleUrl: 'side-menu-user.scss',

--- a/core/src/components/side-menu/side-menu.stories.tsx
+++ b/core/src/components/side-menu/side-menu.stories.tsx
@@ -6,6 +6,7 @@ import readmeSideMenuUser from './side-menu-user/readme.md';
 import readmeSideMenuCollapseButton from './side-menu-collapse-button/readme.md';
 import readmeSideMenuDropdown from './side-menu-dropdown/readme.md';
 import readmeSideMenuItem from './side-menu-item/readme.md';
+import readmeSideMenuDropdownList from './side-menu-dropdown-list/readme.md';
 import readmeSideMenuDropdownListItem from './side-menu-dropdown-list-item/readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
@@ -19,6 +20,7 @@ export default {
       'Side Menu User': readmeSideMenuUser,
       'Side Menu Collapse Button': readmeSideMenuCollapseButton,
       'Side Menu Dropdown': readmeSideMenuDropdown,
+      'Side Menu Dropdown List': readmeSideMenuDropdownList,
       'Side Menu Dropdown List Item': readmeSideMenuDropdownListItem,
       'Side Menu Item': readmeSideMenuItem,
     },

--- a/core/src/components/side-menu/side-menu.stories.tsx
+++ b/core/src/components/side-menu/side-menu.stories.tsx
@@ -23,6 +23,7 @@ export default {
       'Side Menu Dropdown List': readmeSideMenuDropdownList,
       'Side Menu Dropdown List Item': readmeSideMenuDropdownListItem,
       'Side Menu Item': readmeSideMenuItem,
+      'Side Menu Collapse Button': readmeSideMenuCollapseButton,
     },
     layout: 'fullscreen',
     docs: {

--- a/core/src/components/side-menu/side-menu.stories.tsx
+++ b/core/src/components/side-menu/side-menu.stories.tsx
@@ -5,6 +5,7 @@ import readmeSideMenuOverlay from './side-menu-overlay/readme.md';
 import readmeSideMenuUser from './side-menu-user/readme.md';
 import readmeSideMenuCollapseButton from './side-menu-collapse-button/readme.md';
 import readmeSideMenuDropdown from './side-menu-dropdown/readme.md';
+import readmeSideMenuItem from './side-menu-item/readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
@@ -17,6 +18,7 @@ export default {
       'Side Menu User': readmeSideMenuUser,
       'Side Menu Collapse Button': readmeSideMenuCollapseButton,
       'Side Menu Dropdown': readmeSideMenuDropdown,
+      'Side Menu Item': readmeSideMenuItem,
     },
     layout: 'fullscreen',
     docs: {

--- a/core/src/components/side-menu/side-menu.stories.tsx
+++ b/core/src/components/side-menu/side-menu.stories.tsx
@@ -6,6 +6,7 @@ import readmeSideMenuUser from './side-menu-user/readme.md';
 import readmeSideMenuCollapseButton from './side-menu-collapse-button/readme.md';
 import readmeSideMenuDropdown from './side-menu-dropdown/readme.md';
 import readmeSideMenuItem from './side-menu-item/readme.md';
+import readmeSideMenuDropdownListItem from './side-menu-dropdown-list-item/readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
@@ -18,6 +19,7 @@ export default {
       'Side Menu User': readmeSideMenuUser,
       'Side Menu Collapse Button': readmeSideMenuCollapseButton,
       'Side Menu Dropdown': readmeSideMenuDropdown,
+      'Side Menu Dropdown List Item': readmeSideMenuDropdownListItem,
       'Side Menu Item': readmeSideMenuItem,
     },
     layout: 'fullscreen',

--- a/core/src/components/side-menu/side-menu.stories.tsx
+++ b/core/src/components/side-menu/side-menu.stories.tsx
@@ -1,12 +1,10 @@
 import readme from './readme.md';
 import { formatHtmlPreview } from '../../utils/utils';
-import readmeSideMenuCloseButton from './side-menu-close-button/readme.md';
-import readmeSideMenuOverlay from './side-menu-overlay/readme.md';
+
 import readmeSideMenuUser from './side-menu-user/readme.md';
 import readmeSideMenuCollapseButton from './side-menu-collapse-button/readme.md';
 import readmeSideMenuDropdown from './side-menu-dropdown/readme.md';
 import readmeSideMenuItem from './side-menu-item/readme.md';
-import readmeSideMenuDropdownList from './side-menu-dropdown-list/readme.md';
 import readmeSideMenuDropdownListItem from './side-menu-dropdown-list-item/readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
@@ -15,15 +13,11 @@ export default {
   parameters: {
     notes: {
       'Side Menu': readme,
-      'Side Menu Close Button': readmeSideMenuCloseButton,
-      'Side Menu Overlay': readmeSideMenuOverlay,
       'Side Menu User': readmeSideMenuUser,
       'Side Menu Collapse Button': readmeSideMenuCollapseButton,
       'Side Menu Dropdown': readmeSideMenuDropdown,
-      'Side Menu Dropdown List': readmeSideMenuDropdownList,
       'Side Menu Dropdown List Item': readmeSideMenuDropdownListItem,
       'Side Menu Item': readmeSideMenuItem,
-      'Side Menu Collapse Button': readmeSideMenuCollapseButton,
     },
     layout: 'fullscreen',
     docs: {

--- a/core/src/components/side-menu/side-menu.stories.tsx
+++ b/core/src/components/side-menu/side-menu.stories.tsx
@@ -1,11 +1,15 @@
-import readme from './readme.md';
 import { formatHtmlPreview } from '../../utils/utils';
 
+import readme from './readme.md';
 import readmeSideMenuUser from './side-menu-user/readme.md';
+import readmeSideMenuOverlay from './side-menu-overlay/readme.md';
+import readmeSideMenuCloseButton from './side-menu-close-button/readme.md';
 import readmeSideMenuCollapseButton from './side-menu-collapse-button/readme.md';
 import readmeSideMenuDropdown from './side-menu-dropdown/readme.md';
 import readmeSideMenuItem from './side-menu-item/readme.md';
+import readmeSideMenuDropdownList from './side-menu-dropdown-list/readme.md';
 import readmeSideMenuDropdownListItem from './side-menu-dropdown-list-item/readme.md';
+
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
@@ -13,11 +17,14 @@ export default {
   parameters: {
     notes: {
       'Side Menu': readme,
+      'Side Menu Item': readmeSideMenuItem,
+      'Side Menu Dropdown': readmeSideMenuDropdown,
+      'Side Menu Dropdown List': readmeSideMenuDropdownList,
+      'Side Menu Dropdown List Item': readmeSideMenuDropdownListItem,
       'Side Menu User': readmeSideMenuUser,
       'Side Menu Collapse Button': readmeSideMenuCollapseButton,
-      'Side Menu Dropdown': readmeSideMenuDropdown,
-      'Side Menu Dropdown List Item': readmeSideMenuDropdownListItem,
-      'Side Menu Item': readmeSideMenuItem,
+      'Side Menu Close Button': readmeSideMenuCloseButton,
+      'Side Menu Overlay': readmeSideMenuOverlay,
     },
     layout: 'fullscreen',
     docs: {

--- a/core/src/components/side-menu/side-menu.tsx
+++ b/core/src/components/side-menu/side-menu.tsx
@@ -201,7 +201,6 @@ export class TdsSideMenu {
             <slot name="close-button"></slot>
             <div class="tds-side-menu-wrapper">
               <ul class={`tds-side-menu-list tds-side-menu-list-upper`}>
-                {/* FIXME: Change to start-end, top-bottom and name the slot */}
                 <slot></slot>
               </ul>
               <ul class={`tds-side-menu-list tds-side-menu-list-end`}>

--- a/core/src/components/side-menu/side-menu.tsx
+++ b/core/src/components/side-menu/side-menu.tsx
@@ -31,8 +31,9 @@ const INITIALIZE_ANIMATION_DELAY = 500;
 /**
  * @slot overlay - Used of injection of tds-side-menu-overlay
  * @slot close-button - Used for injection of tds-side-menu-close-button that is show when in mobile view
- * @slot UNNAMED-SLOT - Used for nesting upper/top content in Side menu
- * @slot end - Used for items that are presented at the bottom of the side menu, eg. profile settings
+ * @slot <default> - <b>Unnamed slot.</b>
+ * Used for nesting main content of Side Menu, e.g. <code><tds-side-menu-item></code> and <code><tds-side-menu-dropdown></code> components
+ * @slot end - Used for items that are presented at the bottom of the Side Menu, e.g. profile settings
  * @slot sticky-end - Used for tds-side-menu-collapse-button component
  * */
 

--- a/core/src/components/side-menu/side-menu.tsx
+++ b/core/src/components/side-menu/side-menu.tsx
@@ -28,6 +28,14 @@ const GRID_LG_BREAKPOINT = '992px';
 const OPENING_ANIMATION_DURATION = 400;
 const INITIALIZE_ANIMATION_DELAY = 500;
 
+/**
+ * @slot overlay - Used of injection of tds-side-menu-overlay
+ * @slot close-button - Used for injection of tds-side-menu-close-button that is show when in mobile view
+ * @slot UNNAMED-SLOT - Used for nesting upper/top content in Side menu
+ * @slot end - Used for items that are presented at the bottom of the side menu, eg. profile settings
+ * @slot sticky-end - Used for tds-side-menu-collapse-button component
+ * */
+
 @Component({
   tag: 'tds-side-menu',
   styleUrl: 'side-menu.scss',
@@ -192,6 +200,7 @@ export class TdsSideMenu {
             <slot name="close-button"></slot>
             <div class="tds-side-menu-wrapper">
               <ul class={`tds-side-menu-list tds-side-menu-list-upper`}>
+                {/* FIXME: Change to start-end, top-bottom and name the slot */}
                 <slot></slot>
               </ul>
               <ul class={`tds-side-menu-list tds-side-menu-list-end`}>


### PR DESCRIPTION
**Describe pull-request**  
Aligning slots naming per our convention

**Solving issue**  
Fixes: [DTS-1957](https://tegel.atlassian.net/browse/DTS-1957)

**What was done:**
 - document all slot and their names in readme files
 - use `<default>` to indicate those are not named for purpose, can be used for side-menu sub-components ect...
 - show the user only Notes they really need to know about (show one used in stories, hide internal ones)


**How to test**  
1. Go to Netlify PR preview link
4. Check that the Side-menu component and pattern stories still look and function OK.


**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

[DTS-1957]: https://tegel.atlassian.net/browse/DTS-1957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ