### PR TITLE
fix(tabs): clickarea should cover entire tab

### DIFF
--- a/core/src/components/tabs/folder-tabs/folder-tab/folder-tab.scss
+++ b/core/src/components/tabs/folder-tabs/folder-tab/folder-tab.scss
@@ -25,6 +25,10 @@
     border-left-color: transparent;
   }
 
+  ::slotted(*:focus-visible) {
+    @include tds-focus-state;
+  }
+
   div:not(.selected) {
     background-color: var(--tds-folder-tab-background);
 

--- a/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
+++ b/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
@@ -21,7 +21,7 @@
     background-color: transparent;
     border: 0;
     width: 100%;
-    margin: 20px 4px;
+    padding: 20px 4px;
   }
 
   ::slotted(*:focus-visible) {

--- a/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
+++ b/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
@@ -56,7 +56,7 @@
   .inline-tab-item::after {
     content: ' ';
     position: absolute;
-    bottom: -20px;
+    bottom: 0;
     right: 0;
     left: 0;
     margin-left: auto;

--- a/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
+++ b/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
@@ -7,6 +7,7 @@
 
   z-index: tds-z-index(tab);
   display: block;
+  position: relative;
 
   ::slotted(*) {
     all: unset;
@@ -24,8 +25,14 @@
     padding: 20px 4px;
   }
 
-  ::slotted(*:focus-visible) {
-    @include tds-focus-state;
+  ::slotted(*:focus-visible)::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 20px;
+    bottom: 20px;
+    outline: 2px solid var(--tds-blue-400);
   }
 
   .inline-tab-item:not(.selected)::after {

--- a/core/src/components/tabs/inline-tabs/inline-tabs.stories.tsx
+++ b/core/src/components/tabs/inline-tabs/inline-tabs.stories.tsx
@@ -58,31 +58,21 @@ export default {
       options: ['None', 0, 1, 2, 3],
       if: { arg: 'defaultSelectedIndex', eq: 'None' },
     },
-    tabType: {
-      name: 'Button/Link',
-      control: {
-        type: 'radio',
-      },
-      options: ['Button', 'Link'],
-    },
   },
   args: {
     modeVariant: 'Inherit from parent',
     defaultSelectedIndex: 'None',
     selectedIndex: 'None',
-    tabType: 'Button',
   },
 };
 
-const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex, tabType }) =>
+const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex }) =>
   formatHtmlPreview(`
   <tds-inline-tabs
     ${defaultSelectedIndex !== 'None' ? `default-selected-index="${defaultSelectedIndex}"` : ''}
     ${selectedIndex && selectedIndex !== 'None' ? `selected-index="${selectedIndex}"` : ''}
     ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}>
-    ${
-      tabType === 'Button'
-        ? `<tds-inline-tab>
+    <tds-inline-tab>
       <button>First tab</button>
     </tds-inline-tab>
     <tds-inline-tab>
@@ -93,21 +83,7 @@ const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex, tabType })
     </tds-inline-tab>
     <tds-inline-tab disabled>
       <button>Fourth tab</button>
-    </tds-inline-tab>`
-        : `<tds-inline-tab>
-      <a href="#">First tab</a>
     </tds-inline-tab>
-    <tds-inline-tab>
-      <a href="#">Second tab is much longer</a>
-    </tds-inline-tab>
-    <tds-inline-tab>
-      <a href="#">Third tab</a>
-    </tds-inline-tab>
-    <tds-inline-tab disabled>
-      <a href="#">Fourth tab</a>
-    </tds-inline-tab>`
-    }
-      
    </tds-inline-tabs>
 
    <!-- Demo container. -->

--- a/core/src/components/tabs/inline-tabs/inline-tabs.stories.tsx
+++ b/core/src/components/tabs/inline-tabs/inline-tabs.stories.tsx
@@ -58,32 +58,56 @@ export default {
       options: ['None', 0, 1, 2, 3],
       if: { arg: 'defaultSelectedIndex', eq: 'None' },
     },
+    tabType: {
+      name: 'Button/Link',
+      control: {
+        type: 'radio',
+      },
+      options: ['Button', 'Link'],
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
     defaultSelectedIndex: 'None',
     selectedIndex: 'None',
+    tabType: 'Button',
   },
 };
 
-const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex }) =>
+const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex, tabType }) =>
   formatHtmlPreview(`
   <tds-inline-tabs
     ${defaultSelectedIndex !== 'None' ? `default-selected-index="${defaultSelectedIndex}"` : ''}
     ${selectedIndex && selectedIndex !== 'None' ? `selected-index="${selectedIndex}"` : ''}
     ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}>
-      <tds-inline-tab>
-        <button>First tab</button>
-      </tds-inline-tab>
-      <tds-inline-tab>
-        <button>Second tab is much longer</button>
-      </tds-inline-tab>
-      <tds-inline-tab>
-        <button>Third tab</button>
-      </tds-inline-tab>
-      <tds-inline-tab disabled>
-        <button>Fourth tab</button>
-      </tds-inline-tab>
+    ${
+      tabType === 'Button'
+        ? `<tds-inline-tab>
+      <button>First tab</button>
+    </tds-inline-tab>
+    <tds-inline-tab>
+      <button>Second tab is much longer</button>
+    </tds-inline-tab>
+    <tds-inline-tab>
+      <button>Third tab</button>
+    </tds-inline-tab>
+    <tds-inline-tab disabled>
+      <button>Fourth tab</button>
+    </tds-inline-tab>`
+        : `<tds-inline-tab>
+      <a href="#">First tab</a>
+    </tds-inline-tab>
+    <tds-inline-tab>
+      <a href="#">Second tab is much longer</a>
+    </tds-inline-tab>
+    <tds-inline-tab>
+      <a href="#">Third tab</a>
+    </tds-inline-tab>
+    <tds-inline-tab disabled>
+      <a href="#">Fourth tab</a>
+    </tds-inline-tab>`
+    }
+      
    </tds-inline-tabs>
 
    <!-- Demo container. -->

--- a/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
+++ b/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
@@ -21,7 +21,7 @@
     background-color: transparent;
     border: 0;
     width: 100%;
-    margin: 26px 4px;
+    padding: 26px 4px;
   }
 
   ::slotted(*:focus-visible) {

--- a/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
+++ b/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
@@ -55,7 +55,7 @@
   .navigation-tab-item::after {
     content: ' ';
     position: absolute;
-    bottom: -26px;
+    bottom: 0;
     right: 0;
     left: 0;
     margin-left: auto;

--- a/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
+++ b/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
@@ -24,8 +24,14 @@
     padding: 26px 4px;
   }
 
-  ::slotted(*:focus-visible) {
-    @include tds-focus-state;
+  ::slotted(*:focus-visible)::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 26px;
+    bottom: 26px;
+    outline: 2px solid var(--tds-blue-400);
   }
 
   .navigation-tab-item:not(.selected)::after {

--- a/core/src/components/tabs/navigation-tabs/navigation-tabs.stories.tsx
+++ b/core/src/components/tabs/navigation-tabs/navigation-tabs.stories.tsx
@@ -58,22 +58,44 @@ export default {
       options: ['None', 0, 1, 2, 3],
       if: { arg: 'defaultSelectedIndex', eq: 'None' },
     },
+    tabType: {
+      name: 'Button/Link',
+      control: {
+        type: 'radio',
+      },
+      options: ['Button', 'Link'],
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
     defaultSelectedIndex: 'None',
     selectedIndex: 'None',
+    tabType: 'Button',
   },
 };
 
-const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex }) =>
+const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex, tabType }) =>
   formatHtmlPreview(`
     <tds-navigation-tabs
       ${defaultSelectedIndex !== 'None' ? `default-selected-index="${defaultSelectedIndex}"` : ''}
       ${selectedIndex && selectedIndex !== 'None' ? `selected-index="${selectedIndex}"` : ''}
       ${modeVariant !== 'Inherit from parent' ? ` mode-variant="${modeVariant.toLowerCase()}"` : ''}
     >
+    ${
+      tabType === 'Button'
+        ? `<tds-navigation-tab>
+        <button>First tab</button>
+      </tds-navigation-tab>
       <tds-navigation-tab>
+        <button>Second tab is much longer</button>
+      </tds-navigation-tab>
+      <tds-navigation-tab>
+        <button>Third tab</button>
+      </tds-navigation-tab>
+      <tds-navigation-tab disabled>
+        <button>Fourth tab</button>
+      </tds-navigation-tab>`
+        : `<tds-navigation-tab>
         <a href="#">First tab</a>
       </tds-navigation-tab>
       <tds-navigation-tab>
@@ -83,8 +105,9 @@ const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex }) =>
         <a href="#">Third tab</a>
       </tds-navigation-tab>
       <tds-navigation-tab disabled>
-        <a href="javascript:void(0)">Fourth tab</a>
-      </tds-navigation-tab>
+        <a href="#">Fourth tab</a>
+      </tds-navigation-tab>`
+    }
     </tds-navigation-tabs>
 
     <!-- Demo container. -->

--- a/core/src/components/tabs/navigation-tabs/navigation-tabs.stories.tsx
+++ b/core/src/components/tabs/navigation-tabs/navigation-tabs.stories.tsx
@@ -58,32 +58,22 @@ export default {
       options: ['None', 0, 1, 2, 3],
       if: { arg: 'defaultSelectedIndex', eq: 'None' },
     },
-    tabType: {
-      name: 'Button/Link',
-      control: {
-        type: 'radio',
-      },
-      options: ['Button', 'Link'],
-    },
   },
   args: {
     modeVariant: 'Inherit from parent',
     defaultSelectedIndex: 'None',
     selectedIndex: 'None',
-    tabType: 'Button',
   },
 };
 
-const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex, tabType }) =>
+const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex }) =>
   formatHtmlPreview(`
     <tds-navigation-tabs
       ${defaultSelectedIndex !== 'None' ? `default-selected-index="${defaultSelectedIndex}"` : ''}
       ${selectedIndex && selectedIndex !== 'None' ? `selected-index="${selectedIndex}"` : ''}
       ${modeVariant !== 'Inherit from parent' ? ` mode-variant="${modeVariant.toLowerCase()}"` : ''}
     >
-    ${
-      tabType === 'Button'
-        ? `<tds-navigation-tab>
+      <tds-navigation-tab>
         <button>First tab</button>
       </tds-navigation-tab>
       <tds-navigation-tab>
@@ -94,20 +84,7 @@ const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex, tabType })
       </tds-navigation-tab>
       <tds-navigation-tab disabled>
         <button>Fourth tab</button>
-      </tds-navigation-tab>`
-        : `<tds-navigation-tab>
-        <a href="#">First tab</a>
       </tds-navigation-tab>
-      <tds-navigation-tab>
-        <a href="#">Second tab is much longer</a>
-      </tds-navigation-tab>
-      <tds-navigation-tab>
-        <a href="#">Third tab</a>
-      </tds-navigation-tab>
-      <tds-navigation-tab disabled>
-        <a href="#">Fourth tab</a>
-      </tds-navigation-tab>`
-    }
     </tds-navigation-tabs>
 
     <!-- Demo container. -->


### PR DESCRIPTION
**Describe pull-request**  
Refactored the tabs to include the entire slotted item as a clickable area, due to focus state this had to be done using a pseudo element.

**Solving issue**  
Fixes: [CDEP-2226](https://tegel.atlassian.net/browse/CDEP-2226)

**How to test**  
1. Go to Tabs
2. Check in Folder/Inline/Navigation tabs
3. Make sure the clickable area is the entire tab.
4. Change from Button to Link in the controls.
5. Make sure the clickable area is the entire tab.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events



[CDEP-2226]: https://tegel.atlassian.net/browse/CDEP-2226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ