### PR TITLE
fix(toast): link component colors

### DIFF
--- a/core/src/components/link/link-vars.scss
+++ b/core/src/components/link/link-vars.scss
@@ -5,6 +5,14 @@
   --tds-link-focus: var(--tds-blue-400);
   --tds-link-visited: var(--tds-grey-900);
   --tds-link-disabled: var(--tds-grey-400);
+
+  tds-toast {
+    --tds-link: var(--tds-blue-300);
+    --tds-link-hover: var(--tds-blue-400);
+    --tds-link-focus: var(--tds-blue-400);
+    --tds-link-visited: var(--tds-blue-100);
+    --tds-link-disabled: var(--tds-grey-800);
+  }
 }
 
 .tds-mode-dark {
@@ -13,4 +21,12 @@
   --tds-link-focus: var(--tds-blue-400);
   --tds-link-visited: var(--tds-blue-100);
   --tds-link-disabled: var(--tds-grey-800);
+
+  tds-toast {
+    --tds-link: var(--tds-blue-500);
+    --tds-link-hover: var(--tds-blue-400);
+    --tds-link-focus: var(--tds-blue-400);
+    --tds-link-visited: var(--tds-grey-900);
+    --tds-link-disabled: var(--tds-grey-400);
+  }
 }

--- a/core/src/components/toast/toast.scss
+++ b/core/src/components/toast/toast.scss
@@ -97,7 +97,6 @@
 
     .subheader,
     slot[name='subheader']::slotted(*) {
-      margin-top: 4px;
       color: var(--tds-toast-subheadline-color);
       font: var(--tds-detail-02);
       letter-spacing: var(--tds-detail-02-ls);
@@ -114,13 +113,7 @@
     }
 
     .toast-bottom {
-      &.subheader {
-        margin-top: 16px;
-      }
-
-      &.no-subheader {
-        margin-top: 4px;
-      }
+      margin-top: 12px;
     }
   }
 

--- a/core/src/components/toast/toast.stories.tsx
+++ b/core/src/components/toast/toast.stories.tsx
@@ -61,9 +61,9 @@ export default {
     header: 'Header',
     subheader: 'Subheader',
     bottom:
-      '<tds-link slot="bottom">\n' +
-      '    <a href="https://tegel.scania.com/home" target="_blank">Tegel</a>\n' +
-      '</tds-link>',
+      `<tds-link slot="bottom">
+          <a href="https://tegel.scania.com/home" target="_blank">Tegel</a>
+      </tds-link>`,
   },
 };
 

--- a/core/src/components/toast/toast.stories.tsx
+++ b/core/src/components/toast/toast.stories.tsx
@@ -60,7 +60,10 @@ export default {
     variant: 'Information',
     header: 'Header',
     subheader: 'Subheader',
-    bottom: '<a slot="bottom" href="#">This is a link.</a>',
+    bottom:
+      '<tds-link slot="bottom">\n' +
+      '    <a href="https://tegel.scania.com/home" target="_blank">Tegel</a>\n' +
+      '</tds-link>',
   },
 };
 


### PR DESCRIPTION
**Describe pull-request**  
The Link component in the Toast component has to have revert logic when it comes to dark and light mode due to the background color used in the Toast component itself. To clarify, the Toast component in Light mode is using a dark background and an opposite one for light, therefore we need to have a "switch" so the Link component looks good in both versions of the component.  

**Solving issue**  
Fixes: [CDEP-2159](https://tegel.atlassian.net/browse/CDEP-2159)

**How to test**  
1. Go to the Netlify preview link
2. Check the Toast component
3. Inspect the colors of the Link component - in Light mode for the Toast component Link should use its colors for Dark mode and vice versa.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [x] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Note**
The current Link component is OK to use in Toast. The link component will soon have an update from the design side so Charlotte's comment about the Link component not having an underline on hover will soon be updated.
The spacing is updated to reflect upcoming changes in Figma too. 




[CDEP-2159]: https://tegel.atlassian.net/browse/CDEP-2159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ