### PR TITLE
fix(dropdown): move open dir calc to render

### DIFF
--- a/core/src/components/dropdown/dropdown.tsx
+++ b/core/src/components/dropdown/dropdown.tsx
@@ -227,9 +227,6 @@ export class TdsDropdown {
     if (this.defaultValue) {
       this.setDefaultOption();
     }
-    if (this.openDirection === 'auto') {
-      this.getOpenDirection();
-    }
   }
 
   setDefaultOption = () => {
@@ -256,14 +253,17 @@ export class TdsDropdown {
   };
 
   getOpenDirection = () => {
-    const dropdownMenuHeight = this.dropdownList.offsetHeight;
-    const distanceToBottom = this.host.getBoundingClientRect().top;
-    const viewportHeight = window.innerHeight;
-    if (distanceToBottom + dropdownMenuHeight + 57 > viewportHeight) {
-      this.openDirection = 'up';
-    } else {
-      this.openDirection = 'down';
+    if (this.openDirection === 'auto' || !this.openDirection) {
+      const dropdownMenuHeight = this.dropdownList?.offsetHeight ?? 0;
+      const distanceToBottom = this.host.getBoundingClientRect?.().top ?? 0;
+      const viewportHeight = window.innerHeight;
+      if (distanceToBottom + dropdownMenuHeight + 57 > viewportHeight) {
+        return 'up';
+      }
+      return 'down';
     }
+
+    return this.openDirection;
   };
 
   getValue = () => {
@@ -450,7 +450,7 @@ export class TdsDropdown {
           class={`dropdown-list
             ${this.size}
             ${this.open ? 'open' : 'closed'}
-            ${this.openDirection}
+            ${this.getOpenDirection()}
             ${this.label && this.labelPosition === 'outside' ? 'label-outside' : ''}`}
         >
           <slot></slot>

--- a/core/src/components/table/table-header-cell/readme.md
+++ b/core/src/components/table/table-header-cell/readme.md
@@ -20,7 +20,7 @@
 
 | Event           | Description                                                                                                                                                          | Type                                                                                      |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
+| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "desc" \| "asc"; }>` |
 
 
 ----------------------------------------------


### PR DESCRIPTION
**Describe pull-request**  
Move opening direction calculation to render, so it is updated after scroll.

**Solving issue**  
Fixes: #DTS-1979

**How to test**  
1. dropdown story
2. resize window so vertically and watch open direction change.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
