### PR TITLE
fix(icon): set height/width of svg based on size prop

### DIFF
--- a/core/src/components/icon/icon.scss
+++ b/core/src/components/icon/icon.scss
@@ -11,8 +11,6 @@
   line-height: 0;
 
   svg {
-    height: 1em;
-    width: 1em;
     fill: currentcolor;
   }
 }

--- a/core/src/components/icon/icon.tsx
+++ b/core/src/components/icon/icon.tsx
@@ -43,6 +43,8 @@ export class Icon {
             aria-labelledby={`icon ${element.name}`}
             role="img"
             style={{ fontSize: this.size }}
+            height={this.size}
+            width={this.size}
           >
             <title>{`icon ${element.name}`}</title>
             <path fill="currentColor" d={element.definition} />

--- a/core/src/components/side-menu/side-menu.stories.tsx
+++ b/core/src/components/side-menu/side-menu.stories.tsx
@@ -153,20 +153,20 @@ const Template = ({ persistent, collapsible }) =>
 
         <tds-side-menu-item>
           <button>
-            <tds-icon name="timer" size="24"></tds-icon>
+            <tds-icon name="timer" size="24px"></tds-icon>
             About us
           </button>
         </tds-side-menu-item>
 
         <tds-side-menu-item>
           <button>
-            <tds-icon name="truck" size="24"></tds-icon>
+            <tds-icon name="truck" size="24px"></tds-icon>
             Trucks
           </button>
         </tds-side-menu-item>
 
         <tds-side-menu-dropdown default-open selected>
-          <tds-icon slot="button-icon" name="profile" size="24"></tds-icon>
+          <tds-icon slot="button-icon" name="profile" size="24px"></tds-icon>
           <span slot="button-label">
             Wheel types
           </span>
@@ -186,7 +186,7 @@ const Template = ({ persistent, collapsible }) =>
 
         <tds-side-menu-item>
           <button>
-            <tds-icon name="star" size="24"></tds-icon>
+            <tds-icon name="star" size="24px"></tds-icon>
             Values
           </button>
         </tds-side-menu-item>


### PR DESCRIPTION
**Describe pull-request**  
The icon size was unable to change in firefox. This was due to the scss file setting the height/width of the icon to always be 1em (16px).

**Solving issue**  
Fixes: [CDEP-2427](https://tegel.atlassian.net/browse/CDEP-2427)

**How to test**  
1. Open the previewlink in firefox and chrome
2. Go to Side Menu
3. Make sure the icons are the same size.
4. Go to Icons
5. Try changing the size of the icon with the control.
6. Make sure it changes.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  
<img width="1047" alt="Screenshot 2023-08-30 at 10 45 47" src="https://github.com/scania-digital-design-system/tegel/assets/62651103/43c6e108-6d10-45cc-a72e-5c012ed6b5aa">


[CDEP-2427]: https://tegel.atlassian.net/browse/CDEP-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ