### PR TITLE
refactor(header): size instead of type prop

### DIFF
--- a/core/src/components/header/header-dropdown-list-item/header-dropdown-list-item.scss
+++ b/core/src/components/header/header-dropdown-list-item/header-dropdown-list-item.scss
@@ -53,7 +53,7 @@
   border-bottom: 1px solid var(--tds-nav-dropdown-item-border-color);
 }
 
-:host([type='lg']) {
+:host([size='lg']) {
   height: var(--tds-header-height);
 
   ::slotted(a),

--- a/core/src/components/header/header-dropdown-list-item/header-dropdown-list-item.tsx
+++ b/core/src/components/header/header-dropdown-list-item/header-dropdown-list-item.tsx
@@ -14,8 +14,8 @@ export class TdsHeaderDropdownListItem {
   /** If the link should appear selected. */
   @Prop() selected: boolean = false;
 
-  /** The type of the list. */
-  @Prop({ reflect: true }) type: 'md' | 'lg' = 'md';
+  /** The size of the component. */
+  @Prop({ reflect: true }) size: 'md' | 'lg' = 'md';
 
   render() {
     return (

--- a/core/src/components/header/header-dropdown-list-item/readme.md
+++ b/core/src/components/header/header-dropdown-list-item/readme.md
@@ -10,7 +10,7 @@
 | Property   | Attribute  | Description                         | Type           | Default |
 | ---------- | ---------- | ----------------------------------- | -------------- | ------- |
 | `selected` | `selected` | If the link should appear selected. | `boolean`      | `false` |
-| `type`     | `type`     | The type of the list.               | `"lg" \| "md"` | `'md'`  |
+| `size`     | `size`     | The size of the component.          | `"lg" \| "md"` | `'md'`  |
 
 
 ## Slots

--- a/core/src/components/header/header-dropdown-list/header-dropdown-list.scss
+++ b/core/src/components/header/header-dropdown-list/header-dropdown-list.scss
@@ -11,10 +11,10 @@
   padding: 0;
   margin: 0;
   list-style: none;
-  border-radius: none;
+  border-radius: unset;
   background-color: var(--tds-header-app-launcher-menu-bg);
 }
 
-:host([type='lg']) {
+:host([size='lg']) {
   width: 320px;
 }

--- a/core/src/components/header/header-dropdown-list/header-dropdown-list.tsx
+++ b/core/src/components/header/header-dropdown-list/header-dropdown-list.tsx
@@ -15,19 +15,20 @@ export class TdsHeaderDropdownList {
   // A Map to store the slots and their associated slotchange listeners.
   private slotListeners: Map<HTMLSlotElement, EventListener> = new Map();
 
-  @Prop({ reflect: true }) type: 'lg' | 'md' = 'md';
+  /** The size of the component. */
+  @Prop({ reflect: true }) size: 'lg' | 'md' = 'md';
 
   @State() headingElement: HTMLElement;
 
   componentWillLoad() {
     const { children } = this.host;
 
-    // Set the type prop for each child, if they have such a property
+    // Set the size prop for each child, if they have such a property
     for (let i = 0; i < children.length; i++) {
       const child = children[i] as any;
 
-      if ('type' in child) {
-        child.type = this.type;
+      if ('size' in child) {
+        child.size = this.size;
       }
     }
 

--- a/core/src/components/header/header-dropdown-list/readme.md
+++ b/core/src/components/header/header-dropdown-list/readme.md
@@ -7,9 +7,9 @@
 
 ## Properties
 
-| Property | Attribute | Description | Type           | Default |
-| -------- | --------- | ----------- | -------------- | ------- |
-| `type`   | `type`    |             | `"lg" \| "md"` | `'md'`  |
+| Property | Attribute | Description                | Type           | Default |
+| -------- | --------- | -------------------------- | -------------- | ------- |
+| `size`   | `size`    | The size of the component. | `"lg" \| "md"` | `'md'`  |
 
 
 ## Slots

--- a/core/src/components/header/header-launcher-list-item/header-launcher-list-item.tsx
+++ b/core/src/components/header/header-launcher-list-item/header-launcher-list-item.tsx
@@ -12,7 +12,7 @@ export class TdsHeaderLauncherListItem {
   render() {
     return (
       <Host>
-        <tds-header-dropdown-list-item type="lg">
+        <tds-header-dropdown-list-item size="lg">
           <slot></slot>
         </tds-header-dropdown-list-item>
       </Host>

--- a/core/src/components/header/header-launcher-list/header-launcher-list.tsx
+++ b/core/src/components/header/header-launcher-list/header-launcher-list.tsx
@@ -14,7 +14,7 @@ export class TdsHeaderLauncherList {
   render() {
     return (
       <Host>
-        <tds-header-dropdown-list type="lg">
+        <tds-header-dropdown-list size="lg">
           <slot></slot>
         </tds-header-dropdown-list>
       </Host>

--- a/core/src/stories/patterns/navigation/navigation-fewitems.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-fewitems.stories.tsx
@@ -169,7 +169,7 @@ const Template = () =>
 
         <tds-header-dropdown slot="end" placement="end" no-dropdown-icon class="demo-hide demo-lg-show" selected>
           <img slot="icon" src="https://www.svgrepo.com/show/384676/account-avatar-profile-user-6.svg" alt="User menu."/>
-          <tds-header-dropdown-list type="lg">
+          <tds-header-dropdown-list size="lg">
             <tds-header-dropdown-list-user
               header="Name Nameson"
               subheader="Company name">

--- a/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
@@ -79,7 +79,7 @@ const Template = ({ dummyHtml }) =>
           height: calc(100vh - var(--app-bar-height));
           position: sticky;
           top: var(--app-bar-height);
-          left: 0px;
+          left: 0;
         }
       }
 
@@ -139,7 +139,7 @@ const Template = ({ dummyHtml }) =>
       
       <tds-header-dropdown slot="end" placement="end" no-dropdown-icon class="demo-hide demo-xs-show">
         <img slot="icon" src="https://www.svgrepo.com/show/384676/account-avatar-profile-user-6.svg" alt="User menu."/>
-        <tds-header-dropdown-list type="lg">
+        <tds-header-dropdown-list size="lg">
           <tds-header-dropdown-list-user
             header="Name Nameson"
             subheader="Company name">

--- a/core/src/stories/patterns/navigation/navigation-user-menu.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-user-menu.stories.tsx
@@ -88,7 +88,7 @@ const Template = () =>
         
         <tds-header-dropdown slot="end" class="demo-hide demo-xs-show" no-dropdown-icon selected>
           <img slot="icon" src="https://www.svgrepo.com/show/384676/account-avatar-profile-user-6.svg" alt="User menu."/>
-          <tds-header-dropdown-list type="lg">
+          <tds-header-dropdown-list size="lg">
             <tds-header-dropdown-list-user
               header="Name Nameson"
               subheader="Company name">


### PR DESCRIPTION
**Describe pull-request**  
Renaming type prop to size

**Solving issue**  
Fixes: [DTS-2129](https://tegel.atlassian.net/browse/DTS-2129)

**How to test**  
1. Go to Header and Patterns stories in Netlify preview link
2. Check that dropdown and dropdown list items look OK
3. Check if Notes are reflecting renamed props



**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events




[DTS-2129]: https://tegel.atlassian.net/browse/DTS-2129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ