### PR TITLE
fix(button): fixed usage of label slot

### DIFF
--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -215,31 +215,33 @@ button {
   justify-content: center;
 }
 
-tds-button:not([only-icon]) {
-  display: inline-flex;
-  align-items: center;
+tds-button {
+  :not(.only-icon) {
+    display: inline-flex;
+    align-items: center;
 
-  .sm {
-    ::slotted([slot='icon']) {
-      margin-left: var(--tds-spacing-element-12);
-      width: var(--tds-spacing-element-16);
-      height: var(--tds-spacing-element-16);
+    &.sm {
+      ::slotted([slot='icon']) {
+        margin-left: var(--tds-spacing-element-12);
+        width: var(--tds-spacing-element-16);
+        height: var(--tds-spacing-element-16);
+      }
     }
-  }
 
-  .md {
-    ::slotted([slot='icon']) {
-      margin-left: var(--tds-spacing-element-16);
-      width: var(--tds-spacing-element-20);
-      height: var(--tds-spacing-element-20);
+    &.md {
+      ::slotted([slot='icon']) {
+        margin-left: var(--tds-spacing-element-16);
+        width: var(--tds-spacing-element-20);
+        height: var(--tds-spacing-element-20);
+      }
     }
-  }
 
-  .lg {
-    ::slotted([slot='icon']) {
-      margin-left: var(--tds-spacing-element-20);
-      width: var(--tds-spacing-element-20);
-      height: var(--tds-spacing-element-20);
+    &.lg {
+      ::slotted([slot='icon']) {
+        margin-left: var(--tds-spacing-element-20);
+        width: var(--tds-spacing-element-20);
+        height: var(--tds-spacing-element-20);
+      }
     }
   }
 }

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -37,17 +37,13 @@ export class TdsButton {
 
   @State() onlyIcon: boolean = false;
 
-  connectedCallback() {
-    if (!this.text) {
-      this.onlyIcon = true;
-      this.host.setAttribute('only-icon', '');
-    }
-  }
-
   render() {
     const hasLabelSlot = hasSlot('label', this.host);
     const hasIconSlot = hasSlot('icon', this.host);
-
+    if (!this.text && !hasLabelSlot) {
+      this.onlyIcon = true;
+      this.host.setAttribute('only-icon', '');
+    }
     return (
       <Host class={`${this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''}`}>
         <button

--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -42,7 +42,6 @@ export class TdsButton {
     const hasIconSlot = hasSlot('icon', this.host);
     if (!this.text && !hasLabelSlot) {
       this.onlyIcon = true;
-      this.host.setAttribute('only-icon', '');
     }
     return (
       <Host class={`${this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''}`}>

--- a/core/src/components/table/table-header-cell/readme.md
+++ b/core/src/components/table/table-header-cell/readme.md
@@ -20,7 +20,7 @@
 
 | Event           | Description                                                                                                                                                          | Type                                                                                      |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
+| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "desc" \| "asc"; }>` |
 
 
 ----------------------------------------------


### PR DESCRIPTION
**Describe pull-request**  
In the check for if it in an only-icon button we also need to check if they are using the slot rather than the text prop.
Before this fix the button would be treated as a only-icon button if they used the label slot.

Note: I have not added any slot/prop toggle in storybook. When testing you need to checkout the branch and implement the slot usage on your own.

**Solving issue**  
Fixes: [CDEP-2196](https://tegel.atlassian.net/browse/CDEP-2196)

**How to test**  
1. Check out branch
2. In story file, use the slot="label" rather than the text prop.
3. See that the button still works as intended.



[CDEP-2196]: https://tegel.atlassian.net/browse/CDEP-2196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ