### PR TITLE
fix(side-menu): removed open/close animation

### DIFF
--- a/core/src/components/side-menu/side-menu-close-button/side-menu-close-button.scss
+++ b/core/src/components/side-menu/side-menu-close-button/side-menu-close-button.scss
@@ -1,7 +1,4 @@
 :host {
-  opacity: 0;
-  transition: opacity 0.15s ease;
-
   button {
     height: 64px;
     width: 100%;

--- a/core/src/components/side-menu/side-menu-overlay/side-menu-overlay.scss
+++ b/core/src/components/side-menu/side-menu-overlay/side-menu-overlay.scss
@@ -3,8 +3,6 @@
   width: 100%;
   height: 100%;
   background-color: black;
-  transition: opacity 0.4s linear;
-  opacity: 0;
 }
 
 div {

--- a/core/src/components/side-menu/side-menu.scss
+++ b/core/src/components/side-menu/side-menu.scss
@@ -43,10 +43,6 @@
     slot[name='close-button']::slotted(tds-side-menu-close-button) {
       opacity: 1;
     }
-
-    .tds-side-menu-wrapper {
-      transform: scaleY(1);
-    }
   }
 
   .state-upper-slot-empty {
@@ -87,10 +83,6 @@
 
       slot[name='close-button']::slotted(tds-side-menu-close-button) {
         display: none;
-      }
-
-      .tds-side-menu-wrapper {
-        transform: none;
       }
     }
 
@@ -145,10 +137,6 @@ aside {
     flex-direction: column;
     flex-grow: 1;
     background-color: var(--tds-sidebar-side-menu-background-cover);
-    transition: transform 250ms ease;
-    transform-origin: top;
-    transform: scaleY(0);
-
     @include tds-scrollbar;
 
     overflow-y: auto;

--- a/core/src/components/side-menu/side-menu.stories.tsx
+++ b/core/src/components/side-menu/side-menu.stories.tsx
@@ -214,11 +214,11 @@ const Template = ({ persistent, collapsible }) =>
   </div>
   <script>
     sideMenu = document.querySelector('tds-side-menu')
-    document.querySelector('#test').addEventListener('click', ()=> {
+    document.querySelector('#test')?.addEventListener('click', ()=> {
       sideMenu.collapsed = !sideMenu.collapsed;
     })
 
-    document.querySelector('tds-side-menu-collapse-button').addEventListener('tdsCollapse', (event) => {
+    document.querySelector('tds-side-menu-collapse-button')?.addEventListener('tdsCollapse', (event) => {
       console.log(event)
     })
   </script>


### PR DESCRIPTION
**Describe pull-request**  
Removed all animation when opening/closing the side menu.


**Solving issue**  
Fixes: [CDEP-2195](https://tegel.atlassian.net/browse/CDEP-2195)

**How to test**  
1. Go to storybook
2. Check in Side Menu
3. Try opening and closing the side menu (mobile)



[CDEP-2195]: https://tegel.atlassian.net/browse/CDEP-2195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ