### PR TITLE
fix(slider): disabled state update in runtime

### DIFF
--- a/core/src/components/slider/slider-vars.scss
+++ b/core/src/components/slider/slider-vars.scss
@@ -4,7 +4,7 @@
   --tds-slider-thumb-color: var(--tds-blue-800);
   --tds-slider-divider-color: var(--tds-grey-400);
   --tds-slider-track-color: var(--tds-grey-400);
-  --tds-slider-track-fill-color: var(--tds-blue-800);
+  --tds-slider-track-fill-color: red;
   --tds-slider-input-inputfield-color: var(--tds-grey-700);
   --tds-slider-inputfield-color: var(--tds-grey-400);
   --tds-slider-controls-color: var(--tds-grey-958);

--- a/core/src/components/slider/slider-vars.scss
+++ b/core/src/components/slider/slider-vars.scss
@@ -4,7 +4,7 @@
   --tds-slider-thumb-color: var(--tds-blue-800);
   --tds-slider-divider-color: var(--tds-grey-400);
   --tds-slider-track-color: var(--tds-grey-400);
-  --tds-slider-track-fill-color: red;
+  --tds-slider-track-fill-color: var(--tds-blue-800);
   --tds-slider-input-inputfield-color: var(--tds-grey-700);
   --tds-slider-inputfield-color: var(--tds-grey-400);
   --tds-slider-controls-color: var(--tds-grey-958);

--- a/core/src/components/slider/slider.tsx
+++ b/core/src/components/slider/slider.tsx
@@ -469,9 +469,11 @@ export class TdsSlider {
         ></input>
 
         <div
-          class={`tds-slider ${this.disabled ? 'disabled' : ''} ${
-            this.useSmall ? 'tds-slider-small' : ''
-          }`}
+          class={{
+            'tds-slider': true,
+            'disabled': this.disabled,
+            'tds-slider-small': this.useSmall,
+          }}
           ref={(el) => {
             this.wrapperElement = el as HTMLElement;
           }}


### PR DESCRIPTION
**Describe pull-request**  
Refactoring the way class name for disabled state is set. The use of template literals stops the component updating in runtime.

**Solving issue**  
Fixes: https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-2064

**How to test**  
1. Check out branch
2. CD into core
3. Run npm pack
4. Copy generated file into tegel-react-demo local repo on root level
5. In package.json, update path to @scania/tegel to the generated file name (example: "@scania/tegel": "file:scania-tegel-0.0.9.tgz",)
6. Run npm run build (this might cause some errors since we've made changes in Tegel that haven't been released yet. Remove what you don't need for testing the Slider.
7. Run npm run start.
8. Check that the Slider disabled state can be update in runtime.

**Screenshots**  
![image](https://github.com/scania-digital-design-system/tegel/assets/48509966/0c40b80f-3968-434f-8e91-c2b5ab695334)

**Additional context**  
Using template literals, like the implementation seen in the screenshot above, restricts the components from updating class names in runtime. This might be useful to know moving forward.
