### PR TITLE
fix(popover-canvas): use tds link component

### DIFF
--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -208,12 +208,12 @@ button {
   }
 }
 
-:host(tds-button[fullbleed='true']) {
+:host(tds-button[fullbleed]) {
   width: 100%;
   justify-content: center;
 }
 
-:host(tds-button[only-icon='true']) {
+:host(tds-button[only-icon]) {
   .sm {
     padding: $btn-sm-only-icon-padding;
   }
@@ -227,7 +227,7 @@ button {
   }
 }
 
-:host(tds-button:not([only-icon='true'])) {
+:host(tds-button:not([only-icon])) {
   display: inline-flex;
   align-items: center;
 

--- a/core/src/components/popover-canvas/popover-canvas.scss
+++ b/core/src/components/popover-canvas/popover-canvas.scss
@@ -4,6 +4,7 @@
 .tds-popover-canvas {
   @include tds-box-sizing;
 
+  display: inline-block;
   color: var(--tds-popover-canvas-color);
   background-color: var(--tds-popover-canvas-background);
   box-shadow: 0 3px 3px rgb(0 0 0 / 15%), 0 -1px 1px rgb(0 0 0 / 10%);

--- a/core/src/components/popover-canvas/popover-canvas.stories.tsx
+++ b/core/src/components/popover-canvas/popover-canvas.stories.tsx
@@ -74,20 +74,20 @@ const ComponentPopoverCanvas = ({ canvasPosition }) => {
         placement="${canvasPosLookup[canvasPosition]}"
         selector="#trigger"
         class="tds-u-p2">
-        <h2>A Popover Canvas!</h2>
-        <p>
+        <h2 class="tds-headline-02 tds-u-mt0">A Popover Canvas!</h2>
+        <p class="tds-body-01">
           Where you can put anything you want!
-        </p>
-        <p>
+        </p>  
+        <tds-link>
           <a target="_blank" rel="noopener noreferrer" href="https://tegel.scania.com">Even links!</a>
-        </p>
+        </tds-link>
       </tds-popover-canvas>
 
       <!-- demo-wrapper code below is for demonstration purposes only -->
       <div class="demo-wrapper">
         <span class="tds-u-mr2">Click icon for Popover Canvas</span>
         
-        <tds-button aria-label="menu" only-icon id="trigger" type="ghost" size="sm">
+        <tds-button aria-label="menu" only-icon id="trigger" type="secondary" size="sm">
           <tds-icon slot="icon" size="16px" name="kebab"></tds-icon>
         </tds-button>
       </div>


### PR DESCRIPTION
**Describe pull-request**  
Prefer using tds-link component in popover-canvas example

**Solving issue**  
Fixes: [DTS-1996](https://tegel.atlassian.net/browse/DTS-1996)

**How to test**  
1. Open Storybook preview 
2. Check Popover Canvas
3. There should be <tds-link component

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


[DTS-1996]: https://tegel.atlassian.net/browse/DTS-1996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ