### PR TITLE
refactor(message): variant instead of type prop

### DIFF
--- a/core/src/components/message/message.stories.tsx
+++ b/core/src/components/message/message.stories.tsx
@@ -33,9 +33,9 @@ export default {
         defaultValue: { summary: 'Inherit from parent' },
       },
     },
-    messageType: {
-      name: 'Message type',
-      description: 'Changes the type of the component.',
+    messageVariant: {
+      name: 'Message variant',
+      description: 'Changes the variant of the component.',
       control: {
         type: 'radio',
       },
@@ -81,7 +81,7 @@ export default {
   },
   args: {
     modeVariant: 'Inherit from parent',
-    messageType: 'Information',
+    messageVariant: 'Information',
     header: 'Message header',
     extendedMessage:
       'Longer Message text can be placed here. Longer Message text can be placed here.',
@@ -90,7 +90,7 @@ export default {
   },
 };
 
-const Template = ({ modeVariant, messageType, header, extendedMessage, minimal, noIcon }) =>
+const Template = ({ modeVariant, messageVariant, header, extendedMessage, minimal, noIcon }) =>
   formatHtmlPreview(
     `
     <style>
@@ -100,7 +100,7 @@ const Template = ({ modeVariant, messageType, header, extendedMessage, minimal, 
     </style>
     <div class="demo-wrapper">
       <tds-message
-          type="${messageType.toLowerCase()}"
+          variant="${messageVariant.toLowerCase()}"
           header="${header}"
           ${noIcon ? 'no-icon' : ''}
           ${minimal ? 'minimal' : ''}

--- a/core/src/components/message/message.tsx
+++ b/core/src/components/message/message.tsx
@@ -16,8 +16,8 @@ export class TdsMessage {
   /** Variant of the component, based on current mode. */
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
-  /** Type of Message. */
-  @Prop() type: 'information' | 'error' | 'warning' | 'success' = 'information';
+  /** Variant of Message. */
+  @Prop() variant: 'information' | 'error' | 'warning' | 'success' = 'information';
 
   /** Removes the icon in the Message. */
   @Prop() noIcon: boolean = false;
@@ -26,7 +26,7 @@ export class TdsMessage {
   @Prop() minimal: boolean = false;
 
   getIconName = () => {
-    switch (this.type) {
+    switch (this.variant) {
       case 'information':
         return 'info';
       case 'error':
@@ -45,7 +45,7 @@ export class TdsMessage {
       <Host>
         <div
           class={`
-        wrapper ${this.type}
+        wrapper ${this.variant}
         ${this.minimal ? 'minimal' : ''}
         ${this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''}`}
         >

--- a/core/src/components/message/readme.md
+++ b/core/src/components/message/readme.md
@@ -13,7 +13,7 @@
 | `minimal`     | `minimal`      | Minimal Message styling.                         | `boolean`                                            | `false`         |
 | `modeVariant` | `mode-variant` | Variant of the component, based on current mode. | `"primary" \| "secondary"`                           | `null`          |
 | `noIcon`      | `no-icon`      | Removes the icon in the Message.                 | `boolean`                                            | `false`         |
-| `type`        | `type`         | Type of Message.                                 | `"error" \| "information" \| "success" \| "warning"` | `'information'` |
+| `variant`     | `variant`      | Variant of Message.                              | `"error" \| "information" \| "success" \| "warning"` | `'information'` |
 
 
 ## Slots


### PR DESCRIPTION
**Describe pull-request**  
Renaming type prop to variant

**Solving issue**  
Fixes: [DTS-2132](https://tegel.atlassian.net/browse/DTS-2132)

**How to test**  
1. Go to Netlify Preview
2. Check if the variant prop is there in the code and Notes
3. Check if Controls is updated with renamed prop and if switching between variants works OK

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events



[DTS-2132]: https://tegel.atlassian.net/browse/DTS-2132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ