### PR TITLE
fix(popover): reference el prop accept null

### DIFF
--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -40,7 +40,7 @@ export class TdsModal {
   @Prop() selector: string;
 
   /** Element that will show the Modal (takes priority over selector) */
-  @Prop() referenceEl: HTMLElement;
+  @Prop() referenceEl?: HTMLElement | null;
 
   /** Controls whether the Modal is shown or not. If this is set hiding and showing
    * will be decided by this prop and will need to be controlled from the outside. */

--- a/core/src/components/popover-canvas/popover-canvas.tsx
+++ b/core/src/components/popover-canvas/popover-canvas.tsx
@@ -14,7 +14,7 @@ export class TdsPopoverCanvas {
   @Prop() selector: string = '';
 
   /** Element that will trigger the Popover (takes priority over selector) */
-  @Prop() referenceEl: HTMLElement;
+  @Prop() referenceEl?: HTMLElement | null;
 
   /** Controls whether the Popover is shown or not. If this is set hiding and showing
    * will be decided by this prop and will need to be controlled from the outside.

--- a/core/src/components/popover-menu/popover-menu.tsx
+++ b/core/src/components/popover-menu/popover-menu.tsx
@@ -14,7 +14,7 @@ export class TdsPopoverMenu {
   @Prop() selector: string = '';
 
   /** Element that will trigger the pop-over (takes priority over selector) */
-  @Prop() referenceEl: HTMLElement;
+  @Prop() referenceEl?: HTMLElement | null;
 
   /** Decides if the Popover Menu should be visible from the start */
   @Prop() show: boolean = false;

--- a/core/src/components/table/table-header-cell/readme.md
+++ b/core/src/components/table/table-header-cell/readme.md
@@ -20,7 +20,7 @@
 
 | Event           | Description                                                                                                                                                          | Type                                                                                      |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "desc" \| "asc"; }>` |
+| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
 
 
 ----------------------------------------------

--- a/core/src/components/tooltip/tooltip.tsx
+++ b/core/src/components/tooltip/tooltip.tsx
@@ -15,7 +15,7 @@ export class TdsTooltip {
   @Prop() selector: string = '';
 
   /** Element that will trigger the Tooltip (takes priority over selector) */
-  @Prop() referenceEl: HTMLElement;
+  @Prop() referenceEl?: HTMLElement | null;
 
   /** Allow mouse over Tooltip. Useful when Tooltip contains clickable elements like link or button. */
   @Prop() mouseOverTooltip: boolean = false;


### PR DESCRIPTION
**Describe pull-request**  
Makes referenceEl accept null since, for example, in React a ref is null before it is an element.

**Solving issue**  
Fixes: #DTS-2040

**How to test**  
1. Check out repo on your local machine
1. Build the project.
1. Check the types in src/core/components.d.ts that reference el can be null.


**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
