### PR TITLE
docs(storybook): stories sorting and hierarchy

### DIFF
--- a/core/.storybook/preview.js
+++ b/core/.storybook/preview.js
@@ -132,6 +132,7 @@ export const parameters = {
     enableShortcuts: false,
     storySort: {
       method: 'alphabetical',
+      includeNames: true,
       order: [
         'Intro',
         [

--- a/core/src/components/accordion/accordion.stories.tsx
+++ b/core/src/components/accordion/accordion.stories.tsx
@@ -4,7 +4,7 @@ import readmeItem from './accordion-item/readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Accordion`,
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
@@ -104,4 +104,4 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant }) => {
   </script>`);
 };
 
-export const Accordion = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/badge/badge.stories.tsx
+++ b/core/src/components/badge/badge.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Badge`,
   parameters: {
     layout: 'centered',
     notes: readme,
@@ -75,8 +75,9 @@ export default {
 const Template = ({ value, size, hidden, demoCode }) =>
   formatHtmlPreview(
     `
-    ${demoCode
-      ? `<style>
+    ${
+      demoCode
+        ? `<style>
     /* Note: Demo classes used here are just for demo purposes in Storybook */
     .badge-demo-box {
       margin:5px;
@@ -98,7 +99,7 @@ const Template = ({ value, size, hidden, demoCode }) =>
       top: -2px;
     }
     </style>`
-      : ''
+        : ''
     }
 
     <div class="${demoCode ? 'badge-demo-box' : ''}">
@@ -110,4 +111,4 @@ const Template = ({ value, size, hidden, demoCode }) =>
     </div>`,
   );
 
-export const Badge = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/banner/banner.stories.tsx
+++ b/core/src/components/banner/banner.stories.tsx
@@ -6,7 +6,7 @@ import { ComponentsFolder } from '../../utils/constants';
 // FIXME: CMS: Change state to type in Code tab of component
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Banner`,
   parameters: {
     notes: readme,
     layout: 'fullscreen',
@@ -109,4 +109,4 @@ const Template = ({ type, icon, header, subheader, persistent, bottom }) =>
         })
       </script>
     `);
-export const Banner = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/block/block.stories.tsx
+++ b/core/src/components/block/block.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Block`,
   parameters: {
     layout: 'padded',
     notes: readme,
@@ -55,4 +55,4 @@ const Template = ({ modeVariant }) =>
     `,
   );
 
-export const Block = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/core/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -4,7 +4,7 @@ import { formatHtmlPreview } from '../../utils/utils';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Breadcrumbs`,
   parameters: {
     notes: { Breadcrumbs: readme, Breadcrumb: itemReadme },
     design: [
@@ -39,4 +39,4 @@ const Template = () =>
       `,
   );
 
-export const Breadcrumbs = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/button/button.stories.tsx
+++ b/core/src/components/button/button.stories.tsx
@@ -4,7 +4,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Button`,
   parameters: {
     notes: readme,
     layout: 'padded',
@@ -188,4 +188,4 @@ const WebComponentTemplate = ({
 };
 
 /** Button as a web component */
-export const Button = WebComponentTemplate.bind({});
+export const Default = WebComponentTemplate.bind({});

--- a/core/src/components/card/card.stories.tsx
+++ b/core/src/components/card/card.stories.tsx
@@ -6,7 +6,7 @@ import { formatHtmlPreview } from '../../utils/utils';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Card`,
   parameters: {
     notes: readme,
     layout: 'centered',
@@ -185,4 +185,4 @@ const Template = ({
   `,
   );
 
-export const Card = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/checkbox/checkbox.stories.tsx
+++ b/core/src/components/checkbox/checkbox.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Checkbox`,
   parameters: {
     notes: readme,
     layout: 'centered',
@@ -81,4 +81,4 @@ const Template = ({ label, checked, disabled }) =>
     </script>
   `);
 
-export const Checkbox = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/chip/chip.stories.tsx
+++ b/core/src/components/chip/chip.stories.tsx
@@ -1,8 +1,9 @@
 import { formatHtmlPreview } from '../../utils/utils';
 import readme from './readme.md';
+import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: 'Components',
+  title: `${ComponentsFolder}/Chip`,
   parameters: {
     notes: readme,
     layout: 'centered',
@@ -264,4 +265,4 @@ const Template = ({ inputType, size, label, icon, iconPosition }) => {
   `);
 };
 
-export const Chip = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/datetime/datetime.stories.tsx
+++ b/core/src/components/datetime/datetime.stories.tsx
@@ -3,7 +3,7 @@ import { formatHtmlPreview } from '../../utils/utils';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Datetime`,
   parameters: {
     layout: 'centered',
     notes: readme,
@@ -209,4 +209,4 @@ const datetimeTemplate = ({
   );
 };
 
-export const Datetime = datetimeTemplate.bind({});
+export const Default = datetimeTemplate.bind({});

--- a/core/src/components/divider/divider.stories.tsx
+++ b/core/src/components/divider/divider.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Divider`,
   parameters: {
     layout: 'centered',
     notes: { Divider: readme },
@@ -63,4 +63,4 @@ const Template = ({ orientation, width, height }) =>
   </div>
 `);
 
-export const Divider = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/dropdown/dropdown.stories.tsx
+++ b/core/src/components/dropdown/dropdown.stories.tsx
@@ -4,7 +4,7 @@ import { formatHtmlPreview } from '../../utils/utils';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Dropdown`,
   parameters: {
     layout: 'centered',
     notes: { 'Dropdown': readme, 'Dropdown option': readmeDropdownOption },
@@ -301,4 +301,4 @@ const Template = ({
         
   `);
 
-export const Dropdown = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/footer/footer.stories.tsx
+++ b/core/src/components/footer/footer.stories.tsx
@@ -5,7 +5,7 @@ import readmeItem from './footer-item/readme.md';
 import readmeLinkGroup from './footer-group/readme.md';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Footer`,
   parameters: {
     notes: { 'Footer': readme, 'Footer link group': readmeLinkGroup, 'Footer item': readmeItem },
     layout: 'fullscreen',
@@ -151,4 +151,4 @@ const Template = ({ topPart, modeVariant }) =>
   `,
   );
 
-export const Footer = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/header/header.stories.tsx
+++ b/core/src/components/header/header.stories.tsx
@@ -11,7 +11,7 @@ import readmeLauncher from './header-launcher/readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Header`,
   parameters: {
     notes: {
       'Header': readme,
@@ -83,4 +83,4 @@ const Template = () =>
   `,
   );
 
-export const Header = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/link/link.stories.tsx
+++ b/core/src/components/link/link.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Link`,
   parameters: {
     notes: readme,
     layout: 'centered',
@@ -59,4 +59,4 @@ const Template = ({ underline, disabled }) =>
     </tds-link>
   `,
   );
-export const Link = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/message/message.stories.tsx
+++ b/core/src/components/message/message.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Message`,
   parameters: {
     layout: 'centered',
     notes: readme,
@@ -117,4 +117,4 @@ const Template = ({ modeVariant, messageType, header, extendedMessage, minimal, 
     `,
   );
 
-export const Message = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/modal/modal.stories.tsx
+++ b/core/src/components/modal/modal.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Modal`,
   parameters: {
     layout: 'fullscreen',
     notes: readme,
@@ -115,4 +115,4 @@ const ModalTemplate = ({ actions, size, headerText, bodyContent, showModal }) =>
   `,
   );
 
-export const Modal = ModalTemplate.bind({});
+export const Default = ModalTemplate.bind({});

--- a/core/src/components/popover-canvas/popover-canvas.stories.tsx
+++ b/core/src/components/popover-canvas/popover-canvas.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Popover Canvas`,
   parameters: {
     layout: 'centered',
     notes: readme,
@@ -94,4 +94,4 @@ const ComponentPopoverCanvas = ({ canvasPosition }) => {
     `,
   );
 };
-export const PopoverCanvas = ComponentPopoverCanvas.bind({});
+export const Default = ComponentPopoverCanvas.bind({});

--- a/core/src/components/popover-menu/popover-menu.stories.tsx
+++ b/core/src/components/popover-menu/popover-menu.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Popover Menu`,
   parameters: {
     layout: 'centered',
     notes: readme,
@@ -143,4 +143,4 @@ const Template = ({ menuPosition, icons }) => {
   );
 };
 
-export const PopoverMenu = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/radio-button/radio-button.stories.tsx
+++ b/core/src/components/radio-button/radio-button.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Radio Button`,
   parameters: {
     notes: readme,
     layout: 'centered',
@@ -92,4 +92,4 @@ const Template = ({ label, disabled }) =>
   </script>
   `);
 
-export const RadioButton = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/side-menu/side-menu.stories.tsx
+++ b/core/src/components/side-menu/side-menu.stories.tsx
@@ -13,7 +13,7 @@ import readmeSideMenuDropdownListItem from './side-menu-dropdown-list-item/readm
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Side Menu`,
   parameters: {
     notes: {
       'Side Menu': readme,
@@ -225,4 +225,4 @@ const Template = ({ persistent, collapsible }) =>
   `,
   );
 
-export const SideMenu = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/slider/slider.stories.tsx
+++ b/core/src/components/slider/slider.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Slider`,
   argTypes: {
     min: {
       name: 'Min. value',
@@ -263,4 +263,4 @@ const Template = ({
     </script>
   `);
 
-export const Slider = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/spinner/spinner.stories.tsx
+++ b/core/src/components/spinner/spinner.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Spinner`,
   parameters: {
     layout: 'centered', // Center the component horizontally and vertically in the Canvas
     notes: readme,
@@ -64,4 +64,4 @@ const Template = ({ size, variant }) => {
   );
 };
 
-export const Spinner = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/stepper/stepper.stories.tsx
+++ b/core/src/components/stepper/stepper.stories.tsx
@@ -4,7 +4,7 @@ import readmeStep from './step/readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Stepper`,
   parameters: {
     layout: 'centered',
     design: [
@@ -100,4 +100,4 @@ const Template = ({ size, orientation, labelPosition, hideLabels }) =>
   </tds-stepper>
         `,
   );
-export const Stepper = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/table/table-component-basic.stories.tsx
+++ b/core/src/components/table/table-component-basic.stories.tsx
@@ -212,4 +212,4 @@ const BasicTemplate = ({
       </tds-table-body>
   </tds-table>`);
 
-export const Default = BasicTemplate.bind({});
+export const Basic = BasicTemplate.bind({});

--- a/core/src/components/tabs/folder-tabs/folder-tabs.stories.tsx
+++ b/core/src/components/tabs/folder-tabs/folder-tabs.stories.tsx
@@ -4,7 +4,7 @@ import readmeItem from './folder-tab/readme.md';
 import { ComponentsFolder } from '../../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Tabs`,
   parameters: {
     notes: {
       'Folder Tabs': readme,

--- a/core/src/components/tabs/inline-tabs/inline-tabs.stories.tsx
+++ b/core/src/components/tabs/inline-tabs/inline-tabs.stories.tsx
@@ -4,7 +4,7 @@ import readmeTab from './inline-tab/readme.md';
 import { ComponentsFolder } from '../../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Tabs`,
   parameters: {
     notes: {
       'Inline tabs': readme,

--- a/core/src/components/tabs/navigation-tabs/navigation-tabs.stories.tsx
+++ b/core/src/components/tabs/navigation-tabs/navigation-tabs.stories.tsx
@@ -4,7 +4,7 @@ import readmeTab from './navigation-tab/readme.md';
 import { ComponentsFolder } from '../../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Tabs`,
   parameters: {
     notes: {
       'Navigation Tabs': readme,

--- a/core/src/components/text-field/text-field.stories.tsx
+++ b/core/src/components/text-field/text-field.stories.tsx
@@ -3,7 +3,7 @@ import { formatHtmlPreview } from '../../utils/utils';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Text Field`,
   parameters: {
     notes: readme,
     layout: 'centered',
@@ -273,4 +273,4 @@ const Template = ({
   );
 };
 
-export const TextField = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/textarea/textarea.stories.tsx
+++ b/core/src/components/textarea/textarea.stories.tsx
@@ -3,7 +3,7 @@ import { formatHtmlPreview } from '../../utils/utils';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Textarea`,
   parameters: {
     notes: readme,
     layout: 'centered',
@@ -203,4 +203,4 @@ const Template = ({
   `);
 };
 
-export const Textarea = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/toast/toast.stories.tsx
+++ b/core/src/components/toast/toast.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Toast`,
   parameters: {
     layout: 'centered',
     notes: readme,
@@ -81,4 +81,4 @@ const Template = ({ type, header, subheader, bottom }) =>
     </script>
   `,
   );
-export const Toast = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/toggle/toggle.stories.tsx
+++ b/core/src/components/toggle/toggle.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Toggle`,
   parameters: {
     notes: readme,
     layout: 'centered',
@@ -95,4 +95,4 @@ const Template = ({ size, headline, label, checked, disabled }) =>
       })
     </script>
   `);
-export const Toggle = Template.bind({});
+export const Default = Template.bind({});

--- a/core/src/components/tooltip/tooltip.stories.tsx
+++ b/core/src/components/tooltip/tooltip.stories.tsx
@@ -3,7 +3,7 @@ import readme from './readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
 export default {
-  title: ComponentsFolder,
+  title: `${ComponentsFolder}/Tooltip`,
   parameters: {
     layout: 'centered',
     notes: readme,
@@ -133,4 +133,4 @@ const ComponentTooltip = ({ tooltipPosition, mouseOverTooltip, text, slot }) =>
   `,
   );
 
-export const Tooltip = ComponentTooltip.bind({});
+export const Default = ComponentTooltip.bind({});


### PR DESCRIPTION
**Describe pull-request**  
Sorting stories 

**Solving issue**  
Fixes:[ DTS-1697](https://tegel.atlassian.net/browse/DTS-1697)

**How to test** 
1. Open the Netlify preview link
2. Check if component stories are alphabetically ordered
3. Each component story consists of a Component name and then "Default" as a single story.
4. Tabs and Table are the only ones that do not have "Default" as they come with their variations or feature-based stories.

**Additional context**  
The Storybook seems to have an issue with ordering stories with mixed hierarchy levels. Issue triggers once you change the last element in the group to lose its hierarchy. In order to sort stories nicely, the best practice is to keep them same hierarchy level too. I will demo the issue tomorrow on dev-check-in.
