### PR TITLE
fix(table): hover on rows

### DIFF
--- a/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -122,8 +122,6 @@ export class TdsTableBodyRowExpandable {
           'tds-table__row-expand--active': this.isExpanded,
           'tds-table__compact': this.compactDesign,
           'tds-table--divider': this.verticalDividers,
-          'tds-mode-variant-primary': this.modeVariant === 'primary',
-          'tds-mode-variant-secondary': this.modeVariant === 'secondary',
         }}
       >
         <tr class="tds-table__row">

--- a/core/src/components/table/table-body-row/table-body-row.scss
+++ b/core/src/components/table/table-body-row/table-body-row.scss
@@ -21,11 +21,11 @@
 }
 
 :host(.tds-table__row--selected) {
-  background-color: var(--tds-table-body-row-background-active);
+  background-color: var(--tds-table-body-row-background-selected);
 }
 
 :host(.tds-table__row--selected:hover) {
-  background-color: var(--tds-table-body-row-background-active-hover);
+  background-color: var(--tds-table-body-row-background-selected-hover);
 }
 
 :host(.tds-table__row--hidden) {

--- a/core/src/components/table/table-body-row/table-body-row.tsx
+++ b/core/src/components/table/table-body-row/table-body-row.tsx
@@ -5,7 +5,6 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
   'multiselect',
   'verticalDividers',
   'compactDesign',
-  'modeVariant',
 ];
 
 /**
@@ -28,8 +27,6 @@ export class TdsTableBodyRow {
   @State() compactDesign: boolean = false;
 
   @State() noMinWidth: boolean = false;
-
-  @State() modeVariant: 'primary' | 'secondary' = null;
 
   @State() tableId: string = '';
 
@@ -129,8 +126,6 @@ export class TdsTableBodyRow {
           'tds-table__row': true,
           'tds-table__compact': this.compactDesign,
           'tds-table--divider': this.verticalDividers,
-          'tds-mode-variant-primary': this.modeVariant === 'primary',
-          'tds-mode-variant-secondary': this.modeVariant === 'secondary',
         }}
       >
         {this.multiselect && (

--- a/core/src/components/table/table-vars.scss
+++ b/core/src/components/table/table-vars.scss
@@ -21,7 +21,7 @@
   }
 
   --tds-table-body-row-background-selected: var(--tds-grey-300);
-  --tds-table-body-row-background-selected-hover: var(--tds-grey-300);
+  --tds-table-body-row-background-selected-hover: var(--tds-grey-400);
 
   /* Table-footer */
   --tds-table-footer-background: var(--tds-grey-100);

--- a/core/src/components/table/table/table.tsx
+++ b/core/src/components/table/table/table.tsx
@@ -111,7 +111,13 @@ export class TdsTable {
 
   render() {
     return (
-      <Host class={{ 'tds-table--responsive': this.responsive }}>
+      <Host
+        class={{
+          'tds-table--responsive': this.responsive,
+          'tds-mode-variant-primary': this.modeVariant === 'primary',
+          'tds-mode-variant-secondary': this.modeVariant === 'secondary',
+        }}
+      >
         <table
           class={{
             'tds-table': true,


### PR DESCRIPTION
**Describe pull-request**  
Tabel rows were missing hover color on its rows when mode-variant was used. 

**Solving issue**  
Fixes: [CDEP-2047](https://tegel.atlassian.net/browse/CDEP-247)

**How to test**  
1. Go to the preview link below
2. Hover over table rows, the background color should change
3. Select mode-variant, hover background color on rows should be present
4. Select the "Multiselect" story, and select one of the rows - it should change the background color as long as it is selected. Also, the background color of it should change on hover. 
5. Do the same test for light and dark mode


**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [x] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Additional context**  
 - In light mode: The hover color is usually one step darker than the regular state of the row. The selected state is one step darker than the hover. 
 - In dark mode: The hover color is usually one step brighter than the regular state of the row. The selected state is one step brighter than the hover. 


[CDEP-2047]: https://tegel.atlassian.net/browse/CDEP-2047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ