### PR TITLE
fix(modal): closing programatically without emitting event

### DIFF
--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -52,13 +52,13 @@ export class TdsModal {
   /** Shows the Modal.  */
   @Method()
   async showModal() {
-    this.handleShow();
+    this.isShown = true;
   }
 
   /** Closes the Modal. */
   @Method()
   async closeModal() {
-    this.handleClose();
+    this.isShown = false;
   }
 
   /** Emits when the Modal is closed. */
@@ -84,8 +84,7 @@ export class TdsModal {
     }
   }
 
-  /** Emits a close event and then close the Modal if it is not prevented. */
-  handleClose = (event?) => {
+  handleClose = (event) => {
     const closeEvent = this.tdsClose.emit(event);
     if (!closeEvent.defaultPrevented) {
       this.isShown = false;
@@ -158,7 +157,13 @@ export class TdsModal {
           <div class="header">
             {this.header && <div class="header">{this.header}</div>}
             {usesHeaderSlot && <slot name="header"></slot>}
-            <button class="tds-modal-close" aria-label="close" onClick={() => this.handleClose()}>
+            <button
+              class="tds-modal-close"
+              aria-label="close"
+              onClick={(event) => {
+                this.handleClose(event);
+              }}
+            >
               <tds-icon name="cross" size="20px"></tds-icon>
             </button>
           </div>


### PR DESCRIPTION
**Describe pull-request**  
Enabled closing of modal programatically when preventing event. When the modal is closed using the closeModal method on the component it no longer emitts the tdsClose event.


**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1839

**How to test**  
1. Check out the branch
2. Prevent the close event and implement your own closing logic using the closeModal method.
4. Make sure the modal closes.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

