### PR TITLE
fix(chip): focus background color

### DIFF
--- a/core/src/components/chip/chip-vars.scss
+++ b/core/src/components/chip/chip-vars.scss
@@ -6,6 +6,7 @@
   --tds-chips-background-active: var(--tds-blue-500);
   --tds-chips-background-active-hover: var(--tds-blue-600);
   --tds-chips-background-hover: var(--tds-grey-400);
+  --tds-chips-background-focus: var(--tds-grey-50);
   --tds-chips-icon-fill: var(--tds-grey-958);
   --tds-chips-icon-fill-active: var(--tds-white);
 }
@@ -17,6 +18,7 @@
   --tds-chips-background-hover: var(--tds-grey-600);
   --tds-chips-background-active: var(--tds-blue-500);
   --tds-chips-background-active-hover: var(--tds-blue-300);
+  --tds-chips-background-focus: var(--tds-grey-900);
   --tds-chips-icon-fill: var(--tds-white);
   --tds-chips-icon-fill-active: var(--tds-white);
 }

--- a/core/src/components/chip/chip.scss
+++ b/core/src/components/chip/chip.scss
@@ -64,6 +64,8 @@
 
     input:focus-visible + label {
       @include tds-focus-state;
+
+      background-color: var(--tds-chips-background-focus);
     }
 
     input:checked + label {


### PR DESCRIPTION
**Describe pull-request**  
Adding background variable and change when component is in focus

**Solving issue**  
Fixes: [DTS-2072](https://tegel.atlassian.net/browse/DTS-2072)

**How to test**  
1. Check Netlify PR preview link
2. Open Chip component
3. Check that on focus background color is grey-50 (in light mode) and grey-900 in dark mode.


[DTS-2072]: https://tegel.atlassian.net/browse/DTS-2072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ