### PR TITLE
fix(card): class and rule for body image

### DIFF
--- a/core/src/components/card/card.scss
+++ b/core/src/components/card/card.scss
@@ -61,6 +61,10 @@
     }
   }
 
+  .card-body-img {
+    width: 100%;
+  }
+
   .tds-divider {
     margin: 16px 16px 0;
     background-color: var(--tds-card-divider);

--- a/core/src/components/card/card.stories.tsx
+++ b/core/src/components/card/card.stories.tsx
@@ -1,5 +1,6 @@
 import readme from './readme.md';
 import CardPlaceholder from '../../stories/assets/image/card-placeholder.png';
+import CardBodyImage from '../../stories/assets/image/card-img.png';
 import { formatHtmlPreview } from '../../utils/utils';
 import { ComponentsFolder } from '../../utils/constants';
 
@@ -149,7 +150,7 @@ const Template = ({
     ${header ? `header="${header}"` : ''}
     image-placement="${imagePlacement.toLowerCase()}-header"
     ${subheader ? `subheader="${subheader}"` : ''}
-    ${bodyImg ? `body-img="${CardPlaceholder}"` : ''}
+    ${bodyImg ? `body-img="${CardBodyImage}"` : ''}
     ${clickable ? 'clickable' : ''}
     ${bodyDivider ? 'body-divider' : ''}
     >

--- a/core/src/components/card/card.tsx
+++ b/core/src/components/card/card.tsx
@@ -91,7 +91,7 @@ export class TdsCard {
         {this.imagePlacement === 'below-header' && this.getCardHeader()}
         <div class={`card-body`}>
           {usesBodyImageSlot && <slot name="body-image"></slot>}
-          {this.bodyImg && <img class={`card-body-img`} src={this.bodyImg} alt={this.bodyImgAlt} />}
+          {this.bodyImg && <img class="card-body-img" src={this.bodyImg} alt={this.bodyImgAlt} />}
           {this.imagePlacement === 'above-header' && this.getCardHeader()}
           {this.bodyDivider && <tds-divider></tds-divider>}
           {usesBodySlot && <slot name="body"></slot>}


### PR DESCRIPTION
**Describe pull-request**  
Missing CSS rule for body image

**Solving issue**  

Fixes: [DTS-2152](https://tegel.atlassian.net/browse/DTS-2152)

**How to test**  
1. Go to Netlify preview
2. Check Card component
3. Try to change image in body, try to use extra large one to test that it will shrink within card area 

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events





[DTS-2152]: https://tegel.atlassian.net/browse/DTS-2152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ