### PR TITLE
fix(side menu): slot name

### DIFF
--- a/core/src/components/header/header-dropdown/header-dropdown.tsx
+++ b/core/src/components/header/header-dropdown/header-dropdown.tsx
@@ -15,7 +15,7 @@ export class TdsHeaderDropdown {
   @Element() host: HTMLElement;
 
   /** The label of the button that opens the dropdown.
-   * This is an alternative to the button-label slot. */
+   * This is an alternative to the label slot. */
   @Prop() label: string;
 
   /** If the dropdown icon (downwards chevron) should be hidden. */

--- a/core/src/components/header/header-dropdown/readme.md
+++ b/core/src/components/header/header-dropdown/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property         | Attribute          | Description                                                                                       | Type      | Default     |
-| ---------------- | ------------------ | ------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `label`          | `label`            | The label of the button that opens the dropdown. This is an alternative to the button-label slot. | `string`  | `undefined` |
-| `noDropdownIcon` | `no-dropdown-icon` | If the dropdown icon (downwards chevron) should be hidden.                                        | `boolean` | `false`     |
-| `selected`       | `selected`         | If the button that opens the dropdown should appear selected.                                     | `boolean` | `false`     |
+| Property         | Attribute          | Description                                                                                | Type      | Default     |
+| ---------------- | ------------------ | ------------------------------------------------------------------------------------------ | --------- | ----------- |
+| `label`          | `label`            | The label of the button that opens the dropdown. This is an alternative to the label slot. | `string`  | `undefined` |
+| `noDropdownIcon` | `no-dropdown-icon` | If the dropdown icon (downwards chevron) should be hidden.                                 | `boolean` | `false`     |
+| `selected`       | `selected`         | If the button that opens the dropdown should appear selected.                              | `boolean` | `false`     |
 
 
 ## Slots

--- a/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
+++ b/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
@@ -33,7 +33,7 @@ export class TdsSideMenuDropdownListItem {
   componentDidLoad() {
     const dropdownEl = this.host.closest('tds-side-menu-dropdown');
     const dropdownBtnIconSlotEl = dropdownEl.shadowRoot.querySelector(
-      'slot[name="button-icon"]',
+      'slot[name="icon"]',
     ) as HTMLSlotElement;
     const btnIconSlottedEls = dropdownBtnIconSlotEl.assignedElements();
     const hasBtnIcon = btnIconSlottedEls?.length > 0;

--- a/core/src/components/side-menu/side-menu-dropdown/readme.md
+++ b/core/src/components/side-menu/side-menu-dropdown/readme.md
@@ -7,20 +7,20 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                                                                       | Type      | Default     |
-| ------------- | -------------- | ------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `buttonLabel` | `button-label` | The label of the button that opens the dropdown. This is an alternative to the button-label slot. | `string`  | `undefined` |
-| `defaultOpen` | `default-open` | If the dropdown should be open from the start.                                                    | `boolean` | `false`     |
-| `selected`    | `selected`     | If the button that opens the dropdown should appear selected.                                     | `boolean` | `false`     |
+| Property      | Attribute      | Description                                                                                | Type      | Default     |
+| ------------- | -------------- | ------------------------------------------------------------------------------------------ | --------- | ----------- |
+| `buttonLabel` | `button-label` | The label of the button that opens the dropdown. This is an alternative to the label slot. | `string`  | `undefined` |
+| `defaultOpen` | `default-open` | If the dropdown should be open from the start.                                             | `boolean` | `false`     |
+| `selected`    | `selected`     | If the button that opens the dropdown should appear selected.                              | `boolean` | `false`     |
 
 
 ## Slots
 
-| Slot             | Description                                                                                      |
-| ---------------- | ------------------------------------------------------------------------------------------------ |
-| `"<default>"`    | <b>Unnamed slot.</b> For injection of the <code>tds-side-menu-dropdown-list</code> subcomponent. |
-| `"button-icon"`  | Used for injecting the icon that compliments the dropdown title                                  |
-| `"button-label"` | Used for injecting the text, aka dropdown title                                                  |
+| Slot          | Description                                                                                      |
+| ------------- | ------------------------------------------------------------------------------------------------ |
+| `"<default>"` | <b>Unnamed slot.</b> For injection of the <code>tds-side-menu-dropdown-list</code> subcomponent. |
+| `"icon"`      | Used for injecting the icon that compliments the dropdown title                                  |
+| `"label"`     | Used for injecting the text, aka dropdown title                                                  |
 
 
 ## Dependencies

--- a/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -2,8 +2,8 @@ import { Component, Element, Fragment, h, Host, Listen, Prop, State } from '@ste
 import { CollapseEvent } from '../side-menu';
 
 /**
- * @slot button-icon - Used for injecting the icon that compliments the dropdown title
- * @slot button-label - Used for injecting the text, aka dropdown title
+ * @slot icon - Used for injecting the icon that compliments the dropdown title
+ * @slot label - Used for injecting the text, aka dropdown title
  * @slot <default> - <b>Unnamed slot.</b> For injection of the <code>tds-side-menu-dropdown-list</code> subcomponent.
  * */
 @Component({
@@ -18,7 +18,7 @@ export class TdsSideMenuDropdown {
   @Prop() defaultOpen: boolean = false;
 
   /** The label of the button that opens the dropdown.
-   * This is an alternative to the button-label slot. */
+   * This is an alternative to the label slot. */
   @Prop() buttonLabel: string;
 
   /** If the button that opens the dropdown should appear selected. */
@@ -99,11 +99,11 @@ export class TdsSideMenuDropdown {
             }}
           >
             <button>
-              <slot name="button-icon"></slot>
+              <slot name="icon"></slot>
               {!this.collapsed && (
                 <Fragment>
                   {this.buttonLabel}
-                  <slot name="button-label"></slot>
+                  <slot name="label"></slot>
                   <tds-icon class="dropdown-icon" name="chevron_down" size="16px"></tds-icon>
                 </Fragment>
               )}
@@ -113,7 +113,7 @@ export class TdsSideMenuDropdown {
             {this.collapsed && (
               <h3 class="heading-collapsed">
                 {this.buttonLabel}
-                <slot name="button-label"></slot>
+                <slot name="label"></slot>
               </h3>
             )}
             <slot></slot>

--- a/core/src/components/side-menu/side-menu.stories.tsx
+++ b/core/src/components/side-menu/side-menu.stories.tsx
@@ -166,8 +166,8 @@ const Template = ({ persistent, collapsible }) =>
         </tds-side-menu-item>
 
         <tds-side-menu-dropdown default-open selected>
-          <tds-icon slot="button-icon" name="profile" size="24px"></tds-icon>
-          <span slot="button-label">
+          <tds-icon slot="icon" name="profile" size="24px"></tds-icon>
+          <span slot="label">
             Wheel types
           </span>
           <tds-side-menu-dropdown-list>

--- a/core/src/stories/patterns/navigation/navigation-fewitems.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-fewitems.stories.tsx
@@ -210,8 +210,8 @@ const Template = () =>
         </tds-side-menu-item>
 
         <tds-side-menu-dropdown>
-          <tds-icon slot="button-icon" name="tool" size="24"></tds-icon>
-          <span slot="button-label">
+          <tds-icon slot="icon" name="tool" size="24"></tds-icon>
+          <span slot="label">
             Wheel types
           </span>
           <tds-side-menu-dropdown-list>
@@ -233,7 +233,7 @@ const Template = () =>
         
         <tds-side-menu-dropdown slot="end" class="demo-lg-hide" selected>
           <tds-side-menu-user 
-            slot="button-label" 
+            slot="label" 
             heading="Name Namesson" 
             subheading="Company name" 
             img-src="https://www.svgrepo.com/show/384676/account-avatar-profile-user-6.svg" 

--- a/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
@@ -189,8 +189,8 @@ const Template = ({ dummyHtml }) =>
         </tds-side-menu-item>
 
         <tds-side-menu-dropdown default-open selected>
-          <tds-icon slot="button-icon" name="profile" size="24"></tds-icon>
-          <span slot="button-label">
+          <tds-icon slot="icon" name="profile" size="24"></tds-icon>
+          <span slot="label">
             Wheel types
           </span>
           <tds-side-menu-dropdown-list>

--- a/core/src/stories/patterns/navigation/navigation-user-menu.stories.tsx
+++ b/core/src/stories/patterns/navigation/navigation-user-menu.stories.tsx
@@ -115,7 +115,7 @@ const Template = () =>
 
         <tds-side-menu-dropdown slot="end" class="demo-xs-hide" selected default-open>
           <tds-side-menu-user 
-            slot="button-label" 
+            slot="label" 
             heading="Name Namesson" 
             subheading="Company name" 
             img-src="https://www.svgrepo.com/show/384676/account-avatar-profile-user-6.svg" 


### PR DESCRIPTION
**Describe pull-request**  
Update slot in side menu (button-label/button-icon) to conform with slot naming standard.

**Solving issue**  
Fixes: [CDEP-2431](https://tegel.atlassian.net/browse/CDEP-2431)

**How to test**  
1. Go to Side Menu
2. Check under notes and check that slot names are correct.
3. Check Side Menu examples
4. Make sure they still work as before.



[CDEP-2431]: https://tegel.atlassian.net/browse/CDEP-2431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ