### PR TITLE
feat(table): fixed logic for showing/hiding no result message

### DIFF
--- a/core/src/components/icon/readme.md
+++ b/core/src/components/icon/readme.md
@@ -34,6 +34,7 @@
  - [tds-slider](../slider)
  - [tds-step](../stepper/step)
  - [tds-table-footer](../table/table-footer)
+ - [tds-table-toolbar](../table/table-toolbar)
  - [tds-text-field](../text-field)
  - [tds-textarea](../textarea)
  - [tds-toast](../toast)
@@ -60,6 +61,7 @@ graph TD;
   tds-slider --> tds-icon
   tds-step --> tds-icon
   tds-table-footer --> tds-icon
+  tds-table-toolbar --> tds-icon
   tds-text-field --> tds-icon
   tds-textarea --> tds-icon
   tds-toast --> tds-icon

--- a/core/src/components/table/table-body/readme.md
+++ b/core/src/components/table/table-body/readme.md
@@ -11,6 +11,15 @@
 | ----------------- | ------------------- | ---------------------------------------------------------------------------------- | --------- | ----------- |
 | `bodyData`        | `body-data`         | Prop to pass JSON string which enables automatic rendering of Table rows and cells | `any`     | `undefined` |
 | `enableDummyData` | `enable-dummy-data` | Prop for showcase of rendering JSON in body-data, just for presentation purposes   | `boolean` | `false`     |
+| `noResultMessage` | `no-result-message` | Prop for showcase of rendering JSON in body-data, just for presentation purposes   | `string`  | `undefined` |
+
+
+## Slots
+
+| Slot          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `"default"`   | Slot for <tds-table-body-row>                    |
+| `"no-result"` | Slot for no result message when using filtering. |
 
 
 ## Dependencies

--- a/core/src/components/table/table-body/readme.md
+++ b/core/src/components/table/table-body/readme.md
@@ -11,15 +11,15 @@
 | ----------------- | ------------------- | ---------------------------------------------------------------------------------- | --------- | ----------- |
 | `bodyData`        | `body-data`         | Prop to pass JSON string which enables automatic rendering of Table rows and cells | `any`     | `undefined` |
 | `enableDummyData` | `enable-dummy-data` | Prop for showcase of rendering JSON in body-data, just for presentation purposes   | `boolean` | `false`     |
-| `noResultMessage` | `no-result-message` | Prop for showcase of rendering JSON in body-data, just for presentation purposes   | `string`  | `undefined` |
+| `noResultMessage` | `no-result-message` | Prop for no result message when using filtering                                    | `string`  | `undefined` |
 
 
 ## Slots
 
-| Slot          | Description                                      |
-| ------------- | ------------------------------------------------ |
-| `"default"`   | Slot for <tds-table-body-row>                    |
-| `"no-result"` | Slot for no result message when using filtering. |
+| Slot          | Description                                                   |
+| ------------- | ------------------------------------------------------------- |
+| `"default"`   | Default slot for the Table Body, used by <tds-table-body-row> |
+| `"no-result"` | Slot for no result message when using filtering.              |
 
 
 ## Dependencies

--- a/core/src/components/table/table-body/table-body.tsx
+++ b/core/src/components/table/table-body/table-body.tsx
@@ -12,6 +12,7 @@ import {
 } from '@stencil/core';
 
 import { InternalTdsTablePropChange } from '../table/table';
+import { hasSlot } from '../../../utils/utils';
 
 const jsonData = [
   {
@@ -63,6 +64,11 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
   'enableExpandableRows',
 ];
 
+
+/**
+ * @slot default - Slot for <tds-table-body-row>
+ * @slot no-result - Slot for no result message when using filtering.
+*/
 @Component({
   tag: 'tds-table-body',
   styleUrl: 'table-body.scss',
@@ -74,6 +80,9 @@ export class TdsTableBody {
 
   /** Prop for showcase of rendering JSON in body-data, just for presentation purposes */
   @Prop() enableDummyData: boolean = false;
+
+  /** Prop for showcase of rendering JSON in body-data, just for presentation purposes */
+  @Prop() noResultMessage: string;
 
   @State() jsonData: any = JSON.stringify(jsonData);
 
@@ -264,7 +273,7 @@ export class TdsTableBody {
   searchFunction(searchTerm) {
     // grab all rows in body
     const dataRowsFiltering = this.host.querySelectorAll('tds-table-body-row');
-
+    
     if (searchTerm.length > 0) {
       if (this.enablePaginationTableBody) {
         this.tempPaginationDisable = true;
@@ -293,7 +302,6 @@ export class TdsTableBody {
 
       this.disableAllSorting = true;
       this.internalTdsSortingChange.emit([this.tableId, this.disableAllSorting]);
-
       const dataRowsHidden = this.host.querySelectorAll('.tds-table__row--hidden');
 
       // If same, an info message will be shown
@@ -302,14 +310,16 @@ export class TdsTableBody {
       if (this.enablePaginationTableBody) {
         this.tempPaginationDisable = false;
       }
-
+      
+      
       // If pagination is NOT enabled, we show all rows.
       if (!this.enablePaginationTableBody) {
         dataRowsFiltering.forEach((item) => {
           item.classList.remove('tds-table__row--hidden');
         });
       }
-
+      
+      this.showNoResultsMessage = false;
       this.disableAllSorting = false;
       this.internalTdsSortingChange.emit([this.tableId, this.disableAllSorting]);
     }
@@ -367,13 +377,12 @@ export class TdsTableBody {
             ))}
           </tds-table-body-row>
         ))}
-        {this.showNoResultsMessage && (
-          <tr>
+          <tr hidden={!this.showNoResultsMessage}>
             <td class="tds-table__info-message" colSpan={this.columnsNumber}>
-              Unfortunately, no data matches your search term &#128533;
+              <slot name="no-result"/>
+              {this.noResultMessage}
             </td>
           </tr>
-        )}
         <slot></slot>
       </Host>
     );

--- a/core/src/components/table/table-body/table-body.tsx
+++ b/core/src/components/table/table-body/table-body.tsx
@@ -66,7 +66,7 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
 
 
 /**
- * @slot default - Slot for <tds-table-body-row>
+ * @slot default - Default slot for the Table Body, used by <tds-table-body-row>
  * @slot no-result - Slot for no result message when using filtering.
 */
 @Component({

--- a/core/src/components/table/table-body/table-body.tsx
+++ b/core/src/components/table/table-body/table-body.tsx
@@ -81,7 +81,7 @@ export class TdsTableBody {
   /** Prop for showcase of rendering JSON in body-data, just for presentation purposes */
   @Prop() enableDummyData: boolean = false;
 
-  /** Prop for showcase of rendering JSON in body-data, just for presentation purposes */
+  /** Prop for no result message when using filtering */
   @Prop() noResultMessage: string;
 
   @State() jsonData: any = JSON.stringify(jsonData);

--- a/core/src/components/table/table-body/table-body.tsx
+++ b/core/src/components/table/table-body/table-body.tsx
@@ -66,7 +66,7 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
 
 
 /**
- * @slot default - Default slot for the Table Body, used by <tds-table-body-row>
+ * @slot <default> - Default slot for the Table Body, used by <tds-table-body-row>
  * @slot no-result - Slot for no result message when using filtering.
 */
 @Component({

--- a/core/src/components/table/table-component-filtering.stories.tsx
+++ b/core/src/components/table/table-component-filtering.stories.tsx
@@ -171,7 +171,7 @@ const FilteringTemplate = ({
                 column4Width ? `custom-width="${column4Width}"` : ''
               }></tds-header-cell>
           </tds-table-header>
-          <tds-table-body ${useDataProp ? `body-data='${JSON.stringify(dummyData)}'` : ''}>
+          <tds-table-body no-result-message="The query did not match any data." ${useDataProp ? `body-data='${JSON.stringify(dummyData)}'` : ''}>
             ${
               !useDataProp
                 ? dummyData

--- a/core/src/components/table/table-header-cell/readme.md
+++ b/core/src/components/table/table-header-cell/readme.md
@@ -20,7 +20,7 @@
 
 | Event           | Description                                                                                                                                                          | Type                                                                                      |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
+| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "desc" \| "asc"; }>` |
 
 
 ----------------------------------------------

--- a/core/src/components/table/table-toolbar/readme.md
+++ b/core/src/components/table/table-toolbar/readme.md
@@ -24,7 +24,7 @@
 
 | Slot    | Description                                         |
 | ------- | --------------------------------------------------- |
-| `"end"` | Slot the end (right side) of the Table Toolbar. |
+| `"end"` | Slot for the end (right side) of the Table Toolbar. |
 
 
 ## Dependencies


### PR DESCRIPTION
**Describe pull-request**  
 -  Fixed logic for showing/hiding no result message
 - Introduces slot for no result message
 - Introduces prop for no result message. 

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-2044

**How to test**  
1. Go to Table -> Filtering
2. Search for "jp"
3. Check that the no result message works.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

