### PR TITLE
refactor(toast): variant instead of type prop

### DIFF
--- a/core/src/components/toast/readme.md
+++ b/core/src/components/toast/readme.md
@@ -14,7 +14,7 @@
 | `subheader` | `subheader`  | Subheader text for the component.                      | `string`                                             | `undefined`          |
 | `toastId`   | `toast-id`   | ID for the Toast. Randomly generated if not specified. | `string`                                             | `generateUniqueId()` |
 | `toastRole` | `toast-role` | ARIA role for the Toast.                               | `"alert" \| "log" \| "status"`                       | `'alert'`            |
-| `type`      | `type`       | Type of Toast.                                         | `"error" \| "information" \| "success" \| "warning"` | `'information'`      |
+| `variant`   | `variant`    | Type of Toast.                                         | `"error" \| "information" \| "success" \| "warning"` | `'information'`      |
 
 
 ## Events

--- a/core/src/components/toast/toast.stories.tsx
+++ b/core/src/components/toast/toast.stories.tsx
@@ -21,9 +21,9 @@ export default {
     ],
   },
   argTypes: {
-    type: {
-      name: 'Message type',
-      description: 'Changes the type of Toast.',
+    variant: {
+      name: 'Message variant',
+      description: 'Changes the variant of Toast.',
       control: {
         type: 'radio',
       },
@@ -57,17 +57,17 @@ export default {
     },
   },
   args: {
-    type: 'Information',
+    variant: 'Information',
     header: 'Header',
     subheader: 'Subheader',
     bottom: '<a slot="bottom" href="#">This is a link.</a>',
   },
 };
 
-const Template = ({ type, header, subheader, bottom }) =>
+const Template = ({ variant, header, subheader, bottom }) =>
   formatHtmlPreview(
     `<tds-toast
-        type="${type.toLowerCase()}"
+        variant="${variant.toLowerCase()}"
         header="${header}"
         ${subheader ? `subheader="${subheader}"` : ''}
     >

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -25,7 +25,7 @@ export class TdsToast {
   @Prop() subheader: string;
 
   /** Type of Toast. */
-  @Prop() type: 'information' | 'error' | 'warning' | 'success' = 'information';
+  @Prop() variant: 'information' | 'error' | 'warning' | 'success' = 'information';
 
   /** Hides the Toast. */
   @Prop({ reflect: true }) hidden: boolean = false;
@@ -57,7 +57,7 @@ export class TdsToast {
   }>;
 
   getIconName = () => {
-    switch (this.type) {
+    switch (this.variant) {
       case 'information':
         return 'info';
       case 'error':
@@ -102,7 +102,7 @@ export class TdsToast {
         <div
           class={`
             wrapper
-            ${this.type}`}
+            ${this.variant}`}
         >
           <tds-icon name={this.getIconName()} size="20px"></tds-icon>
           <div class={`content`}>


### PR DESCRIPTION
**Describe pull-request**  
Renaming prop type to variant 

**Solving issue**  
Fixes: [DTS-2133](https://tegel.atlassian.net/browse/DTS-2133)

**How to test**  
1. Go to the Netlify preview link
2. Check the Toast component
3. Run through its variant options and make sure the code and design is updated

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


[DTS-2133]: https://tegel.atlassian.net/browse/DTS-2133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ