### PR TITLE
fix(footer): apply styling only to links/buttons

### DIFF
--- a/core/src/components/footer/footer-item/footer-item.scss
+++ b/core/src/components/footer/footer-item/footer-item.scss
@@ -1,7 +1,8 @@
 @import '../../../mixins/focus-state';
 
 [role='listitem'] {
-  ::slotted(*) {
+  ::slotted(a),
+  ::slotted(button) {
     font: var(--tds-headline-06);
     letter-spacing: var(--tds-headline-06-ls);
     color: var(--tds-footer-main-links);
@@ -9,16 +10,19 @@
     text-decoration: none;
   }
 
-  ::slotted(*:focus-visible) {
+  ::slotted(a:focus-visible),
+  ::slotted(button:focus-visible) {
     @include tds-focus-state;
   }
 
-  ::slotted(*:hover) {
+  ::slotted(a:hover),
+  ::slotted(button:hover) {
     text-decoration: underline;
   }
 
   &.top-part-child {
-    ::slotted(*) {
+    ::slotted(a),
+    ::slotted(button) {
       color: var(--tds-footer-top-links);
       font-family: 'Scania Sans Semi Condensed', 'Scania Sans Condensed', arial, helvetica,
         sans-serif;
@@ -27,7 +31,8 @@
       line-height: 18px;
     }
 
-    ::slotted(*:focus-visible) {
+    ::slotted(a:focus-visible),
+    ::slotted(button:focus-visible) {
       @include tds-focus-state;
     }
   }
@@ -37,19 +42,22 @@
   [role='listitem'].top-part-child {
     border-bottom: 1px solid var(--tds-footer-top-divider);
 
-    ::slotted(*) {
+    ::slotted(a),
+    ::slotted(button) {
       display: block;
       height: 100%;
       padding: 19px 40px;
       font-weight: normal;
     }
 
-    ::slotted(*:hover) {
+    ::slotted(a:hover),
+    ::slotted(button:hover) {
       text-decoration: underline;
       background-color: var(--tds-footer-top-links-background-hover);
     }
 
-    ::slotted(*:focus-visible) {
+    ::slotted(a:focus-visible),
+    ::slotted(button:focus-visible) {
       @include tds-focus-state;
     }
   }


### PR DESCRIPTION
**Describe pull-request**  
Updated the CSS to only apply styling to links and buttons. This is to enable the user to more easily created custom top parts of the footer.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1841

**How to test**  
1. Go to Footer
2. Check that the styling is still correct.
