### PR TITLE
feat(message): align slots

### DIFF
--- a/core/src/components/message/message.scss
+++ b/core/src/components/message/message.scss
@@ -1,5 +1,5 @@
 :host {
-  .wrapper {
+  .message-wrapper {
     display: flex;
     padding: 16px;
     background-color: var(--tds-message-background);
@@ -38,20 +38,20 @@
       }
     }
 
-    &.minimal {
+    &.message-minimal {
       border: none;
       display: flex;
       align-items: center;
       padding: 0;
       background-color: transparent;
 
-      .header {
+      .message-header {
         font: var(--tds-detail-02);
         letter-spacing: var(--tds-detail-02-ls);
       }
 
       &.error {
-        .header {
+        .message-header {
           color: var(--tds-negative);
         }
       }
@@ -62,19 +62,19 @@
     padding-right: 16px;
   }
 
-  .content {
+  .message-content {
     display: flex;
     flex-direction: column;
     gap: 4px;
     color: var(--tds-message-color);
     padding: 2px 0;
 
-    .header {
+    .message-header {
       font: var(--tds-headline-07);
       letter-spacing: var(--tds-headline-07-ls);
     }
 
-    .extended-message {
+    .message-extended-message {
       color: var(--tds-message-color);
       font: var(--tds-detail-02);
       letter-spacing: var(--tds-detail-02-ls);

--- a/core/src/components/message/message.scss
+++ b/core/src/components/message/message.scss
@@ -1,5 +1,5 @@
 :host {
-  .message-wrapper {
+  .wrapper {
     display: flex;
     padding: 16px;
     background-color: var(--tds-message-background);
@@ -38,20 +38,20 @@
       }
     }
 
-    &.message-minimal {
+    &.minimal {
       border: none;
       display: flex;
       align-items: center;
       padding: 0;
       background-color: transparent;
 
-      .message-header {
+      .header {
         font: var(--tds-detail-02);
         letter-spacing: var(--tds-detail-02-ls);
       }
 
       &.error {
-        .message-header {
+        .header {
           color: var(--tds-negative);
         }
       }
@@ -62,19 +62,19 @@
     padding-right: 16px;
   }
 
-  .message-content {
+  .content {
     display: flex;
     flex-direction: column;
     gap: 4px;
     color: var(--tds-message-color);
     padding: 2px 0;
 
-    .message-header {
+    .header {
       font: var(--tds-headline-07);
       letter-spacing: var(--tds-headline-07-ls);
     }
 
-    .message-extended-message {
+    .extended-message {
       color: var(--tds-message-color);
       font: var(--tds-detail-02);
       letter-spacing: var(--tds-detail-02-ls);

--- a/core/src/components/message/message.tsx
+++ b/core/src/components/message/message.tsx
@@ -1,5 +1,9 @@
 import { Component, Host, h, Prop } from '@stencil/core';
 
+/**
+ * @slot <default> - Default slot for the extended message section.
+ */
+
 @Component({
   tag: 'tds-message',
   styleUrl: 'message.scss',
@@ -41,15 +45,15 @@ export class TdsMessage {
       <Host>
         <div
           class={`
-        message-wrapper ${this.type}
-        ${this.minimal ? 'message-minimal' : ''}
+        wrapper ${this.type}
+        ${this.minimal ? 'minimal' : ''}
         ${this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''}`}
         >
           {!this.noIcon && <tds-icon name={this.getIconName()} size="20px"></tds-icon>}
-          <div class={`message-content`}>
-            {this.header && <div class="message-header">{this.header}</div>}
+          <div class={`content`}>
+            {this.header && <div class="header">{this.header}</div>}
             {!this.minimal && (
-              <div class="message-extended-message">
+              <div class="extended-message">
                 <slot></slot>
               </div>
             )}

--- a/core/src/components/message/message.tsx
+++ b/core/src/components/message/message.tsx
@@ -41,15 +41,15 @@ export class TdsMessage {
       <Host>
         <div
           class={`
-        wrapper ${this.type}
-        ${this.minimal ? 'minimal' : ''}
+        message-wrapper ${this.type}
+        ${this.minimal ? 'message-minimal' : ''}
         ${this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''}`}
         >
           {!this.noIcon && <tds-icon name={this.getIconName()} size="20px"></tds-icon>}
-          <div class={`content`}>
-            {this.header && <div class="header">{this.header}</div>}
+          <div class={`message-content`}>
+            {this.header && <div class="message-header">{this.header}</div>}
             {!this.minimal && (
-              <div class="extended-message">
+              <div class="message-extended-message">
                 <slot></slot>
               </div>
             )}

--- a/core/src/components/message/message.tsx
+++ b/core/src/components/message/message.tsx
@@ -41,15 +41,15 @@ export class TdsMessage {
       <Host>
         <div
           class={`
-        message-wrapper ${this.type}
-        ${this.minimal ? 'message-minimal' : ''}
+        wrapper ${this.type}
+        ${this.minimal ? 'minimal' : ''}
         ${this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''}`}
         >
           {!this.noIcon && <tds-icon name={this.getIconName()} size="20px"></tds-icon>}
-          <div class={`message-content`}>
-            {this.header && <div class="message-header">{this.header}</div>}
+          <div class={`content`}>
+            {this.header && <div class="header">{this.header}</div>}
             {!this.minimal && (
-              <div class="message-extended-message">
+              <div class="extended-message">
                 <slot></slot>
               </div>
             )}

--- a/core/src/components/message/readme.md
+++ b/core/src/components/message/readme.md
@@ -16,6 +16,13 @@
 | `type`        | `type`         | Type of Message.                                 | `"error" \| "information" \| "success" \| "warning"` | `'information'` |
 
 
+## Slots
+
+| Slot          | Description                                    |
+| ------------- | ---------------------------------------------- |
+| `"<default>"` | Default slot for the extended message section. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/table/table-toolbar/readme.md
+++ b/core/src/components/table/table-toolbar/readme.md
@@ -24,7 +24,7 @@
 
 | Slot    | Description                                         |
 | ------- | --------------------------------------------------- |
-| `"end"` | Slot the end (right side) of the Table Toolbar. |
+| `"end"` | Slot for the end (right side) of the Table Toolbar. |
 
 
 ## Dependencies

--- a/core/src/components/table/table-toolbar/readme.md
+++ b/core/src/components/table/table-toolbar/readme.md
@@ -24,7 +24,7 @@
 
 | Slot    | Description                                         |
 | ------- | --------------------------------------------------- |
-| `"end"` | Slot for the end (right side) of the Table Toolbar. |
+| `"end"` | Slot the end (right side) of the Table Toolbar. |
 
 
 ## Dependencies


### PR DESCRIPTION
**Describe pull-request**  
Documented default slot for the extended message section and aligned SCSS classes. 

**Solving issue**  
Fixes: https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-1953

**How to test**  
1. Go to Storybook.
2. Check in Components -> Message.
3. Test the controls and check the styles.
4. Go to Notes tab and read slot documentation.