### PR TITLE
Fix/side menu overlay

### DIFF
--- a/core/src/components/side-menu/side-menu-overlay/side-menu-overlay.scss
+++ b/core/src/components/side-menu/side-menu-overlay/side-menu-overlay.scss
@@ -5,4 +5,5 @@
   background-color: black;
   transition: opacity 0.4s linear;
   opacity: 0;
+  pointer-events: none;
 }

--- a/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
@@ -235,12 +235,15 @@ const Template = ({ dummyHtml }) =>
       </tds-side-menu>
 
       <main class="tds-u-h-100 tds-u-p3" style="box-sizing: border-box;">
+      <tds-button class='tds-u-absolute tds-u-right0 tds-u-pr1' onclick='console.log("Button is clicked!")' text='Test button' size='sm'></tds-button>
         <p>If there are more than a few buttons and/or links in the Header, they might not fit on medium size screens. 
         <br/>In that case they should be placed in a persistent side menu — which is always visible on large screens.</p>
 
         <p><i>Note: The side menu is sticky, and should not scroll with the main content of the page.</i></p>
 
         <p><i>Note: The collapse button is optional.</i></p>
+        
+        
 
         ${dummyHtml}
       </main>


### PR DESCRIPTION
**Describe pull-request**  
Disable clicking behind the overlay

**Solving issue**  
When side-menu-overlay is present, make it impossible to click on elements behind.

**How to test**  
1. Open Patterns, Many Navigation Items
2. Click on button on the screen, console log should fire 
3. Make the screen smaller, open the side menu from the hamburger menu
4. Try to click on the button again, it should not fire

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


