### PR TITLE
fix(modal/toast/banner/card): align slot names

### DIFF
--- a/core/src/components/banner/banner.scss
+++ b/core/src/components/banner/banner.scss
@@ -67,7 +67,7 @@
     letter-spacing: var(--tds-detail-02-ls);
   }
 
-  slot[name='bottom'] {
+  slot[name='actions'] {
     &::slotted(*) {
       display: block;
       width: fit-content;

--- a/core/src/components/banner/banner.stories.tsx
+++ b/core/src/components/banner/banner.stories.tsx
@@ -49,8 +49,8 @@ export default {
         type: 'text',
       },
     },
-    bottom: {
-      name: 'Bottom slot',
+    actions: {
+      name: 'Actions slot',
       description: 'Slot for the bottom part of the Banner, used for links.',
       control: {
         type: 'text',
@@ -71,12 +71,12 @@ export default {
     variant: 'Default',
     header: 'This is a header text area',
     subheader: 'This is the subheader text area',
-    bottom: '<tds-link slot="bottom" ><a href="/">Link example</a></tds-link>',
+    actions: '<tds-link slot="actions" ><a href="/">Link example</a></tds-link>',
     icon: 'truck',
   },
 };
 
-const Template = ({ variant, icon, header, subheader, bottom }) =>
+const Template = ({ variant, icon, header, subheader, actions }) =>
   formatHtmlPreview(`
       <tds-banner
           ${variant !== 'Default' ? `variant="${variant.toLowerCase()}"` : ''}
@@ -84,7 +84,7 @@ const Template = ({ variant, icon, header, subheader, bottom }) =>
           ${header !== '' ? `header="${header}"` : ''}
           ${subheader ? `subheader="${subheader}"` : ''}       
           >
-          ${bottom ? `${bottom}` : ''}
+          ${actions ? `${actions}` : ''}
       </tds-banner>
 
       <!-- Script tag with eventlistener for demo purposes. -->

--- a/core/src/components/banner/banner.tsx
+++ b/core/src/components/banner/banner.tsx
@@ -4,7 +4,7 @@ import { generateUniqueId, hasSlot } from '../../utils/utils';
 /**
  * @slot header - Slot for the Header of the Banner
  * @slot subheader - Slot for the Subheader of the Banner
- * @slot bottom - Slot for the bottom part of the Banner, used for links.
+ * @slot actions - Slot for the bottom part of the Banner, used for links.
  */
 @Component({
   tag: 'tds-banner',
@@ -99,7 +99,7 @@ export class TdsBanner {
   render() {
     const usesHeaderSlot = hasSlot('subheader', this.host);
     const usesSubheaderSlot = hasSlot('subheader', this.host);
-    const usesBottomSlot = hasSlot('bottom', this.host);
+    const usesActionsSlot = hasSlot('actions', this.host);
     return (
       <Host
         role="banner"
@@ -123,7 +123,7 @@ export class TdsBanner {
             {this.subheader && <div class="subheader">{this.subheader}</div>}
             {usesSubheaderSlot && <slot name="subheader"></slot>}
           </div>
-          {usesBottomSlot && <slot name="bottom"></slot>}
+          {usesActionsSlot && <slot name="actions"></slot>}
         </div>
 
         <div class={`banner-close`}>

--- a/core/src/components/banner/readme.md
+++ b/core/src/components/banner/readme.md
@@ -52,7 +52,7 @@ Type: `Promise<void>`
 
 | Slot          | Description                                             |
 | ------------- | ------------------------------------------------------- |
-| `"bottom"`    | Slot for the bottom part of the Banner, used for links. |
+| `"actions"`   | Slot for the bottom part of the Banner, used for links. |
 | `"header"`    | Slot for the Header of the Banner                       |
 | `"subheader"` | Slot for the Subheader of the Banner                    |
 

--- a/core/src/components/card/card.scss
+++ b/core/src/components/card/card.scss
@@ -86,7 +86,7 @@
     max-width: 336px;
   }
 
-  slot[name='bottom']::slotted(*) {
+  slot[name='actions']::slotted(*) {
     display: flex;
     padding: 16px;
     color: var(--tds-card-icon-color);

--- a/core/src/components/card/card.stories.tsx
+++ b/core/src/components/card/card.stories.tsx
@@ -93,7 +93,7 @@ export default {
         defaultValue: { summary: false },
       },
     },
-    cardBottom: {
+    cardActions: {
       name: 'Content of the bottom of the Card',
       description: 'Slot to add custom HTML elements to the bottom of the Card.',
       control: {
@@ -120,7 +120,7 @@ export default {
     bodyImg: false,
     bodyContent: '',
     bodyDivider: false,
-    cardBottom: `<tds-icon slot="bottom" size="20px" name="arrow_right"></tds-icon>`,
+    cardActions: `<tds-icon slot="actions" size="20px" name="arrow_right"></tds-icon>`,
     clickable: false,
   },
 };
@@ -134,7 +134,7 @@ const Template = ({
   bodyImg,
   bodyContent,
   bodyDivider,
-  cardBottom,
+  cardActions,
   clickable,
 }) =>
   formatHtmlPreview(
@@ -167,7 +167,7 @@ const Template = ({
     </div>`
       : ''
   }
-    ${cardBottom ? `${cardBottom}` : ''}
+    ${cardActions ? `${cardActions}` : ''}
     </tds-card>
     </div>
     ${

--- a/core/src/components/card/card.tsx
+++ b/core/src/components/card/card.tsx
@@ -7,7 +7,7 @@ import { generateUniqueId, hasSlot } from '../../utils/utils';
  * @slot thumbnail - Slot for the Card thumbnail.
  * @slot body - Slot for the body section of the Card.
  * @slot body-image - Slot for the body section of the Card, used for image.
- * @slot bottom - Slot for the bottom section of the Card.
+ * @slot actions - Slot for the bottom section of the Card, used for buttons .
  */
 @Component({
   tag: 'tds-card',

--- a/core/src/components/card/card.tsx
+++ b/core/src/components/card/card.tsx
@@ -85,7 +85,7 @@ export class TdsCard {
   getCardContent = () => {
     const usesBodySlot = hasSlot('body', this.host);
     const usesBodyImageSlot = hasSlot('body-image', this.host);
-    const usesBottomSlot = hasSlot('bottom', this.host);
+    const usesActionsSlot = hasSlot('actions', this.host);
     return (
       <div>
         {this.imagePlacement === 'below-header' && this.getCardHeader()}
@@ -96,7 +96,7 @@ export class TdsCard {
           {this.bodyDivider && <tds-divider></tds-divider>}
           {usesBodySlot && <slot name="body"></slot>}
         </div>
-        {usesBottomSlot && <slot name={`bottom`}></slot>}
+        {usesActionsSlot && <slot name={`actions`}></slot>}
       </div>
     );
   };

--- a/core/src/components/card/readme.md
+++ b/core/src/components/card/readme.md
@@ -29,14 +29,14 @@
 
 ## Slots
 
-| Slot           | Description                                            |
-| -------------- | ------------------------------------------------------ |
-| `"body"`       | Slot for the body section of the Card.                 |
-| `"body-image"` | Slot for the body section of the Card, used for image. |
-| `"bottom"`     | Slot for the bottom section of the Card.               |
-| `"header"`     | Slot for the Card header.                              |
-| `"subheader"`  | Slot for the Card subheader.                           |
-| `"thumbnail"`  | Slot for the Card thumbnail.                           |
+| Slot           | Description                                                 |
+| -------------- | ----------------------------------------------------------- |
+| `"actions"`    | Slot for the bottom section of the Card, used for buttons . |
+| `"body"`       | Slot for the body section of the Card.                      |
+| `"body-image"` | Slot for the body section of the Card, used for image.      |
+| `"header"`     | Slot for the Card header.                                   |
+| `"subheader"`  | Slot for the Card subheader.                                |
+| `"thumbnail"`  | Slot for the Card thumbnail.                                |
 
 
 ## Dependencies

--- a/core/src/components/modal/modal.stories.tsx
+++ b/core/src/components/modal/modal.stories.tsx
@@ -21,10 +21,10 @@ export default {
     ],
   },
   argTypes: {
-    actions: {
-      name: 'Actions',
+    actionsPosition: {
+      name: 'Actions position',
       description:
-        "Defines the behaviour of Modal action's slot - if slot scrolls or stays on top of the content.",
+        "Defines the postion of Modal action's slot - if slot scrolls or stays on top of the content.",
       control: {
         type: 'radio',
       },
@@ -95,7 +95,7 @@ const ModalTemplate = ({ actions, size, headerText, bodyContent, showModal }) =>
   selector="#my-modal-button"   
    ${showModal ? 'show' : ''} 
    id="my-modal" size="${sizeLookUp[size]}" 
-   actions="${actions.toLowerCase()}">          
+   actions-position="${actions.toLowerCase()}">          
       <span slot="body">
           ${bodyContent}
       </span>      

--- a/core/src/components/modal/modal.stories.tsx
+++ b/core/src/components/modal/modal.stories.tsx
@@ -67,7 +67,7 @@ export default {
     },
   },
   args: {
-    actions: 'Static',
+    actionsPosition: 'Static',
     size: 'Large',
     headerText: 'The buttons for the Modal only works in the canvas tab',
     bodyContent:
@@ -83,7 +83,7 @@ const sizeLookUp = {
   'Extra small': 'xs',
 };
 
-const ModalTemplate = ({ actions, size, headerText, bodyContent, showModal }) =>
+const ModalTemplate = ({ actionsPosition, size, headerText, bodyContent, showModal }) =>
   formatHtmlPreview(
     `
  <!-- The button below is just for demo purposes -->
@@ -95,7 +95,7 @@ const ModalTemplate = ({ actions, size, headerText, bodyContent, showModal }) =>
   selector="#my-modal-button"   
    ${showModal ? 'show' : ''} 
    id="my-modal" size="${sizeLookUp[size]}" 
-   actions-position="${actions.toLowerCase()}">          
+   actions-position="${actionsPosition.toLowerCase()}">          
       <span slot="body">
           ${bodyContent}
       </span>      

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -33,8 +33,8 @@ export class TdsModal {
   /** Size of Modal  */
   @Prop() size: 'xs' | 'sm' | 'md' | 'lg' = 'md';
 
-  /** Sticky or Static Actions  */
-  @Prop() actions: 'sticky' | 'static' = 'static';
+  /** Changes the position behaviour of the actions slot.  */
+  @Prop() actionsPostion: 'sticky' | 'static' = 'static';
 
   /** CSS selector for the element that will show the Modal. */
   @Prop() selector: string;
@@ -150,9 +150,9 @@ export class TdsModal {
         class={`tds-modal-backdrop ${this.isShown ? 'show' : 'hide'}`}
       >
         <div
-          class={`tds-modal ${this.actions ? `tds-modal__actions-${this.actions}` : ''} ${
-            this.size ? `tds-modal-${this.size}` : ''
-          } `}
+          class={`tds-modal ${
+            this.actionsPostion ? `tds-modal__actions-${this.actionsPostion}` : ''
+          } ${this.size ? `tds-modal-${this.size}` : ''} `}
         >
           <div class="header">
             {this.header && <div class="header">{this.header}</div>}

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -34,7 +34,7 @@ export class TdsModal {
   @Prop() size: 'xs' | 'sm' | 'md' | 'lg' = 'md';
 
   /** Changes the position behaviour of the actions slot.  */
-  @Prop() actionsPostion: 'sticky' | 'static' = 'static';
+  @Prop() actionsPosition: 'sticky' | 'static' = 'static';
 
   /** CSS selector for the element that will show the Modal. */
   @Prop() selector: string;
@@ -149,11 +149,7 @@ export class TdsModal {
         }}
         class={`tds-modal-backdrop ${this.isShown ? 'show' : 'hide'}`}
       >
-        <div
-          class={`tds-modal ${
-            this.actionsPostion ? `tds-modal__actions-${this.actionsPostion}` : ''
-          } ${this.size ? `tds-modal-${this.size}` : ''} `}
-        >
+        <div class={`tds-modal tds-modal__actions-${this.actionsPosition} tds-modal-${this.size}`}>
           <div class="header">
             {this.header && <div class="header">{this.header}</div>}
             {usesHeaderSlot && <slot name="header"></slot>}

--- a/core/src/components/modal/readme.md
+++ b/core/src/components/modal/readme.md
@@ -7,15 +7,15 @@
 
 ## Properties
 
-| Property      | Attribute  | Description                                                                                                                                                 | Type                           | Default     |
-| ------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ----------- |
-| `actions`     | `actions`  | Sticky or Static Actions                                                                                                                                    | `"static" \| "sticky"`         | `'static'`  |
-| `header`      | `header`   | Sets the header of the Modal.                                                                                                                               | `string`                       | `undefined` |
-| `prevent`     | `prevent`  | Disables closing Modal on clicking on overlay area.                                                                                                         | `boolean`                      | `false`     |
-| `referenceEl` | --         | Element that will show the Modal (takes priority over selector)                                                                                             | `HTMLElement`                  | `undefined` |
-| `selector`    | `selector` | CSS selector for the element that will show the Modal.                                                                                                      | `string`                       | `undefined` |
-| `show`        | `show`     | Controls whether the Modal is shown or not. If this is set hiding and showing will be decided by this prop and will need to be controlled from the outside. | `boolean`                      | `undefined` |
-| `size`        | `size`     | Size of Modal                                                                                                                                               | `"lg" \| "md" \| "sm" \| "xs"` | `'md'`      |
+| Property         | Attribute         | Description                                                                                                                                                 | Type                           | Default     |
+| ---------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ----------- |
+| `actionsPostion` | `actions-postion` | Changes the position behaviour of the actions slot.                                                                                                         | `"static" \| "sticky"`         | `'static'`  |
+| `header`         | `header`          | Sets the header of the Modal.                                                                                                                               | `string`                       | `undefined` |
+| `prevent`        | `prevent`         | Disables closing Modal on clicking on overlay area.                                                                                                         | `boolean`                      | `false`     |
+| `referenceEl`    | --                | Element that will show the Modal (takes priority over selector)                                                                                             | `HTMLElement`                  | `undefined` |
+| `selector`       | `selector`        | CSS selector for the element that will show the Modal.                                                                                                      | `string`                       | `undefined` |
+| `show`           | `show`            | Controls whether the Modal is shown or not. If this is set hiding and showing will be decided by this prop and will need to be controlled from the outside. | `boolean`                      | `undefined` |
+| `size`           | `size`            | Size of Modal                                                                                                                                               | `"lg" \| "md" \| "sm" \| "xs"` | `'md'`      |
 
 
 ## Events

--- a/core/src/components/modal/readme.md
+++ b/core/src/components/modal/readme.md
@@ -7,15 +7,15 @@
 
 ## Properties
 
-| Property         | Attribute         | Description                                                                                                                                                 | Type                           | Default     |
-| ---------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ----------- |
-| `actionsPostion` | `actions-postion` | Changes the position behaviour of the actions slot.                                                                                                         | `"static" \| "sticky"`         | `'static'`  |
-| `header`         | `header`          | Sets the header of the Modal.                                                                                                                               | `string`                       | `undefined` |
-| `prevent`        | `prevent`         | Disables closing Modal on clicking on overlay area.                                                                                                         | `boolean`                      | `false`     |
-| `referenceEl`    | --                | Element that will show the Modal (takes priority over selector)                                                                                             | `HTMLElement`                  | `undefined` |
-| `selector`       | `selector`        | CSS selector for the element that will show the Modal.                                                                                                      | `string`                       | `undefined` |
-| `show`           | `show`            | Controls whether the Modal is shown or not. If this is set hiding and showing will be decided by this prop and will need to be controlled from the outside. | `boolean`                      | `undefined` |
-| `size`           | `size`            | Size of Modal                                                                                                                                               | `"lg" \| "md" \| "sm" \| "xs"` | `'md'`      |
+| Property          | Attribute          | Description                                                                                                                                                 | Type                           | Default     |
+| ----------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ----------- |
+| `actionsPosition` | `actions-position` | Changes the position behaviour of the actions slot.                                                                                                         | `"static" \| "sticky"`         | `'static'`  |
+| `header`          | `header`           | Sets the header of the Modal.                                                                                                                               | `string`                       | `undefined` |
+| `prevent`         | `prevent`          | Disables closing Modal on clicking on overlay area.                                                                                                         | `boolean`                      | `false`     |
+| `referenceEl`     | --                 | Element that will show the Modal (takes priority over selector)                                                                                             | `HTMLElement`                  | `undefined` |
+| `selector`        | `selector`         | CSS selector for the element that will show the Modal.                                                                                                      | `string`                       | `undefined` |
+| `show`            | `show`             | Controls whether the Modal is shown or not. If this is set hiding and showing will be decided by this prop and will need to be controlled from the outside. | `boolean`                      | `undefined` |
+| `size`            | `size`             | Size of Modal                                                                                                                                               | `"lg" \| "md" \| "sm" \| "xs"` | `'md'`      |
 
 
 ## Events

--- a/core/src/components/toast/readme.md
+++ b/core/src/components/toast/readme.md
@@ -51,7 +51,7 @@ Type: `Promise<void>`
 
 | Slot          | Description                                        |
 | ------------- | -------------------------------------------------- |
-| `"bottom"`    | Slot for the Toast bottom section, used for links. |
+| `"actions"`   | Slot for the Toast bottom section, used for links. |
 | `"header"`    | Slot for the Toast header.                         |
 | `"subheader"` | Slot for the Toast subheader.                      |
 

--- a/core/src/components/toast/toast.scss
+++ b/core/src/components/toast/toast.scss
@@ -117,7 +117,7 @@
     }
   }
 
-  slot[name='bottom']::slotted(*) {
+  slot[name='actions']::slotted(*) {
     color: var(--tds-toast-link-color);
   }
 

--- a/core/src/components/toast/toast.stories.tsx
+++ b/core/src/components/toast/toast.stories.tsx
@@ -48,8 +48,8 @@ export default {
         type: 'text',
       },
     },
-    bottom: {
-      name: 'Bottom slot',
+    actions: {
+      name: 'Actions slot',
       description: 'Slot for the bottom part of the Toast, used for links.',
       control: {
         type: 'text',
@@ -60,21 +60,20 @@ export default {
     variant: 'Information',
     header: 'Header',
     subheader: 'Subheader',
-    bottom:
-      `<tds-link slot="bottom">
+    actions: `<tds-link slot="actions">
           <a href="https://tegel.scania.com/home" target="_blank">Tegel</a>
       </tds-link>`,
   },
 };
 
-const Template = ({ variant, header, subheader, bottom }) =>
+const Template = ({ variant, header, subheader, actions }) =>
   formatHtmlPreview(
     `<tds-toast
         variant="${variant.toLowerCase()}"
         header="${header}"
         ${subheader ? `subheader="${subheader}"` : ''}
     >
-    ${bottom || ''}
+    ${actions || ''}
     </tds-toast>
     
     <script>

--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -5,7 +5,7 @@ import { generateUniqueId, hasSlot } from '../../utils/utils';
 /**
  * @slot header - Slot for the Toast header.
  * @slot subheader - Slot for the Toast subheader.
- * @slot bottom - Slot for the Toast bottom section, used for links.
+ * @slot actions - Slot for the Toast bottom section, used for links.
  */
 @Component({
   tag: 'tds-toast',
@@ -92,7 +92,7 @@ export class TdsToast {
   render() {
     const usesHeaderSlot = hasSlot('header', this.host);
     const usesSubheaderSlot = hasSlot('subheader', this.host);
-    const usesBottomSlot = hasSlot('bottom', this.host);
+    const usesActionsSlot = hasSlot('actions', this.host);
     return (
       <Host
         toastRole={this.toastRole}
@@ -112,13 +112,13 @@ export class TdsToast {
               {this.subheader && <div class="subheader">{this.subheader}</div>}
               {usesSubheaderSlot && <slot name="subheader"></slot>}
             </div>
-            {usesBottomSlot && (
+            {usesActionsSlot && (
               <div
                 class={`toast-bottom ${
                   usesSubheaderSlot || this.subheader ? 'subheader' : 'no-subheader'
                 }`}
               >
-                <slot name="bottom"></slot>
+                <slot name="actions"></slot>
               </div>
             )}
           </div>


### PR DESCRIPTION
**Describe pull-request**
Aligned bottom slot name and renamed actions prop (modal).

**Solving issue**  
Fixes: [CDEP-2447](https://tegel.atlassian.net/browse/CDEP-2447)

**How to test**  
1. Go to the affected components
2. Make sure the slots work as inteded.



[CDEP-2441]: https://tegel.atlassian.net/browse/CDEP-2441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CDEP-2447]: https://tegel.atlassian.net/browse/CDEP-2447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ