### PR TITLE
fix(table:sorting): fixed width on icon to prevent content jump

### DIFF
--- a/core/src/components/table/table-header-cell/table-header-cell.scss
+++ b/core/src/components/table/table-header-cell/table-header-cell.scss
@@ -59,6 +59,7 @@
       /* not to shrink on lot of text */
       flex: 0 0 16px;
       height: 16px;
+      width: 16px;
       opacity: 0;
       transform-origin: center;
       transition: opacity 200ms ease-in, transform 200ms ease;


### PR DESCRIPTION
**Describe pull-request**  
Content jumping on sorting in react-demo-apge

**Solving issue**  
Fixes: [DTS-2005](https://tegel.atlassian.net/browse/DTS-2005)

**How to test**  
1. Go to react demo example
2. Open table component
3. Try to sort it - content should move left/right a bit
4. Now inspect the element and on `tds-table__header-button-icon` add width: 16px.
5. Jumping left and right should stop now.
6. I have added that rule in CSS in this PR...

**Note**
The issue seems not to be visible in Storybook, therefore testing in React.

[DTS-2005]: https://tegel.atlassian.net/browse/DTS-2005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ