### PR TITLE
fix(toast): closing programatically without emitting event

### DIFF
--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -36,13 +36,13 @@ export class TdsToast {
   /** Hides the Toast. */
   @Method()
   async hideToast() {
-    this.handleClose();
+    this.hidden = true;
   }
 
   /** Shows the Toast. */
   @Method()
   async showToast() {
-    this.handleShow();
+    this.hidden = false;
   }
 
   /** Sends unique Toast identifier when component is closed. */


### PR DESCRIPTION
**Describe pull-request**  
Updated the hide/showToast methods to not emit tdsClose/tdsShow event.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1960

**How to test**  
1. Check out branch.
2. Prevent default on tdsClose/Show event.
3. Hide/show the toast programatically and make sure it works.
