### PR TITLE
fix(stepper): adjust Stepper layout to not force space between Steps

### DIFF
--- a/core/src/components/stepper/stepper.scss
+++ b/core/src/components/stepper/stepper.scss
@@ -17,10 +17,14 @@
       flex-direction: column;
       justify-content: unset;
       gap: 52px;
+
+      &.sm {
+        gap: 36px;
+      }
     }
 
-    &.vertical.sm {
-      gap: 36px;
+    &.horizontal.text-position-aside {
+      justify-content: unset;
     }
   }
 }


### PR DESCRIPTION
**Describe pull-request**  
Adjusted justify-content rule to not force space between Steps when in horizontal orientation and labels are aside.

**Solving issue**  
Fixes: https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-2051

**How to test**  
1. Check out branch
2. Check in Components -> Stepper
3. Make sure Stepper looks according to design when Orientation = Horizontal and Text position = Aside
4. Change layout: 'centered', to layout: 'padded', on line 9 in stepper.stories.tsx and make sure everything still looks as it should
