### PR TITLE
feat(dropdown, checkbox): fix multiselect clickable area

### DIFF
--- a/core/src/components/checkbox/checkbox.scss
+++ b/core/src/components/checkbox/checkbox.scss
@@ -1,5 +1,18 @@
 @import '../../mixins/box-sizing';
 
+:host {
+  // If the user sets a custom height on the checkbox
+  // (height 100%, to fill a list item in a dropdown, for example)
+  // The default behavior is to center the label and checkbox vertically.
+  align-items: center;
+
+  // Limit the clickable area to the bounds of the host element.
+  position: relative;
+
+  // If the user adds paddings to the host element, we it to stay the same size.
+  box-sizing: border-box;
+}
+
 .tds-checkbox {
   @include tds-box-sizing;
 
@@ -31,6 +44,16 @@
       cursor: pointer;
       display: flex;
       align-items: center;
+
+      // This makes the whole of <tds-checkbox> clickable, even if its :host element is resized by the user.
+      &::before {
+        content: '';
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        left: 0;
+        top: 0;
+      }
     }
 
     &::before,

--- a/core/src/components/dropdown/dropdown-option/dropdown-option.scss
+++ b/core/src/components/dropdown/dropdown-option/dropdown-option.scss
@@ -50,15 +50,14 @@
     }
 
     .multiselect {
-      padding: 0 16px;
       width: 100%;
+      height: 100%;
 
-      // This is to make the entire button clickable
-      tds-checkbox,
-      .tds-checkbox-webcomponent,
-      label {
+      tds-checkbox {
+        display: flex;
         height: 100%;
         width: 100%;
+        padding: 0 16px;
       }
     }
 

--- a/core/src/components/table/table-header-cell/readme.md
+++ b/core/src/components/table/table-header-cell/readme.md
@@ -20,7 +20,7 @@
 
 | Event           | Description                                                                                                                                                          | Type                                                                                      |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "desc" \| "asc"; }>` |
+| `tdsSortChange` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
 
 
 ----------------------------------------------


### PR DESCRIPTION
Make multiselect items clickable everywhere. Done by modifications to checkboxes clickable area.

**Solving issue**  
Fixes: [CDEP-2327](https://tegel.atlassian.net/browse/CDEP-2327)

**How to test**  
Test clickable area of checkbox, components using checkbox, and dropdown multiselect. 
These are the only parts that should have been potentially affected.

**Additional context**  
Checkboxes were modified to make their use simpler in cases like this. (Making it so the user doesn't have to do a hack to accomplish this)


[CDEP-2327]: https://tegel.atlassian.net/browse/CDEP-2327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ