### PR TITLE
fix(link): span instead of div for inline alignment

### DIFF
--- a/core/src/components/link/link.stories.tsx
+++ b/core/src/components/link/link.stories.tsx
@@ -51,12 +51,14 @@ export default {
 const Template = ({ underline, disabled }) =>
   formatHtmlPreview(
     `
-    <tds-link
+    <p class='tds-body-02'>The <tds-link
         ${disabled ? 'disabled' : ''}
         ${underline ? '' : 'underline="false"'}
         >
-        <a href="#">This is a link.</a>
-    </tds-link>
+        <a href="https://tegel.scania.com/home" target='_blank'>Tegel</a>
+    </tds-link> Design System is for digital products and services at Scania.
+     It enables an efficient development process and ensures a premium experience across all of Scania's digital touchpoints.    
+    </p>  
   `,
   );
 export const Default = Template.bind({});

--- a/core/src/components/link/link.tsx
+++ b/core/src/components/link/link.tsx
@@ -23,14 +23,14 @@ export class TdsLink {
 
   render() {
     return (
-      <div
-        class={`
+      <span
+        class={`        
           ${this.disabled ? 'disabled' : ''}
           ${!this.underline ? 'no-underline' : ''}
           `}
       >
         <slot></slot>
-      </div>
+      </span>
     );
   }
 }


### PR DESCRIPTION
**Describe pull-request**  
div inside a component prevents it from inlining, lets use span instead

**Solving issue**  
Fixes: [DTS-2144](https://tegel.atlassian.net/browse/DTS-2144)

**How to test**  
1. Go to the Netlify preview link
2. Check if the Link component is now in line with text


**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Additional note**
[Inline Display Components](https://www.w3schools.com/css/css_display_visibility.asp)


[DTS-2144]: https://tegel.atlassian.net/browse/DTS-2144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ