### PR TITLE
feat(datetime): min & max props

### DIFF
--- a/core/src/components/datetime/datetime.stories.tsx
+++ b/core/src/components/datetime/datetime.stories.tsx
@@ -67,13 +67,35 @@ export default {
     defaultValue: {
       name: 'Default value',
       description:
-        'Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM.',
+        'Sets max value. Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM.',
       control: {
         type: 'radio',
       },
       options: ['None', 'Custom'],
       table: {
         defaultValue: { summary: 'none' },
+      },
+    },
+    minValue: {
+      description:
+        'Sets min value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"',
+      name: 'Min value',
+      control: {
+        type: 'text',
+      },
+      table: {
+        defaultValue: { summary: undefined },
+      },
+    },
+    maxValue: {
+      description:
+        'Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"',
+      name: 'Max value',
+      control: {
+        type: 'text',
+      },
+      table: {
+        defaultValue: { summary: undefined },
       },
     },
     noMinWidth: {
@@ -117,6 +139,8 @@ export default {
     type: 'Datetime',
     size: 'Large',
     defaultValue: 'None',
+    minValue: '',
+    maxValue: '',
     noMinWidth: false,
     label: 'Label text',
     helper: 'Helper text',
@@ -130,6 +154,8 @@ const datetimeTemplate = ({
   type,
   size,
   defaultValue,
+  minValue,
+  maxValue,
   noMinWidth,
   label,
   helper,
@@ -181,7 +207,9 @@ const datetimeTemplate = ({
       id="datetime"
       ${defaultValue !== 'None' ? `default-value="${getDefaultValue(defaultValue, type)}"` : ''}
       ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}
-      type="${typeLookup[type]}"
+      type="${typeLookup[type]}"      
+      ${minValue ? `min=${minValue}` : ''}
+      ${maxValue ? `min=${maxValue}` : ''}
       size="${sizeLookup[size]}"
       state="${stateLookup[state]}"
       ${disabled ? 'disabled' : ''}

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -10,11 +10,17 @@ export class TdsDatetime {
   /** Text-input for focus state */
   textInput?: HTMLInputElement;
 
-  /** Which input type, text, password or similar */
+  /** Sets input type */
   @Prop({ reflect: true }) type: 'datetime-local' | 'date' | 'time' = 'datetime-local';
 
   /** Value of the input text */
   @Prop({ reflect: true }) value = '';
+
+  /** Sets min value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00" */
+  @Prop() min: string;
+
+  /** Sets max value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00" */
+  @Prop() max: string;
 
   /** Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM */
   @Prop() defaultValue: string | 'none' = 'none';
@@ -175,6 +181,8 @@ export class TdsDatetime {
               type={this.type}
               disabled={this.disabled}
               value={this.value}
+              min={this.min}
+              max={this.max}
               autofocus={this.autofocus}
               name={this.name}
               onInput={(e) => this.handleInput(e)}

--- a/core/src/components/datetime/readme.md
+++ b/core/src/components/datetime/readme.md
@@ -14,12 +14,14 @@
 | `disabled`     | `disabled`      | Set input in disabled state                                                                                             | `boolean`                              | `false`            |
 | `helper`       | `helper`        | Helper text for the component                                                                                           | `string`                               | `''`               |
 | `label`        | `label`         | Label text for the component                                                                                            | `string`                               | `''`               |
+| `max`          | `max`           | Sets max value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"                 | `string`                               | `undefined`        |
+| `min`          | `min`           | Sets min value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"                 | `string`                               | `undefined`        |
 | `modeVariant`  | `mode-variant`  | Set the variant of the Datetime component.                                                                              | `"primary" \| "secondary"`             | `null`             |
 | `name`         | `name`          | Name property                                                                                                           | `string`                               | `''`               |
 | `noMinWidth`   | `no-min-width`  | Resets min width rule                                                                                                   | `boolean`                              | `false`            |
 | `size`         | `size`          | Size of the input                                                                                                       | `"lg" \| "md" \| "sm"`                 | `'lg'`             |
 | `state`        | `state`         | Error state of input                                                                                                    | `string`                               | `undefined`        |
-| `type`         | `type`          | Which input type, text, password or similar                                                                             | `"date" \| "datetime-local" \| "time"` | `'datetime-local'` |
+| `type`         | `type`          | Sets input type                                                                                                         | `"date" \| "datetime-local" \| "time"` | `'datetime-local'` |
 | `value`        | `value`         | Value of the input text                                                                                                 | `string`                               | `''`               |
 
 

--- a/core/src/components/dropdown/readme.md
+++ b/core/src/components/dropdown/readme.md
@@ -1,5 +1,7 @@
 # tds-dropdown
 
+### Good to know
+ - Setting type='time' together with min and max props will not prevent user from set time outside min-max range. It is known issue for native input element. Here is more about it and how to work with it: [Time validation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#validation)
 
 <!-- Auto Generated Below -->
 

--- a/core/src/components/table/table-header-cell/readme.md
+++ b/core/src/components/table/table-header-cell/readme.md
@@ -20,7 +20,7 @@
 
 | Event           | Description                                                                                                                                                          | Type                                                                                      |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
+| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "desc" \| "asc"; }>` |
 
 
 ----------------------------------------------


### PR DESCRIPTION
**Describe pull-request**  
Allowing users to set min and max value in DateTime component

**Solving issue**  
Fixes: [DTS-2179](https://tegel.atlassian.net/browse/DTS-2179)

**How to test**  
1. Go to Netlify preview link
2. Try to set different min/max values in Storybook.
3. Check if works as intended for date and datetime. "time" has issues with limitation even in native HTML component.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Additional context**  
Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"


[DTS-2179]: https://tegel.atlassian.net/browse/DTS-2179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ