### PR TITLE
fix(side menu): collapsed scroll

### DIFF
--- a/core/src/components/side-menu/side-menu-item/side-menu-item.scss
+++ b/core/src/components/side-menu/side-menu-item/side-menu-item.scss
@@ -55,6 +55,7 @@
         display: flex;
         justify-content: center;
         align-items: center;
+        position: relative;
       }
     }
 


### PR DESCRIPTION
**Describe pull-request**  
Added position relative to allow for underlying item to position themself absolute, and to keep correct position on scroll.

**Solving issue**  
Fixes: [CDEP-2433](https://tegel.atlassian.net/browse/CDEP-2433)

**How to test**  
1. Go to Side Menu
2. Create vertical scroll on side menu (in collapsed state)
3. Make sure the icons/buttons are positioned correctly.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


[CDEP-2433]: https://tegel.atlassian.net/browse/CDEP-2433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ