### PR TITLE
feat: adding .npmignore 

### DIFF
--- a/core/.npmignore
+++ b/core/.npmignore
@@ -1,0 +1,6 @@
+# Files to be ignored in npm publish
+
+# Ignoring story files here instead of tsconfig to avoid issues with files being shipped
+# + issues with typscript trowing error for imported readme files when they are exluded in tsconfig
+**/*.stories.tsx
+**/stories

--- a/core/src/components/card/card.stories.tsx
+++ b/core/src/components/card/card.stories.tsx
@@ -1,6 +1,4 @@
-// @ts-ignore
 import readme from './readme.md';
-// @ts-ignore
 import CardPlaceholder from '../../stories/assets/image/card-placeholder.png';
 import { formatHtmlPreview } from '../../utils/utils';
 import { ComponentsFolder } from '../../utils/constants';

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -11,6 +11,5 @@
     "jsx": "react",
     "jsxFactory": "h"
   },
-  "include": ["src"],
-  "exclude": ["**/*.stories.tsx", "**/*.stories.ts", "**/stories"]
+  "include": ["src"]
 }


### PR DESCRIPTION
**Describe pull-request**  
Adding .npmignore file to handle files we do not want to publish when releasing code

**Solving issue**  
Component readme files are imported in every story for the need of showing it in the <i>Notes</i> tab. We were getting typescript issues for them, even though they are defined in the globals.d.ts. 
The reason for that is that they were excluded in tsconfig. 
Another way is to exclude them in the .npmignore file and then the problem is gone.

**How to test**  
1. Branch out main and see if you get warnings for in import lines of readme's in any component. (There should be one)
2. Now branch out this branch and see if warnings are gone
