### PR TITLE
fix(textarea): aligned autofocus prop with other components

### DIFF
--- a/core/src/components/textarea/readme.md
+++ b/core/src/components/textarea/readme.md
@@ -9,7 +9,7 @@
 
 | Property        | Attribute        | Description                             | Type                                  | Default      |
 | --------------- | ---------------- | --------------------------------------- | ------------------------------------- | ------------ |
-| `autoFocus`     | `auto-focus`     | Control of autofocus                    | `boolean`                             | `false`      |
+| `autofocus`     | `autofocus`      | Control of autofocus                    | `boolean`                             | `false`      |
 | `cols`          | `cols`           | Textarea cols attribute                 | `number`                              | `undefined`  |
 | `disabled`      | `disabled`       | Set input in disabled state             | `boolean`                             | `false`      |
 | `helper`        | `helper`         | Helper text                             | `string`                              | `undefined`  |

--- a/core/src/components/textarea/textarea.tsx
+++ b/core/src/components/textarea/textarea.tsx
@@ -50,7 +50,7 @@ export class TdsTextarea {
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
   /** Control of autofocus */
-  @Prop() autoFocus: boolean = false;
+  @Prop() autofocus: boolean = false;
 
   /** Unset minimum width of 208px. */
   @Prop() noMinWidth: boolean = false;
@@ -141,7 +141,7 @@ export class TdsTextarea {
             placeholder={this.placeholder}
             value={this.value}
             name={this.name}
-            autofocus={this.autoFocus}
+            autofocus={this.autofocus}
             maxlength={this.maxLength}
             cols={this.cols}
             rows={this.rows}

--- a/core/src/stories/Migration/Migration.stories.mdx
+++ b/core/src/stories/Migration/Migration.stories.mdx
@@ -477,27 +477,6 @@ Rename all instances of `readonly` to `read-only`.
 
 ```
 
-#### Changed prop name 'autofocus'
-
-The prop `autofocus` was changed to `auto-focus` to conform with other prop names.
-
-##### What action is required?
-
-Rename all instances of `autofocus` to `auto-focus`.
-
-```jsx
-// Old ❌
-<sdds-textarea
-    autofocus
-></sdds-textarea>
-
-// New ✅
-<tds-textarea
-    auto-focus
-></tds-textarea>
-
-```
-
 #### Added prop for mode-variant and removed class `sdds-on-white-bg` on container element
 
 Previously the class `sdds-on-white-bg` was used to determine the mode variant. We have now introduced the prop `mode-variant` with values `primary` or


### PR DESCRIPTION
**Describe pull-request**  
Aligned the autofocus prop with other components (datetime and text-field)

**Solving issue**  
Fixes: [CDEP-2437](https://tegel.atlassian.net/browse/CDEP-2437)

**How to test**  
1. Go to Textarea
2. Check the notes and check that to autofocus prop is lowercased and one word.
3. Validate that it is the same for datetime and text-field


[CDEP-2437]: https://tegel.atlassian.net/browse/CDEP-2437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ