### PR TITLE
fix(button): added variable for active state on slotted icon

### DIFF
--- a/core/src/components/button/button-vars.scss
+++ b/core/src/components/button/button-vars.scss
@@ -44,6 +44,8 @@
   --tds-btn-secondary-border-color-disabled: rgb(0 0 0 / 38%);
   --tds-btn-icon-secondary-color-focus: var(--tds-black);
   --tds-btn-icon-secondary-fill-focus: var(--tds-black);
+  --tds-btn-icon-secondary-fill-active: var(--tds-black);
+  --tds-btn-icon-secondary-fill-active: var(--tds-black);
 
   /* ICON */ //not used
   --tds-btn-icon-secondary-fill: var(--tds-black);
@@ -52,6 +54,10 @@
   /* ICON HOVER */ //not used
   --tds-btn-icon-secondary-fill-hover: var(--tds-grey-50);
   --tds-btn-icon-secondary-color-hover: var(--tds-grey-50);
+
+  /* ICON HOVER */ //not used
+  --tds-btn-icon-secondary-fill-active: var(--tds-black);
+  --tds-btn-icon-secondary-color-active: var(--tds-black);
 
   //Ghost
   --tds-btn-ghost-background: transparent;

--- a/core/src/components/button/button.scss
+++ b/core/src/components/button/button.scss
@@ -172,6 +172,15 @@ button {
         @each $prop in $props {
           #{$prop}: var(--tds-btn-#{$type}-#{$prop}-active);
         }
+
+        &:not(.disabled) {
+          ::slotted([slot='icon']) {
+            @each $prop in $iconProps {
+              fill: var(--tds-btn-icon-#{$type}-#{$prop}-active);
+              color: var(--tds-btn-icon-#{$type}-#{$prop}-active);
+            }
+          }
+        }
       }
 
       &.disabled,


### PR DESCRIPTION
**Describe pull-request**  
Added a variable for the slotted icon on active state of button. This was previously getting overridden by the hover state of the slotted icon.

**Solving issue**  
Fixes: [CDEP-1982](https://tegel.atlassian.net/browse/CDEP-1982)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Button
3. Set it to use secondary variant.
4. Click the button and make sure the icon is the correct color when it is being clicked.



[CDEP-1982]: https://tegel.atlassian.net/browse/CDEP-1982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ