### PR TITLE
tds table built-in filtering did not work with expandable rows

### DIFF
--- a/core/src/components/table/table-body-row-expandable/table-body-row-expandable.scss
+++ b/core/src/components/table/table-body-row-expandable/table-body-row-expandable.scss
@@ -92,6 +92,10 @@
   }
 }
 
+:host(.tds-table__row--hidden) {
+  display: none;
+}
+
 :host(.tds-table--divider) {
   .tds-table__cell--expand {
     border-right: 1px solid var(--tds-table-divider);

--- a/core/src/components/table/table-body/table-body.tsx
+++ b/core/src/components/table/table-body/table-body.tsx
@@ -220,7 +220,7 @@ export class TdsTableBody {
 
   searchFunction(searchTerm) {
     // grab all rows in body
-    const dataRowsFiltering = this.host.querySelectorAll('tds-table-body-row');
+    const dataRowsFiltering = this.host.querySelectorAll('tds-table-body-row, tds-table-body-row-expandable', );
 
     if (searchTerm.length > 0) {
       if (this.enablePaginationTableBody) {


### PR DESCRIPTION
**Describe pull-request**  
tds table built-in filtering did not work with expandable rows. Once the user starts typing into the search box, empty <tr> appears as first row, below the headers. Even if the "no-result-message" is not set, the empty row appears.

**Solving issue**  
included tds-table-body-row-expandable element inside the search function
added hiding style for body-row-expandable.

**How to test**  
1. add expandable rows in tds table
2. test filter functionality in the web browser

**Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [x] Keyboard operability
- [x] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [x] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  
![image](https://github.com/scania-digital-design-system/tegel/assets/8792533/60397c4d-89e5-44b2-9dce-1377a2fa0ea3)

