### PR TITLE
fix(side menu): corrected background color of collapsed dropdown

### DIFF
--- a/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.scss
+++ b/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.scss
@@ -28,7 +28,7 @@
       position: absolute;
       left: var(--side-menu-width);
       box-shadow: var(--tds-nav-dropdown-menu-box);
-      background-color: var(--tds-grey-958);
+      background-color: var(--tds-sidebar-side-menu-subnav-background);
 
       .heading-collapsed {
         all: unset;

--- a/core/src/components/side-menu/side-menu-vars.scss
+++ b/core/src/components/side-menu/side-menu-vars.scss
@@ -25,7 +25,7 @@
   --tds-sidebar-side-menu-single-subitem-color-active: var(--tds-grey-958);
   --tds-sidebar-side-menu-single-subitem-backgrund: var(--tds-white);
   --tds-sidebar-side-menu-single-subitem-divider: var(--tds-grey-300);
-  --tds-sidebar-side-menu-subnav-backgrund: var(--tds-white);
+  --tds-sidebar-side-menu-subnav-background: var(--tds-white);
   --tds-sidebar-side-menu-single-subitem-selected-border-color: var(--tds-blue-400);
 }
 
@@ -53,6 +53,6 @@
   --tds-sidebar-side-menu-single-subitem-color-active: var(--tds-grey-958);
   --tds-sidebar-side-menu-single-subitem-backgrund: var(--tds-grey-958);
   --tds-sidebar-side-menu-single-subitem-divider: var(--tds-grey-700);
-  --tds-sidebar-side-menu-subnav-backgrund: var(--tds-grey-800);
+  --tds-sidebar-side-menu-subnav-background: var(--tds-grey-958);
   --tds-sidebar-side-menu-single-subitem-selected-border-color: var(--tds-blue-400);
 }


### PR DESCRIPTION
**Describe pull-request**  
Corrected background color of collapsed dropdown.

**Solving issue**  
Fixes: -

**How to test**  
1. Go to Side Menu
2. Check the background of the collapsed dropdown.

**Screenshots**  
<img width="741" alt="Screenshot 2023-07-03 at 16 16 40" src="https://github.com/scania-digital-design-system/tegel/assets/62651103/3643eeb4-206d-43c4-a53a-95c332395f40">

