### PR TITLE
fix(footer): horizontal scroll issue

### DIFF
--- a/core/src/components/footer/footer.scss
+++ b/core/src/components/footer/footer.scss
@@ -4,6 +4,7 @@
   $grid-lg: 992px;
 
   slot[name='top']::slotted(*) {
+    box-sizing: border-box;
     background-color: var(--tds-footer-top-background);
     padding: 40px;
     display: grid;


### PR DESCRIPTION
**Describe pull-request**  
When no box-sizing, padding is added after width rule, so width: 100% + 40px + 40px which results in horizontal scroll.

**Solving issue**  
Fixes: [DTS-2153](https://tegel.atlassian.net/browse/DTS-2153)

**How to test**  
1. Check the prod storybook
2. Check the PR storybook
3. Compare the footer component with top part, inspect and see if there is no more horizontal scroll

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events



[DTS-2153]: https://tegel.atlassian.net/browse/DTS-2153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ