### PR TITLE
fix(side-menu): z-index

### DIFF
--- a/core/src/components/side-menu/side-menu.scss
+++ b/core/src/components/side-menu/side-menu.scss
@@ -64,6 +64,13 @@
   }
 }
 
+@media (max-width: $grid-lg) {
+  :host([open]) {
+    pointer-events: auto;
+    z-index: tds-z-index(header) + 1;
+  }
+}
+
 @media (min-width: $grid-lg) {
   :host([persistent]) {
     pointer-events: auto;

--- a/core/src/components/side-menu/side-menu.scss
+++ b/core/src/components/side-menu/side-menu.scss
@@ -4,11 +4,6 @@
 @import '../../mixins/z-index';
 @import '../../global/variables';
 
-:host([open]) {
-  pointer-events: auto;
-  z-index: tds-z-index(header) + 1;
-}
-
 :host {
   pointer-events: none;
   display: block;
@@ -70,6 +65,11 @@
 }
 
 @media (min-width: $grid-lg) {
+  :host([open]) {
+    pointer-events: auto;
+    z-index: tds-z-index(header) + 1;
+  }
+
   :host([persistent]) {
     pointer-events: auto;
     position: static;

--- a/core/src/components/side-menu/side-menu.scss
+++ b/core/src/components/side-menu/side-menu.scss
@@ -65,11 +65,6 @@
 }
 
 @media (min-width: $grid-lg) {
-  :host([open]) {
-    pointer-events: auto;
-    z-index: tds-z-index(header) + 1;
-  }
-
   :host([persistent]) {
     pointer-events: auto;
     position: static;

--- a/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
@@ -230,7 +230,7 @@ const Template = ({ dummyHtml }) =>
           </button>
         </tds-side-menu-item>
 
-        <tds-side-menu-collapse-button slot="sticky-end" onclick="demoSideMenu.collapsed = !demoSideMenu.collapsed;"></tds-side-menu-collapse-button>
+        <tds-side-menu-collapse-button slot="sticky-end"></tds-side-menu-collapse-button>
 
       </tds-side-menu>
 


### PR DESCRIPTION
**Describe pull-request**  
Updated z-index to only take affect on smaller screens. This fixes the issue of a user on small screen opening the side-menu -> making the window bigger -> side-menu now overlaps header.

**Solving issue**  
Fixes: 

**Screenshots**  
<img width="1404" alt="Screenshot 2023-07-03 at 12 25 12" src="https://github.com/scania-digital-design-system/tegel/assets/62651103/f48e649e-124a-4e52-badc-e255b96ab686">
