### PR TITLE
docs: document unnamed slots

### DIFF
--- a/core/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/core/src/components/accordion/accordion-item/accordion-item.tsx
@@ -1,6 +1,7 @@
 import { Component, Event, EventEmitter, h, Host, Method, Prop } from '@stencil/core';
 
 /**
+ * @slot <default> - <b>Unnamed slot.</b> For content of an expanded accordion.
  * @slot header - Slot for the Accordion Item header.
  */
 

--- a/core/src/components/accordion/accordion-item/readme.md
+++ b/core/src/components/accordion/accordion-item/readme.md
@@ -38,9 +38,10 @@ Type: `Promise<void>`
 
 ## Slots
 
-| Slot       | Description                         |
-| ---------- | ----------------------------------- |
-| `"header"` | Slot for the Accordion Item header. |
+| Slot          | Description                                                |
+| ------------- | ---------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For content of an expanded accordion. |
+| `"header"`    | Slot for the Accordion Item header.                        |
 
 
 ## Dependencies

--- a/core/src/components/accordion/accordion.tsx
+++ b/core/src/components/accordion/accordion.tsx
@@ -1,5 +1,8 @@
 import { Component, h, Host, Prop } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For accordion items.
+ */
 @Component({
   tag: 'tds-accordion',
   styleUrl: 'accordion.scss',

--- a/core/src/components/accordion/readme.md
+++ b/core/src/components/accordion/readme.md
@@ -12,6 +12,13 @@
 | `modeVariant` | `mode-variant` | Set the variant of the Accordion. | `"primary" \| "secondary"` | `null`  |
 
 
+## Slots
+
+| Slot          | Description                               |
+| ------------- | ----------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For accordion items. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/block/block.tsx
+++ b/core/src/components/block/block.tsx
@@ -1,5 +1,8 @@
 import { Component, h, Prop, Element } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the content.
+ */
 @Component({
   tag: 'tds-block',
   styleUrl: 'block.scss',

--- a/core/src/components/block/readme.md
+++ b/core/src/components/block/readme.md
@@ -12,6 +12,13 @@
 | `modeVariant` | `mode-variant` | Mode variant of the component, based on current mode. | `"primary" \| "secondary"` | `null`  |
 
 
+## Slots
+
+| Slot          | Description                           |
+| ------------- | ------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For the content. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/breadcrumbs/breadcrumb/breadcrumb.tsx
+++ b/core/src/components/breadcrumbs/breadcrumb/breadcrumb.tsx
@@ -1,5 +1,8 @@
 import { Component, h, Prop } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For a native <code>&lt;a></code> element.
+ */
 @Component({
   tag: 'tds-breadcrumb',
   styleUrl: 'breadcrumb.scss',

--- a/core/src/components/breadcrumbs/breadcrumb/readme.md
+++ b/core/src/components/breadcrumbs/breadcrumb/readme.md
@@ -12,6 +12,13 @@
 | `current` | `current` | Boolean for the current link | `boolean` | `false` |
 
 
+## Slots
+
+| Slot          | Description                                                    |
+| ------------- | -------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For a native <code>&lt;a></code> element. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,5 +1,8 @@
 import { Component, h, Element } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the breadcrumb elements.
+ */
 @Component({
   tag: 'tds-breadcrumbs',
   styleUrl: 'breadcrumbs.scss',

--- a/core/src/components/breadcrumbs/readme.md
+++ b/core/src/components/breadcrumbs/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                                       |
+| ------------- | ------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For the breadcrumb elements. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -2,6 +2,9 @@ import { Component, Host, h, Prop, State, Element, Event } from '@stencil/core';
 import { EventEmitter, Method } from '@stencil/core/internal';
 import { TdsCheckboxCustomEvent } from '../../../components';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the option label text.
+ */
 @Component({
   tag: 'tds-dropdown-option',
   styleUrl: 'dropdown-option.scss',

--- a/core/src/components/dropdown/dropdown-option/readme.md
+++ b/core/src/components/dropdown/dropdown-option/readme.md
@@ -35,6 +35,13 @@ Type: `Promise<void>`
 
 
 
+## Slots
+
+| Slot          | Description                                     |
+| ------------- | ----------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For the option label text. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/dropdown/dropdown.tsx
+++ b/core/src/components/dropdown/dropdown.tsx
@@ -7,6 +7,9 @@ import {
   findPreviousFocusableItem,
 } from '../../utils/utils';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For dropdown option elements.
+ */
 @Component({
   tag: 'tds-dropdown',
   styleUrl: 'dropdown.scss',

--- a/core/src/components/dropdown/readme.md
+++ b/core/src/components/dropdown/readme.md
@@ -78,6 +78,13 @@ Type: `Promise<{ value: string; label: string; }[]>`
 
 
 
+## Slots
+
+| Slot          | Description                                        |
+| ------------- | -------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For dropdown option elements. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/footer/footer-group/footer-group.tsx
+++ b/core/src/components/footer/footer-group/footer-group.tsx
@@ -1,6 +1,9 @@
 import { Component, Host, h, Prop, Element } from '@stencil/core';
 import { State } from '@stencil/core/internal';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For footer items.
+ */
 @Component({
   tag: 'tds-footer-group',
   styleUrl: 'footer-group.scss',

--- a/core/src/components/footer/footer-group/readme.md
+++ b/core/src/components/footer/footer-group/readme.md
@@ -12,6 +12,13 @@
 | `titleText` | `title-text` | Title text for the link group, only valid on top part of Footer. | `string` | `undefined` |
 
 
+## Slots
+
+| Slot          | Description                            |
+| ------------- | -------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For footer items. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/footer/footer-item/footer-item.tsx
+++ b/core/src/components/footer/footer-item/footer-item.tsx
@@ -1,5 +1,8 @@
 import { Component, Element, h } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For slotting a link, button, or similar.
+ */
 @Component({
   tag: 'tds-footer-item',
   styleUrl: 'footer-item.scss',

--- a/core/src/components/footer/footer-item/readme.md
+++ b/core/src/components/footer/footer-item/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                                                   |
+| ------------- | ------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For slotting a link, button, or similar. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/header/core-header-item/core-header-item.tsx
+++ b/core/src/components/header/core-header-item/core-header-item.tsx
@@ -1,5 +1,8 @@
 import { Component, h, Host } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For content.
+ */
 @Component({
   tag: 'tds-core-header-item',
   styleUrl: 'core-header-item.scss',

--- a/core/src/components/header/core-header-item/readme.md
+++ b/core/src/components/header/core-header-item/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                       |
+| ------------- | --------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For content. |
+
+
 ## Dependencies
 
 ### Used by

--- a/core/src/components/header/header-brand-symbol/header-brand-symbol.tsx
+++ b/core/src/components/header/header-brand-symbol/header-brand-symbol.tsx
@@ -1,5 +1,8 @@
 import { Component, Element, h, Host } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For a link.
+ */
 @Component({
   tag: 'tds-header-brand-symbol',
   styleUrl: 'header-brand-symbol.scss',

--- a/core/src/components/header/header-brand-symbol/readme.md
+++ b/core/src/components/header/header-brand-symbol/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                      |
+| ------------- | -------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For a link. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/header/header-dropdown-list-item/header-dropdown-list-item.tsx
+++ b/core/src/components/header/header-dropdown-list-item/header-dropdown-list-item.tsx
@@ -1,5 +1,8 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For a link or button element.
+ */
 @Component({
   tag: 'tds-header-dropdown-list-item',
   styleUrl: 'header-dropdown-list-item.scss',

--- a/core/src/components/header/header-dropdown-list-item/readme.md
+++ b/core/src/components/header/header-dropdown-list-item/readme.md
@@ -13,6 +13,13 @@
 | `type`     | `type`     | The type of the list.               | `"lg" \| "md"` | `'md'`  |
 
 
+## Slots
+
+| Slot          | Description                                        |
+| ------------- | -------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For a link or button element. |
+
+
 ## Dependencies
 
 ### Used by

--- a/core/src/components/header/header-dropdown-list/header-dropdown-list.tsx
+++ b/core/src/components/header/header-dropdown-list/header-dropdown-list.tsx
@@ -1,6 +1,9 @@
 import { Component, Element, Host, h, Prop, State } from '@stencil/core';
 import { getPreviousNestedChildOfSiblingsMatching, isHeadingElement } from '../../../utils/utils';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For a dropdown list item.
+ */
 @Component({
   tag: 'tds-header-dropdown-list',
   styleUrl: 'header-dropdown-list.scss',

--- a/core/src/components/header/header-dropdown-list/readme.md
+++ b/core/src/components/header/header-dropdown-list/readme.md
@@ -12,6 +12,13 @@
 | `type`   | `type`    |             | `"lg" \| "md"` | `'md'`  |
 
 
+## Slots
+
+| Slot          | Description                                    |
+| ------------- | ---------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For a dropdown list item. |
+
+
 ## Dependencies
 
 ### Used by

--- a/core/src/components/header/header-dropdown/header-dropdown.tsx
+++ b/core/src/components/header/header-dropdown/header-dropdown.tsx
@@ -2,6 +2,7 @@ import { Component, Element, h, Host, Listen, Prop, State } from '@stencil/core'
 import { generateUniqueId } from '../../../utils/utils';
 
 /**
+ * @slot <default> - <b>Unnamed slot.</b> For injecting a dropdown list.
  * @slot icon - Slot for an Icon in the dropdown button.
  * @slot label - Slot for a label text in the dropdown button.
  */

--- a/core/src/components/header/header-dropdown/readme.md
+++ b/core/src/components/header/header-dropdown/readme.md
@@ -16,10 +16,11 @@
 
 ## Slots
 
-| Slot      | Description                                   |
-| --------- | --------------------------------------------- |
-| `"icon"`  | Slot for an Icon in the dropdown button.      |
-| `"label"` | Slot for a label text in the dropdown button. |
+| Slot          | Description                                         |
+| ------------- | --------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For injecting a dropdown list. |
+| `"icon"`      | Slot for an Icon in the dropdown button.            |
+| `"label"`     | Slot for a label text in the dropdown button.       |
 
 
 ## Dependencies

--- a/core/src/components/header/header-item/header-item.tsx
+++ b/core/src/components/header/header-item/header-item.tsx
@@ -1,6 +1,9 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { dfs } from '../../../utils/utils';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For a link or button element.
+ */
 @Component({
   tag: 'tds-header-item',
   styleUrl: 'header-item.scss',

--- a/core/src/components/header/header-item/readme.md
+++ b/core/src/components/header/header-item/readme.md
@@ -13,6 +13,13 @@
 | `selected` | `selected` | If the button should appear selected.                                                                                            | `boolean` | `false` |
 
 
+## Slots
+
+| Slot          | Description                                        |
+| ------------- | -------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For a link or button element. |
+
+
 ## Dependencies
 
 ### Used by

--- a/core/src/components/header/header-launcher-grid-item/header-launcher-grid-item.tsx
+++ b/core/src/components/header/header-launcher-grid-item/header-launcher-grid-item.tsx
@@ -1,5 +1,8 @@
 import { Component, h, Host } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For a link or button element.
+ */
 @Component({
   tag: 'tds-header-launcher-grid-item',
   styleUrl: 'header-launcher-grid-item.scss',

--- a/core/src/components/header/header-launcher-grid-item/readme.md
+++ b/core/src/components/header/header-launcher-grid-item/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                                        |
+| ------------- | -------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For a link or button element. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/header/header-launcher-grid-title/header-launcher-grid-title.tsx
+++ b/core/src/components/header/header-launcher-grid-title/header-launcher-grid-title.tsx
@@ -1,6 +1,9 @@
 import { Component, h, Host } from '@stencil/core';
 import { generateUniqueId } from '../../../utils/utils';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the title text.
+ */
 @Component({
   tag: 'tds-header-launcher-grid-title',
   styleUrl: 'header-launcher-grid-title.scss',

--- a/core/src/components/header/header-launcher-grid-title/readme.md
+++ b/core/src/components/header/header-launcher-grid-title/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                              |
+| ------------- | ---------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For the title text. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/header/header-launcher-grid/header-launcher-grid.tsx
+++ b/core/src/components/header/header-launcher-grid/header-launcher-grid.tsx
@@ -1,6 +1,9 @@
 import { Component, Element, h, Host, State } from '@stencil/core';
 import { getPreviousNestedChildOfSiblingsMatching, isHeadingElement } from '../../../utils/utils';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For a grid item element.
+ */
 @Component({
   tag: 'tds-header-launcher-grid',
   styleUrl: 'header-launcher-grid.scss',

--- a/core/src/components/header/header-launcher-grid/readme.md
+++ b/core/src/components/header/header-launcher-grid/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                                   |
+| ------------- | --------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For a grid item element. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/header/header-launcher-list-item/header-launcher-list-item.tsx
+++ b/core/src/components/header/header-launcher-list-item/header-launcher-list-item.tsx
@@ -1,5 +1,8 @@
 import { Component, h, Host } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For a link or button element.
+ */
 @Component({
   tag: 'tds-header-launcher-list-item',
   styleUrl: 'header-launcher-list-item.scss',

--- a/core/src/components/header/header-launcher-list-item/readme.md
+++ b/core/src/components/header/header-launcher-list-item/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                                        |
+| ------------- | -------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For a link or button element. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/header/header-launcher-list-title/header-launcher-list-title.tsx
+++ b/core/src/components/header/header-launcher-list-title/header-launcher-list-title.tsx
@@ -1,6 +1,9 @@
 import { Component, Element, h, Host } from '@stencil/core';
 import { generateUniqueId } from '../../../utils/utils';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the title text.
+ */
 @Component({
   tag: 'tds-header-launcher-list-title',
   styleUrl: 'header-launcher-list-title.scss',

--- a/core/src/components/header/header-launcher-list-title/readme.md
+++ b/core/src/components/header/header-launcher-list-title/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                              |
+| ------------- | ---------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For the title text. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/header/header-launcher-list/header-launcher-list.tsx
+++ b/core/src/components/header/header-launcher-list/header-launcher-list.tsx
@@ -1,6 +1,9 @@
 import { Component, Host, h } from '@stencil/core';
 import { generateUniqueId } from '../../../utils/utils';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For list items.
+ */
 @Component({
   tag: 'tds-header-launcher-list',
   shadow: false,

--- a/core/src/components/header/header-launcher-list/readme.md
+++ b/core/src/components/header/header-launcher-list/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                          |
+| ------------- | ------------------------------------ |
+| `"<default>"` | <b>Unnamed slot.</b> For list items. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/header/header-launcher/header-launcher.tsx
+++ b/core/src/components/header/header-launcher/header-launcher.tsx
@@ -1,6 +1,9 @@
 import { Component, Host, h, Element, Listen, State } from '@stencil/core';
 import { Attributes, generateUniqueId, inheritAriaAttributes } from '../../../utils/utils';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For a launcher list (or grid) element.
+ */
 @Component({
   tag: 'tds-header-launcher',
   styleUrl: 'header-launcher.scss',

--- a/core/src/components/header/header-launcher/readme.md
+++ b/core/src/components/header/header-launcher/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                                                 |
+| ------------- | ----------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For a launcher list (or grid) element. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/header/header-title/header-title.tsx
+++ b/core/src/components/header/header-title/header-title.tsx
@@ -1,5 +1,8 @@
 import { Component, h, Host } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the header title text.
+ */
 @Component({
   tag: 'tds-header-title',
   styleUrl: 'header-title.scss',

--- a/core/src/components/header/header-title/readme.md
+++ b/core/src/components/header/header-title/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                                     |
+| ------------- | ----------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For the header title text. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/header/header.stories.tsx
+++ b/core/src/components/header/header.stories.tsx
@@ -7,6 +7,7 @@ import readmeDropdown from './header-dropdown/readme.md';
 import readmeDropdownList from './header-dropdown-list/readme.md';
 import readmeDropdownListItem from './header-dropdown-list-item/readme.md';
 import readmeDropdownListUser from './header-dropdown-list-user/readme.md';
+import readmeBrandSymbol from './header-brand-symbol/readme.md';
 import readmeLauncher from './header-launcher/readme.md';
 import { ComponentsFolder } from '../../utils/constants';
 
@@ -23,6 +24,7 @@ export default {
       'Header dropdown list item': readmeDropdownListItem,
       'Header dropdown list user': readmeDropdownListUser,
       'Header launcher': readmeLauncher,
+      'Header brand symbol': readmeBrandSymbol,
     },
     layout: 'fullscreen',
     docs: {

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -2,6 +2,7 @@ import { Component, h, Host, Element } from '@stencil/core';
 import { inheritAriaAttributes, updateListChildrenRoles } from '../../utils/utils';
 
 /**
+ * @slot <default> - <b>Unnamed slot.</b> Slot for the left-aligned content consisting of buttons, dropdowns, links, etc.
  * @slot hamburger - Slot for the hamburger button for opening the mobile menu.
  * @slot title - Slot for the title.
  * @slot end - Slot for the end (right side) of the header.

--- a/core/src/components/header/readme.md
+++ b/core/src/components/header/readme.md
@@ -7,11 +7,12 @@
 
 ## Slots
 
-| Slot          | Description                                                |
-| ------------- | ---------------------------------------------------------- |
-| `"end"`       | Slot for the end (right side) of the header.               |
-| `"hamburger"` | Slot for the hamburger button for opening the mobile menu. |
-| `"title"`     | Slot for the title.                                        |
+| Slot          | Description                                                                                          |
+| ------------- | ---------------------------------------------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> Slot for the left-aligned content consisting of buttons, dropdowns, links, etc. |
+| `"end"`       | Slot for the end (right side) of the header.                                                         |
+| `"hamburger"` | Slot for the hamburger button for opening the mobile menu.                                           |
+| `"title"`     | Slot for the title.                                                                                  |
 
 
 ----------------------------------------------

--- a/core/src/components/link/link.tsx
+++ b/core/src/components/link/link.tsx
@@ -1,5 +1,8 @@
 import { Component, h, Prop, Element } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For a link element. Eg. <code>&lt;a><a></code>.
+ */
 @Component({
   tag: 'tds-link',
   styleUrl: 'link.scss',

--- a/core/src/components/link/readme.md
+++ b/core/src/components/link/readme.md
@@ -13,6 +13,13 @@
 | `underline` | `underline` | Displays the Link with an underline. | `boolean` | `true`  |
 
 
+## Slots
+
+| Slot          | Description                                                          |
+| ------------- | -------------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For a link element. Eg. <code>&lt;a><a></code>. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/message/message.tsx
+++ b/core/src/components/message/message.tsx
@@ -1,7 +1,7 @@
 import { Component, Host, h, Prop } from '@stencil/core';
 
 /**
- * @slot <default> - Default slot for the extended message section.
+ * @slot <default> - <b>Unnamed slot.</b> For the extended message. Not visible on minimal messages.
  */
 
 @Component({

--- a/core/src/components/message/readme.md
+++ b/core/src/components/message/readme.md
@@ -18,9 +18,9 @@
 
 ## Slots
 
-| Slot          | Description                                    |
-| ------------- | ---------------------------------------------- |
-| `"<default>"` | Default slot for the extended message section. |
+| Slot          | Description                                                                     |
+| ------------- | ------------------------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For the extended message. Not visible on minimal messages. |
 
 
 ## Dependencies

--- a/core/src/components/popover-canvas/popover-canvas.tsx
+++ b/core/src/components/popover-canvas/popover-canvas.tsx
@@ -2,6 +2,9 @@ import { Component, Host, Element, Listen, h, Prop, State, Watch } from '@stenci
 import { createPopper } from '@popperjs/core';
 import type { Placement, Instance } from '@popperjs/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the contents of the popover.
+ */
 @Component({
   tag: 'tds-popover-canvas',
   styleUrl: 'popover-canvas.scss',

--- a/core/src/components/popover-canvas/readme.md
+++ b/core/src/components/popover-canvas/readme.md
@@ -18,6 +18,13 @@
 | `show`           | `show`            | Controls whether the Popover is shown or not. If this is set hiding and showing will be decided by this prop and will need to be controlled from the outside. | `boolean`                                                                                                                                                                                                    | `null`      |
 
 
+## Slots
+
+| Slot          | Description                                           |
+| ------------- | ----------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For the contents of the popover. |
+
+
 ## Dependencies
 
 ### Used by

--- a/core/src/components/popover-menu/popover-menu.tsx
+++ b/core/src/components/popover-menu/popover-menu.tsx
@@ -2,6 +2,9 @@ import { Component, Element, Host, Listen, h, Prop, State } from '@stencil/core'
 import { createPopper } from '@popperjs/core';
 import type { Placement, Instance } from '@popperjs/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the list of menu items.
+ */
 @Component({
   tag: 'tds-popover-menu',
   styleUrl: 'popover-menu.scss',

--- a/core/src/components/popover-menu/readme.md
+++ b/core/src/components/popover-menu/readme.md
@@ -17,6 +17,13 @@
 | `show`           | `show`            | Decides if the Popover Menu should be visible from the start          | `boolean`                                                                                                                                                                                                    | `false`     |
 
 
+## Slots
+
+| Slot          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `"<default>"` | <b>Unnamed slot.</b> For the list of menu items. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/side-menu/readme.md
+++ b/core/src/components/side-menu/readme.md
@@ -21,13 +21,13 @@
 
 ## Slots
 
-| Slot             | Description                                                                                                                                                  |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `"<default>"`    | <b>Unnamed slot.</b> Used for nesting main content of Side Menu, e.g. <code><tds-side-menu-item></code> and <code><tds-side-menu-dropdown></code> components |
-| `"close-button"` | Used for injection of tds-side-menu-close-button that is show when in mobile view                                                                            |
-| `"end"`          | Used for items that are presented at the bottom of the Side Menu, e.g. profile settings                                                                      |
-| `"overlay"`      | Used of injection of tds-side-menu-overlay                                                                                                                   |
-| `"sticky-end"`   | Used for tds-side-menu-collapse-button component                                                                                                             |
+| Slot             | Description                                                                                                                                                                                                       |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"<default>"`    | <b>Unnamed slot.</b> For primary content of the side menu - like buttons. Used for nesting main content of Side Menu, e.g. <code><tds-side-menu-item></code> and <code><tds-side-menu-dropdown></code> components |
+| `"close-button"` | Used for injection of tds-side-menu-close-button that is show when in mobile view                                                                                                                                 |
+| `"end"`          | Used for items that are presented at the bottom of the Side Menu, e.g. profile settings                                                                                                                           |
+| `"overlay"`      | Used of injection of tds-side-menu-overlay                                                                                                                                                                        |
+| `"sticky-end"`   | Used for tds-side-menu-collapse-button component                                                                                                                                                                  |
 
 
 ----------------------------------------------

--- a/core/src/components/side-menu/side-menu-collapse-button/readme.md
+++ b/core/src/components/side-menu/side-menu-collapse-button/readme.md
@@ -14,9 +14,9 @@
 
 ## Slots
 
-| Slot          | Description                                                               |
-| ------------- | ------------------------------------------------------------------------- |
-| `"<default>"` | <b>Unnamed slot.</b> Used for injecting text presented in collapse button |
+| Slot          | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| `"<default>"` | <b>Unnamed slot.</b> For the text label of the button. |
 
 
 ## Dependencies

--- a/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -2,7 +2,7 @@ import { Component, Element, h, Host, Listen, State, Event, EventEmitter } from 
 import { CollapseEvent } from '../side-menu';
 
 /**
- * @slot <default>  - <b>Unnamed slot.</b> Used for injecting text presented in collapse button
+ * @slot <default>  - <b>Unnamed slot.</b> For the text label of the button.
  * */
 
 @Component({

--- a/core/src/components/side-menu/side-menu-dropdown-list-item/readme.md
+++ b/core/src/components/side-menu/side-menu-dropdown-list-item/readme.md
@@ -14,9 +14,9 @@
 
 ## Slots
 
-| Slot          | Description                                                                                       |
-| ------------- | ------------------------------------------------------------------------------------------------- |
-| `"<default>"` | <b>Unnamed slot.</b> Used for injecting native <code>button</code> and <code>link</code> elements |
+| Slot          | Description                                                                                          |
+| ------------- | ---------------------------------------------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For injecting a native <code>&lt;button></code> or <code>&lt;a></code> element. |
 
 
 ----------------------------------------------

--- a/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
+++ b/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
@@ -2,7 +2,7 @@ import { Component, Element, h, Host, Listen, Prop, State } from '@stencil/core'
 import { CollapseEvent } from '../side-menu';
 
 /**
- * @slot <default>  - <b>Unnamed slot.</b> Used for injecting native <code>button</code> and <code>link</code> elements
+ * @slot <default> - <b>Unnamed slot.</b> For injecting a native <code>&lt;button></code> or <code>&lt;a></code> element.
  * */
 @Component({
   tag: 'tds-side-menu-dropdown-list-item',

--- a/core/src/components/side-menu/side-menu-dropdown-list/readme.md
+++ b/core/src/components/side-menu/side-menu-dropdown-list/readme.md
@@ -7,9 +7,9 @@
 
 ## Slots
 
-| Slot          | Description                                                                                           |
-| ------------- | ----------------------------------------------------------------------------------------------------- |
-| `"<default>"` | <b>Unnamed slot.</b> Used for injection of <code>tds-side-menu-dropdown-list-item</code> subcomponent |
+| Slot          | Description                                                                                        |
+| ------------- | -------------------------------------------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For injection of <code>tds-side-menu-dropdown-list-item</code> subcomponents. |
 
 
 ----------------------------------------------

--- a/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
+++ b/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
@@ -2,7 +2,7 @@ import { Component, Host, h, Listen, Element, State } from '@stencil/core';
 import { CollapseEvent } from '../side-menu';
 
 /**
- * @slot <default>  - <b>Unnamed slot.</b> Used for injection of <code>tds-side-menu-dropdown-list-item</code> subcomponent
+ * @slot <default>  - <b>Unnamed slot.</b> For injection of <code>tds-side-menu-dropdown-list-item</code> subcomponents.
  * */
 @Component({
   tag: 'tds-side-menu-dropdown-list',

--- a/core/src/components/side-menu/side-menu-dropdown/readme.md
+++ b/core/src/components/side-menu/side-menu-dropdown/readme.md
@@ -18,7 +18,7 @@
 
 | Slot             | Description                                                                                      |
 | ---------------- | ------------------------------------------------------------------------------------------------ |
-| `"<default>"`    | <b>Unnamed slot.</b> Used for injection of <code>tds-side-menu-dropdown-list</code> subcomponent |
+| `"<default>"`    | <b>Unnamed slot.</b> For injection of the <code>tds-side-menu-dropdown-list</code> subcomponent. |
 | `"button-icon"`  | Used for injecting the icon that compliments the dropdown title                                  |
 | `"button-label"` | Used for injecting the text, aka dropdown title                                                  |
 

--- a/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -4,7 +4,7 @@ import { CollapseEvent } from '../side-menu';
 /**
  * @slot button-icon - Used for injecting the icon that compliments the dropdown title
  * @slot button-label - Used for injecting the text, aka dropdown title
- * @slot <default>  - <b>Unnamed slot.</b> Used for injection of <code>tds-side-menu-dropdown-list</code> subcomponent
+ * @slot <default> - <b>Unnamed slot.</b> For injection of the <code>tds-side-menu-dropdown-list</code> subcomponent.
  * */
 @Component({
   tag: 'tds-side-menu-dropdown',

--- a/core/src/components/side-menu/side-menu-item/readme.md
+++ b/core/src/components/side-menu/side-menu-item/readme.md
@@ -15,9 +15,9 @@
 
 ## Slots
 
-| Slot          | Description                                                                                       |
-| ------------- | ------------------------------------------------------------------------------------------------- |
-| `"<default>"` | <b>Unnamed slot.</b> Used for injecting native <code>button</code> and <code>link</code> elements |
+| Slot          | Description                                                                                          |
+| ------------- | ---------------------------------------------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For injecting a native <code>&lt;button</code> and <code>&lt;a></code> element. |
 
 
 ## Dependencies

--- a/core/src/components/side-menu/side-menu-item/side-menu-item.tsx
+++ b/core/src/components/side-menu/side-menu-item/side-menu-item.tsx
@@ -3,7 +3,7 @@ import { CollapseEvent } from '../side-menu';
 import { dfs } from '../../../utils/utils';
 
 /**
- * @slot <default>  - <b>Unnamed slot.</b> Used for injecting native <code>button</code> and <code>link</code> elements
+ * @slot <default> - <b>Unnamed slot.</b> For injecting a native <code>&lt;button</code> and <code>&lt;a></code> element.
  * */
 @Component({
   tag: 'tds-side-menu-item',

--- a/core/src/components/side-menu/side-menu.tsx
+++ b/core/src/components/side-menu/side-menu.tsx
@@ -31,7 +31,7 @@ const INITIALIZE_ANIMATION_DELAY = 500;
 /**
  * @slot overlay - Used of injection of tds-side-menu-overlay
  * @slot close-button - Used for injection of tds-side-menu-close-button that is show when in mobile view
- * @slot <default> - <b>Unnamed slot.</b>
+ * @slot <default> - <b>Unnamed slot.</b> For primary content of the side menu - like buttons.
  * Used for nesting main content of Side Menu, e.g. <code><tds-side-menu-item></code> and <code><tds-side-menu-dropdown></code> components
  * @slot end - Used for items that are presented at the bottom of the Side Menu, e.g. profile settings
  * @slot sticky-end - Used for tds-side-menu-collapse-button component

--- a/core/src/components/stepper/readme.md
+++ b/core/src/components/stepper/readme.md
@@ -23,6 +23,13 @@
 | `internalTdsPropsChange` |             | `CustomEvent<{ stepperId: string; changed: (keyof TdsStepperProps)[]; } & Partial<TdsStepperProps>>` |
 
 
+## Slots
+
+| Slot          | Description                                 |
+| ------------- | ------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For the step elements. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/stepper/stepper.tsx
+++ b/core/src/components/stepper/stepper.tsx
@@ -14,6 +14,9 @@ export type InternalTdsStepperPropChange = {
   changed: Array<keyof TdsStepperProps>;
 } & Partial<TdsStepperProps>;
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the step elements.
+ */
 @Component({
   tag: 'tds-stepper',
   styleUrl: 'stepper.scss',

--- a/core/src/components/table/table-body-cell/readme.md
+++ b/core/src/components/table/table-body-cell/readme.md
@@ -14,6 +14,13 @@
 | `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                            | `boolean`          | `false`     |
 
 
+## Slots
+
+| Slot          | Description                                 |
+| ------------- | ------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For the cell contents. |
+
+
 ## Dependencies
 
 ### Used by

--- a/core/src/components/table/table-body-cell/table-body-cell.tsx
+++ b/core/src/components/table/table-body-cell/table-body-cell.tsx
@@ -6,6 +6,9 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
   'compactDesign',
   'noMinWidth',
 ];
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the cell contents.
+ */
 @Component({
   tag: 'tds-body-cell',
   styleUrl: 'table-body-cell.scss',

--- a/core/src/components/table/table-body-row-expandable/readme.md
+++ b/core/src/components/table/table-body-row-expandable/readme.md
@@ -14,9 +14,10 @@
 
 ## Slots
 
-| Slot           | Description                |
-| -------------- | -------------------------- |
-| `"expand-row"` | Slot for the expanded row. |
+| Slot           | Description                         |
+| -------------- | ----------------------------------- |
+| `"<default>"`  | <b>Unnamed slot.</b> For the cells. |
+| `"expand-row"` | Slot for the expanded row.          |
 
 
 ----------------------------------------------

--- a/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -19,6 +19,7 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
 ];
 
 /**
+ * @slot <default> - <b>Unnamed slot.</b> For the cells.
  * @slot expand-row - Slot for the expanded row.
  */
 @Component({

--- a/core/src/components/table/table-body-row/readme.md
+++ b/core/src/components/table/table-body-row/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                         |
+| ------------- | ----------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For the cells. |
+
+
 ## Dependencies
 
 ### Used by

--- a/core/src/components/table/table-body-row/table-body-row.tsx
+++ b/core/src/components/table/table-body-row/table-body-row.tsx
@@ -8,6 +8,9 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
   'modeVariant',
 ];
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the cells.
+ */
 @Component({
   tag: 'tds-table-body-row',
   styleUrl: 'table-body-row.scss',

--- a/core/src/components/table/table-body/readme.md
+++ b/core/src/components/table/table-body/readme.md
@@ -15,10 +15,10 @@
 
 ## Slots
 
-| Slot          | Description                                                   |
-| ------------- | ------------------------------------------------------------- |
-| `"<default>"` | Default slot for the Table Body, used by <tds-table-body-row> |
-| `"no-result"` | Slot for no result message when using filtering.              |
+| Slot          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `"<default>"` | <b>Unnamed slot.</b> For table rows.             |
+| `"no-result"` | Slot for no result message when using filtering. |
 
 
 ## Dependencies

--- a/core/src/components/table/table-body/table-body.tsx
+++ b/core/src/components/table/table-body/table-body.tsx
@@ -18,11 +18,10 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
   'enableExpandableRows',
 ];
 
-
 /**
- * @slot <default> - Default slot for the Table Body, used by <tds-table-body-row>
+ * @slot <default> - <b>Unnamed slot.</b> For table rows.
  * @slot no-result - Slot for no result message when using filtering.
-*/
+ */
 @Component({
   tag: 'tds-table-body',
   styleUrl: 'table-body.scss',
@@ -222,7 +221,7 @@ export class TdsTableBody {
   searchFunction(searchTerm) {
     // grab all rows in body
     const dataRowsFiltering = this.host.querySelectorAll('tds-table-body-row');
-    
+
     if (searchTerm.length > 0) {
       if (this.enablePaginationTableBody) {
         this.tempPaginationDisable = true;
@@ -259,15 +258,14 @@ export class TdsTableBody {
       if (this.enablePaginationTableBody) {
         this.tempPaginationDisable = false;
       }
-      
-      
+
       // If pagination is NOT enabled, we show all rows.
       if (!this.enablePaginationTableBody) {
         dataRowsFiltering.forEach((item) => {
           item.classList.remove('tds-table__row--hidden');
         });
       }
-      
+
       this.showNoResultsMessage = false;
       this.disableAllSorting = false;
       this.internalTdsSortingChange.emit([this.tableId, this.disableAllSorting]);
@@ -297,7 +295,7 @@ export class TdsTableBody {
       this[tablePropName] = this.tableEl[tablePropName];
     });
 
-    if(this.bodyData){
+    if (this.bodyData) {
       this.arrayDataWatcher(this.bodyData);
     }
   }
@@ -324,12 +322,12 @@ export class TdsTableBody {
             ))}
           </tds-table-body-row>
         ))}
-          <tr hidden={!this.showNoResultsMessage}>
-            <td class="tds-table__info-message" colSpan={this.columnsNumber}>
-              <slot name="no-result"/>
-              {this.noResultMessage}
-            </td>
-          </tr>
+        <tr hidden={!this.showNoResultsMessage}>
+          <td class="tds-table__info-message" colSpan={this.columnsNumber}>
+            <slot name="no-result" />
+            {this.noResultMessage}
+          </td>
+        </tr>
         <slot></slot>
       </Host>
     );

--- a/core/src/components/table/table-header/readme.md
+++ b/core/src/components/table/table-header/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Slots
+
+| Slot          | Description                                |
+| ------------- | ------------------------------------------ |
+| `"<default>"` | <b>Unnamed slot.</b> For the header cells. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/table/table-header/table-header.tsx
+++ b/core/src/components/table/table-header/table-header.tsx
@@ -9,6 +9,9 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
   'noMinWidth',
 ];
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the header cells.
+ */
 @Component({
   tag: 'tds-table-header',
   styleUrl: 'table-header.scss',

--- a/core/src/components/table/table/readme.md
+++ b/core/src/components/table/table/readme.md
@@ -19,6 +19,13 @@
 | `verticalDividers`     | `vertical-dividers`      | Enables style with vertical dividers between columns                                                                                                                                                                                        | `boolean`                  | `false`              |
 
 
+## Slots
+
+| Slot          | Description                                  |
+| ------------- | -------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For the table contents. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/table/table/table.tsx
+++ b/core/src/components/table/table/table.tsx
@@ -20,6 +20,9 @@ export type InternalTdsTablePropChange = {
   changed: Array<keyof Props>;
 } & Partial<Props>;
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the table contents.
+ */
 @Component({
   tag: 'tds-table',
   styleUrl: 'table.scss',

--- a/core/src/components/tabs/folder-tabs/folder-tab/folder-tab.tsx
+++ b/core/src/components/tabs/folder-tabs/folder-tab/folder-tab.tsx
@@ -1,5 +1,8 @@
 import { Component, Host, h, Method, State, Prop } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the tab link or button.
+ */
 @Component({
   tag: 'tds-folder-tab',
   styleUrl: 'folder-tab.scss',

--- a/core/src/components/tabs/folder-tabs/folder-tab/readme.md
+++ b/core/src/components/tabs/folder-tabs/folder-tab/readme.md
@@ -12,6 +12,13 @@
 | `disabled` | `disabled` | Disables the Tab. | `boolean` | `false` |
 
 
+## Slots
+
+| Slot          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `"<default>"` | <b>Unnamed slot.</b> For the tab link or button. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/tabs/folder-tabs/folder-tabs.tsx
+++ b/core/src/components/tabs/folder-tabs/folder-tabs.tsx
@@ -10,6 +10,9 @@ import {
   Method,
 } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the tab elements.
+ */
 @Component({
   tag: 'tds-folder-tabs',
   styleUrl: 'folder-tabs.scss',

--- a/core/src/components/tabs/folder-tabs/readme.md
+++ b/core/src/components/tabs/folder-tabs/readme.md
@@ -34,6 +34,13 @@ Type: `Promise<{ selectedTabIndex: number; }>`
 
 
 
+## Slots
+
+| Slot          | Description                                |
+| ------------- | ------------------------------------------ |
+| `"<default>"` | <b>Unnamed slot.</b> For the tab elements. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.tsx
+++ b/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.tsx
@@ -1,5 +1,8 @@
 import { Component, Host, h, Prop, Method, State } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the tab link or button.
+ */
 @Component({
   tag: 'tds-inline-tab',
   styleUrl: 'inline-tab.scss',

--- a/core/src/components/tabs/inline-tabs/inline-tab/readme.md
+++ b/core/src/components/tabs/inline-tabs/inline-tab/readme.md
@@ -12,6 +12,13 @@
 | `disabled` | `disabled` | Disables the Tab. | `boolean` | `false` |
 
 
+## Slots
+
+| Slot          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `"<default>"` | <b>Unnamed slot.</b> For the tab link or button. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/core/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -1,6 +1,9 @@
 import { Component, Host, State, Element, h, Prop, Event, EventEmitter } from '@stencil/core';
 import { Method } from '@stencil/core/internal';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the tab elements.
+ */
 @Component({
   tag: 'tds-inline-tabs',
   styleUrl: 'inline-tabs.scss',

--- a/core/src/components/tabs/inline-tabs/readme.md
+++ b/core/src/components/tabs/inline-tabs/readme.md
@@ -34,6 +34,13 @@ Type: `Promise<{ selectedTabIndex: number; }>`
 
 
 
+## Slots
+
+| Slot          | Description                                |
+| ------------- | ------------------------------------------ |
+| `"<default>"` | <b>Unnamed slot.</b> For the tab elements. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.tsx
+++ b/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.tsx
@@ -1,5 +1,8 @@
 import { Component, Host, h, Prop, State, Method } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the tab link or button.
+ */
 @Component({
   tag: 'tds-navigation-tab',
   styleUrl: 'navigation-tab.scss',

--- a/core/src/components/tabs/navigation-tabs/navigation-tab/readme.md
+++ b/core/src/components/tabs/navigation-tabs/navigation-tab/readme.md
@@ -12,6 +12,13 @@
 | `disabled` | `disabled` | Disables the Tab. | `boolean` | `false` |
 
 
+## Slots
+
+| Slot          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `"<default>"` | <b>Unnamed slot.</b> For the tab link or button. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/tabs/navigation-tabs/navigation-tabs.tsx
+++ b/core/src/components/tabs/navigation-tabs/navigation-tabs.tsx
@@ -10,6 +10,9 @@ import {
   Method,
 } from '@stencil/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the tab elements.
+ */
 @Component({
   tag: 'tds-navigation-tabs',
   styleUrl: 'navigation-tabs.scss',

--- a/core/src/components/tabs/navigation-tabs/readme.md
+++ b/core/src/components/tabs/navigation-tabs/readme.md
@@ -34,6 +34,13 @@ Type: `Promise<{ selectedTabIndex: number; }>`
 
 
 
+## Slots
+
+| Slot          | Description                                |
+| ------------- | ------------------------------------------ |
+| `"<default>"` | <b>Unnamed slot.</b> For the tab elements. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/core/src/components/tooltip/readme.md
+++ b/core/src/components/tooltip/readme.md
@@ -30,6 +30,13 @@ Type: `Promise<void>`
 
 
 
+## Slots
+
+| Slot          | Description                                    |
+| ------------- | ---------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For the tooltip contents. |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/core/src/components/tooltip/tooltip.tsx
+++ b/core/src/components/tooltip/tooltip.tsx
@@ -2,6 +2,9 @@ import { Component, h, Prop, State, Method } from '@stencil/core';
 import { createPopper } from '@popperjs/core';
 import type { Placement, Instance } from '@popperjs/core';
 
+/**
+ * @slot <default> - <b>Unnamed slot.</b> For the tooltip contents.
+ */
 @Component({
   tag: 'tds-tooltip',
   styleUrl: 'tooltip.scss',


### PR DESCRIPTION
**Describe pull-request**  
Adds doc comments for all unnamed slots.

**Solving issue**  
Fixes: #DTS-2098

**How to test**  
Because of the high number of changed files i suggest a smoke test: Select 5-10 stories randomly and only check them, that should be enough.

So:

1. Go to Storybook
2. Check in a ca 5-10 randomly selected stories, are unnamed slots documented?

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
