### PR TITLE
fix(datetime): corrected secondary mode variant

### DIFF
--- a/core/src/components/datetime/datetime-vars.scss
+++ b/core/src/components/datetime/datetime-vars.scss
@@ -1,8 +1,6 @@
 :root,
 .tds-mode-light {
   --tds-datetime-color: var(--tds-grey-868);
-  --tds-datetime-background-primary: var(--tds-grey-50);
-  --tds-datetime-background-secondary: var(--tds-white);
   --tds-datetime-background: var(--tds-datetime-background-primary);
   --tds-datetime-icon: var(--tds-grey-868);
   --tds-datetime-border-bottom: var(--tds-grey-400);
@@ -42,12 +40,18 @@
 
   // Prefix and Suffix
   --tds-datetime-ps-color: var(--tds-grey-600);
+
+  .tds-mode-variant-primary {
+    --tds-datetime-background: var(--tds-grey-50);
+  }
+
+  .tds-mode-variant-secondary {
+    --tds-datetime-background: var(--tds-white);
+  }
 }
 
 .tds-mode-dark {
   --tds-datetime-color: var(--tds-grey-600);
-  --tds-datetime-background-primary: var(--tds-grey-900);
-  --tds-datetime-background-secondary: var(--tds-grey-868);
   --tds-datetime-background: var(--tds-datetime-background-primary);
   --tds-datetime-icon: var(--tds-grey-50);
   --tds-datetime-border-bottom: var(--tds-grey-600);
@@ -88,4 +92,12 @@
 
   // Prefix and Suffix
   --tds-datetime-ps-color: var(--tds-grey-600);
+
+  .tds-mode-variant-primary {
+    --tds-datetime-background: var(--tds-grey-900);
+  }
+
+  .tds-mode-variant-secondary {
+    --tds-datetime-background: var(--tds-grey-868);
+  }
 }

--- a/core/src/components/datetime/datetime-vars.scss
+++ b/core/src/components/datetime/datetime-vars.scss
@@ -1,7 +1,7 @@
 :root,
 .tds-mode-light {
   --tds-datetime-color: var(--tds-grey-868);
-  --tds-datetime-background: var(--tds-datetime-background-primary);
+  --tds-datetime-background: var(--tds-grey-50);
   --tds-datetime-icon: var(--tds-grey-868);
   --tds-datetime-border-bottom: var(--tds-grey-400);
   --tds-datetime-placeholder: var(--tds-grey-500);
@@ -52,7 +52,7 @@
 
 .tds-mode-dark {
   --tds-datetime-color: var(--tds-grey-600);
-  --tds-datetime-background: var(--tds-datetime-background-primary);
+  --tds-datetime-background: var(--tds-grey-900);
   --tds-datetime-icon: var(--tds-grey-50);
   --tds-datetime-border-bottom: var(--tds-grey-600);
   --tds-datetime-placeholder: var(--tds-grey-500);

--- a/core/src/components/datetime/datetime.scss
+++ b/core/src/components/datetime/datetime.scss
@@ -377,11 +377,3 @@ input[type='time']::-webkit-inner-spin-button,
 input[type='time']::-webkit-calendar-picker-indicator {
   opacity: 0;
 }
-
-.tds-mode-variant-primary {
-  --tds-datetime-background: var(--tds-datetime-background-primary);
-}
-
-.tds-mode-variant-secondary {
-  --tds-datetime-background: var(--tds-datetime-background-secondary);
-}

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -165,8 +165,7 @@ export class TdsDatetime {
             ? `tds-form-datetime-${this.state}`
             : ''
         }
-        ${this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''}
-        `}
+        ${this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''}`}
       >
         {this.label && (
           <label htmlFor={this.name} class="tds-datetime-label">


### PR DESCRIPTION
**Describe pull-request**  
The datetime had a different implementation of primary/secondary mode which led to some unexpected behaviour in our demo page. 

If the element did not have a pop of mode-variant it could not inherit the mode-variant from outside of the component.

You can view the issue by checking out the main branch of tegel-react-demo -> in the FormPage.tsx remove all inline setting of mode-variant="secondary" and then toggle the mode-variant.

<img width="1211" alt="Screenshot 2023-08-28 at 16 51 55" src="https://github.com/scania-digital-design-system/tegel/assets/62651103/bf23d2b7-2d10-4740-aa19-8ac2e9b01424">


**Solving issue**  
Fixes: [CDEP-2416](https://tegel.atlassian.net/browse/CDEP-2416)

**How to test** 
1. Check the form on [this](https://github.com/scania-digital-design-system/tegel-react-demo/pull/126) page and toggle the primary/secondary mode-variants

**NOTE**
It is only the inital input that should change, not the background of the opened datetime component.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


[CDEP-2416]: https://tegel.atlassian.net/browse/CDEP-2416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ