### PR TITLE
fix(chip): double events firing

### DIFF
--- a/core/src/components/chip/chip.tsx
+++ b/core/src/components/chip/chip.tsx
@@ -112,7 +112,7 @@ export class TdsChip {
             }}
           >
             <input type={this.type} id={this.chipId} {...inputAttributes}></input>
-            <label onClick={(event) => event.stopPropagation()} htmlFor={this.chipId}>
+            <label onClick={(event) => event.preventDefault()} htmlFor={this.chipId}>
               {hasPrefixSlot && <slot name="prefix" />}
               {hasLabelSlot && <slot name="label" />}
               {hasSuffixSlot && <slot name="suffix" />}

--- a/core/src/components/chip/chip.tsx
+++ b/core/src/components/chip/chip.tsx
@@ -112,7 +112,7 @@ export class TdsChip {
             }}
           >
             <input type={this.type} id={this.chipId} {...inputAttributes}></input>
-            <label onClick={(event) => event.preventDefault()} htmlFor={this.chipId}>
+            <label onClick={(event) => event.stopPropagation()} htmlFor={this.chipId}>
               {hasPrefixSlot && <slot name="prefix" />}
               {hasLabelSlot && <slot name="label" />}
               {hasSuffixSlot && <slot name="suffix" />}

--- a/core/src/components/chip/chip.tsx
+++ b/core/src/components/chip/chip.tsx
@@ -112,7 +112,7 @@ export class TdsChip {
             }}
           >
             <input type={this.type} id={this.chipId} {...inputAttributes}></input>
-            <label htmlFor={this.chipId}>
+            <label onClick={(event) => event.stopPropagation()} htmlFor={this.chipId}>
               {hasPrefixSlot && <slot name="prefix" />}
               {hasLabelSlot && <slot name="label" />}
               {hasSuffixSlot && <slot name="suffix" />}


### PR DESCRIPTION
**Describe pull-request**  
In the react demo page the onClick event on the tds-chip were being fired twice. This was due to the click on the element was triggering a click on both the label and the input. I have now put a stopPropogation on the onClick event of the label.


**To see the error in action:**
1. Go the the react demo page
2. Go to Chips page
3. Click either of the two first chips
4. See the alert appear twice.

**Solving issue**  
Fixes: [DTS-2176](https://tegel.atlassian.net/browse/DTS-2176)

**How to test**  
1. Checkout branch.
5. Run npm build in tegel/core
6. Run npm pack
7. Run npm install {link to tarball generated by npm pack}
8. Go to the demo page -> chips -> click the chips and se that the alert only appears once.



[DTS-2176]: https://tegel.atlassian.net/browse/DTS-2176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ