### PR TITLE
refactor(popover-core): rename and move

### DIFF
--- a/core/src/components/header/header-dropdown/readme.md
+++ b/core/src/components/header/header-dropdown/readme.md
@@ -38,7 +38,7 @@ graph TD;
   tds-header-dropdown --> tds-icon
   tds-header-dropdown --> tds-popover-canvas
   tds-header-item --> tds-core-header-item
-  tds-popover-canvas --> tds-core-popover
+  tds-popover-canvas --> tds-popover-core
   style tds-header-dropdown fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/core/src/components/header/header-launcher/readme.md
+++ b/core/src/components/header/header-launcher/readme.md
@@ -27,7 +27,7 @@ graph TD;
   tds-header-launcher-button --> tds-header-item
   tds-header-launcher-button --> tds-icon
   tds-header-item --> tds-core-header-item
-  tds-popover-canvas --> tds-core-popover
+  tds-popover-canvas --> tds-popover-core
   style tds-header-launcher fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/core/src/components/popover-canvas/popover-canvas.tsx
+++ b/core/src/components/popover-canvas/popover-canvas.tsx
@@ -46,7 +46,7 @@ export class TdsPopoverCanvas {
   render() {
     return (
       <Host>
-        <tds-core-popover
+        <tds-popover-core
           {...this.inheritedAttributes}
           class={{
             'tds-popover-canvas': true,
@@ -65,7 +65,7 @@ export class TdsPopoverCanvas {
             {/* (@stencil/core@3.3.0): This div is somehow needed to keep the slotted children in a predictable order */}
             <slot></slot>
           </div>
-        </tds-core-popover>
+        </tds-popover-core>
       </Host>
     );
   }

--- a/core/src/components/popover-canvas/readme.md
+++ b/core/src/components/popover-canvas/readme.md
@@ -34,12 +34,12 @@
 
 ### Depends on
 
-- [tds-core-popover](../core-popover)
+- [tds-popover-core](../popover-core)
 
 ### Graph
 ```mermaid
 graph TD;
-  tds-popover-canvas --> tds-core-popover
+  tds-popover-canvas --> tds-popover-core
   tds-header-dropdown --> tds-popover-canvas
   tds-header-launcher --> tds-popover-canvas
   style tds-popover-canvas fill:#f9f,stroke:#333,stroke-width:4px

--- a/core/src/components/popover-core/popover-core.tsx
+++ b/core/src/components/popover-core/popover-core.tsx
@@ -14,12 +14,12 @@ import { createPopper } from '@popperjs/core';
 import type { Placement, Instance } from '@popperjs/core';
 
 @Component({
-  tag: 'tds-core-popover',
+  tag: 'tds-popover-core',
   shadow: false,
   scoped: true,
 })
-export class TdsCorePopover {
-  @Element() host!: HTMLTdsCorePopoverElement;
+export class TdsPopoverCore {
+  @Element() host!: HTMLTdsPopoverCoreElement;
 
   /** The CSS-selector for an element that will trigger the pop-over */
   @Prop() selector: string = '';

--- a/core/src/components/popover-core/readme.md
+++ b/core/src/components/popover-core/readme.md
@@ -31,10 +31,10 @@
 ### Graph
 ```mermaid
 graph TD;
-  tds-popover-canvas --> tds-core-popover
-  tds-popover-menu --> tds-core-popover
-  tds-tooltip --> tds-core-popover
-  style tds-core-popover fill:#f9f,stroke:#333,stroke-width:4px
+  tds-popover-canvas --> tds-popover-core
+  tds-popover-menu --> tds-popover-core
+  tds-tooltip --> tds-popover-core
+  style tds-popover-core fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
 ----------------------------------------------

--- a/core/src/components/popover-menu/popover-menu.tsx
+++ b/core/src/components/popover-menu/popover-menu.tsx
@@ -41,7 +41,7 @@ export class TdsPopoverMenu {
   render() {
     return (
       <Host>
-        <tds-core-popover
+        <tds-popover-core
           class={{
             'tds-popover-menu': true,
             [this.inheritedAttributes.class ?? '']: true,
@@ -54,7 +54,7 @@ export class TdsPopoverMenu {
           offsetDistance={this.offsetDistance}
         >
           <slot></slot>
-        </tds-core-popover>
+        </tds-popover-core>
       </Host>
     );
   }

--- a/core/src/components/popover-menu/readme.md
+++ b/core/src/components/popover-menu/readme.md
@@ -28,12 +28,12 @@
 
 ### Depends on
 
-- [tds-core-popover](../core-popover)
+- [tds-popover-core](../popover-core)
 
 ### Graph
 ```mermaid
 graph TD;
-  tds-popover-menu --> tds-core-popover
+  tds-popover-menu --> tds-popover-core
   style tds-popover-menu fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/core/src/components/tooltip/readme.md
+++ b/core/src/components/tooltip/readme.md
@@ -28,12 +28,12 @@
 
 ### Depends on
 
-- [tds-core-popover](../core-popover)
+- [tds-popover-core](../popover-core)
 
 ### Graph
 ```mermaid
 graph TD;
-  tds-tooltip --> tds-core-popover
+  tds-tooltip --> tds-popover-core
   style tds-tooltip fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/core/src/components/tooltip/tooltip.tsx
+++ b/core/src/components/tooltip/tooltip.tsx
@@ -68,7 +68,7 @@ export class TdsTooltip {
   render() {
     return (
       <Host>
-        <tds-core-popover
+        <tds-popover-core
           {...this.inheritedAttributes}
           class={{
             'tds-tooltip': true,
@@ -93,7 +93,7 @@ export class TdsTooltip {
           {this.text}
           {/* Slot is added to support adding HTML elements to component */}
           <slot></slot>
-        </tds-core-popover>
+        </tds-popover-core>
       </Host>
     );
   }


### PR DESCRIPTION
**Describe pull-request**  
Rename core-popover component

**Solving issue**  
Fixes: [DTS-2158](https://tegel.atlassian.net/browse/DTS-2158)

**How to test**  
1. Go to Netlify Preview
2. Check that the Popover canvas, Popover menu and Tooltip work as intended

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


[DTS-2158]: https://tegel.atlassian.net/browse/DTS-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ