### PR TITLE
fix(tabs): set transition on hover

### DIFF
--- a/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
+++ b/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
@@ -28,6 +28,11 @@
     @include tds-focus-state;
   }
 
+  .inline-tab-item:not(.selected)::after {
+    width: 0%;
+    transition: width 0.15s ease-in-out 0s;
+  }
+
   .inline-tab-item {
     position: relative;
     margin-right: 32px;
@@ -53,10 +58,6 @@
     height: 2px;
     background-color: var(--tds-inline-tabs-tab-indicator-background-hover);
     z-index: 1;
-  }
-
-  .inline-tab-item:hover::after {
-    transition: width 0.15s ease-in-out 0s;
   }
 
   .selected {

--- a/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
+++ b/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
@@ -52,8 +52,11 @@
     margin-right: auto;
     height: 2px;
     background-color: var(--tds-inline-tabs-tab-indicator-background-hover);
-    transition: width 0.15s ease-in-out 0s;
     z-index: 1;
+  }
+
+  .inline-tab-item:hover::after {
+    transition: width 0.15s ease-in-out 0s;
   }
 
   .selected {

--- a/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
+++ b/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
@@ -52,8 +52,11 @@
     margin-right: auto;
     height: 2px;
     background-color: var(--tds-navigation-tabs-tab-indicator-background-hover);
-    transition: width 0.15s ease-in-out 0s;
     z-index: 1;
+  }
+
+  .navigation-tab-item:hover::after {
+    transition: width 0.15s ease-in-out 0s;
   }
 
   .selected {

--- a/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
+++ b/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
@@ -28,6 +28,11 @@
     @include tds-focus-state;
   }
 
+  .navigation-tab-item:not(.selected)::after {
+    width: 0%;
+    transition: width 0.15s ease-in-out 0s;
+  }
+
   .navigation-tab-item {
     position: relative;
     margin-right: 32px;
@@ -53,10 +58,6 @@
     height: 2px;
     background-color: var(--tds-navigation-tabs-tab-indicator-background-hover);
     z-index: 1;
-  }
-
-  .navigation-tab-item:hover::after {
-    transition: width 0.15s ease-in-out 0s;
   }
 
   .selected {


### PR DESCRIPTION
**Describe pull-request**  
Sets the width transition on hover to not the the flashing on page load.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-2006

**How to test**  
1. Go to Inline/Navigation Tabs
2. Check the animation on the selected tab on load.
3. It should not transition.
