### PR TITLE
fix(tabs): watcher for selectedIndex & defaultSelectedIndex

### DIFF
--- a/core/src/components/tabs/folder-tabs/folder-tabs.tsx
+++ b/core/src/components/tabs/folder-tabs/folder-tabs.tsx
@@ -77,6 +77,15 @@ export class TdsFolderTabs {
     };
   }
 
+  @Watch('selectedIndex')
+  handleSelectedIndexUpdate() {
+    this.children = Array.from(this.host.children).map((tabElement: HTMLTdsFolderTabElement) => {
+      tabElement.setSelected(false);
+      return tabElement;
+    });
+    this.children[this.selectedIndex].setSelected(true);
+  }
+
   @Watch('defaultSelectedIndex')
   handleDefaultSelectedIndexUpdate() {
     this.children = Array.from(this.host.children).map((tabElement: HTMLTdsFolderTabElement) => {

--- a/core/src/components/tabs/folder-tabs/folder-tabs.tsx
+++ b/core/src/components/tabs/folder-tabs/folder-tabs.tsx
@@ -8,6 +8,7 @@ import {
   Event,
   EventEmitter,
   Method,
+  Watch,
 } from '@stencil/core';
 
 /**
@@ -74,6 +75,16 @@ export class TdsFolderTabs {
     return {
       selectedTabIndex: this.selectedIndex,
     };
+  }
+
+  @Watch('defaultSelectedIndex')
+  handleDefaultSelectedIndexUpdate() {
+    this.children = Array.from(this.host.children).map((tabElement: HTMLTdsFolderTabElement) => {
+      tabElement.setSelected(false);
+      return tabElement;
+    });
+    this.children[this.defaultSelectedIndex].setSelected(true);
+    this.selectedIndex = this.defaultSelectedIndex;
   }
 
   calculateButtonWidth() {

--- a/core/src/components/tabs/folder-tabs/folder-tabs.tsx
+++ b/core/src/components/tabs/folder-tabs/folder-tabs.tsx
@@ -86,16 +86,6 @@ export class TdsFolderTabs {
     this.children[this.selectedIndex].setSelected(true);
   }
 
-  @Watch('defaultSelectedIndex')
-  handleDefaultSelectedIndexUpdate() {
-    this.children = Array.from(this.host.children).map((tabElement: HTMLTdsFolderTabElement) => {
-      tabElement.setSelected(false);
-      return tabElement;
-    });
-    this.children[this.defaultSelectedIndex].setSelected(true);
-    this.selectedIndex = this.defaultSelectedIndex;
-  }
-
   calculateButtonWidth() {
     this.children = this.children.map((tab: HTMLTdsFolderTabElement) => {
       if (tab.offsetWidth > this.buttonWidth) {

--- a/core/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/core/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, State, Element, h, Prop, Event, EventEmitter } from '@stencil/core';
-import { Method } from '@stencil/core/internal';
+import { Method, Watch } from '@stencil/core/internal';
 
 /**
  * @slot <default> - <b>Unnamed slot.</b> For the tab elements.
@@ -67,6 +67,16 @@ export class TdsInlineTabs {
     return {
       selectedTabIndex: this.selectedIndex,
     };
+  }
+
+  @Watch('defaultSelectedIndex')
+  handleDefaultSelectedIndexUpdate() {
+    this.children = Array.from(this.host.children).map((tabElement: HTMLTdsInlineTabElement) => {
+      tabElement.setSelected(false);
+      return tabElement;
+    });
+    this.children[this.defaultSelectedIndex].setSelected(true);
+    this.selectedIndex = this.defaultSelectedIndex;
   }
 
   scrollRight() {

--- a/core/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/core/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -69,6 +69,15 @@ export class TdsInlineTabs {
     };
   }
 
+  @Watch('selectedIndex')
+  handleSelectedIndexUpdate() {
+    this.children = Array.from(this.host.children).map((tabElement: HTMLTdsInlineTabElement) => {
+      tabElement.setSelected(false);
+      return tabElement;
+    });
+    this.children[this.selectedIndex].setSelected(true);
+  }
+
   @Watch('defaultSelectedIndex')
   handleDefaultSelectedIndexUpdate() {
     this.children = Array.from(this.host.children).map((tabElement: HTMLTdsInlineTabElement) => {

--- a/core/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/core/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -78,16 +78,6 @@ export class TdsInlineTabs {
     this.children[this.selectedIndex].setSelected(true);
   }
 
-  @Watch('defaultSelectedIndex')
-  handleDefaultSelectedIndexUpdate() {
-    this.children = Array.from(this.host.children).map((tabElement: HTMLTdsInlineTabElement) => {
-      tabElement.setSelected(false);
-      return tabElement;
-    });
-    this.children[this.defaultSelectedIndex].setSelected(true);
-    this.selectedIndex = this.defaultSelectedIndex;
-  }
-
   scrollRight() {
     const scroll = this.navWrapperElement.scrollLeft;
     this.navWrapperElement.scrollLeft = scroll + this.buttonsWidth;

--- a/core/src/components/tabs/navigation-tabs/navigation-tabs.tsx
+++ b/core/src/components/tabs/navigation-tabs/navigation-tabs.tsx
@@ -75,6 +75,17 @@ export class TdsNavigationTabs {
     selectedTabIndex: number;
   }>;
 
+  @Watch('selectedIndex')
+  handleSelectedIndexUpdate() {
+    this.children = Array.from(this.host.children).map(
+      (tabElement: HTMLTdsNavigationTabElement) => {
+        tabElement.setSelected(false);
+        return tabElement;
+      },
+    );
+    this.children[this.selectedIndex].setSelected(true);
+  }
+
   @Watch('defaultSelectedIndex')
   handleDefaultSelectedIndexUpdate() {
     this.children = Array.from(this.host.children).map(

--- a/core/src/components/tabs/navigation-tabs/navigation-tabs.tsx
+++ b/core/src/components/tabs/navigation-tabs/navigation-tabs.tsx
@@ -86,18 +86,6 @@ export class TdsNavigationTabs {
     this.children[this.selectedIndex].setSelected(true);
   }
 
-  @Watch('defaultSelectedIndex')
-  handleDefaultSelectedIndexUpdate() {
-    this.children = Array.from(this.host.children).map(
-      (tabElement: HTMLTdsNavigationTabElement) => {
-        tabElement.setSelected(false);
-        return tabElement;
-      },
-    );
-    this.children[this.defaultSelectedIndex].setSelected(true);
-    this.selectedIndex = this.defaultSelectedIndex;
-  }
-
   scrollRight() {
     const scroll = this.navWrapperElement.scrollLeft;
     this.navWrapperElement.scrollLeft = scroll + this.buttonsWidth;

--- a/core/src/components/tabs/navigation-tabs/navigation-tabs.tsx
+++ b/core/src/components/tabs/navigation-tabs/navigation-tabs.tsx
@@ -8,6 +8,7 @@ import {
   Event,
   EventEmitter,
   Method,
+  Watch,
 } from '@stencil/core';
 
 /**
@@ -73,6 +74,18 @@ export class TdsNavigationTabs {
   tdsChange: EventEmitter<{
     selectedTabIndex: number;
   }>;
+
+  @Watch('defaultSelectedIndex')
+  handleDefaultSelectedIndexUpdate() {
+    this.children = Array.from(this.host.children).map(
+      (tabElement: HTMLTdsNavigationTabElement) => {
+        tabElement.setSelected(false);
+        return tabElement;
+      },
+    );
+    this.children[this.defaultSelectedIndex].setSelected(true);
+    this.selectedIndex = this.defaultSelectedIndex;
+  }
 
   scrollRight() {
     const scroll = this.navWrapperElement.scrollLeft;


### PR DESCRIPTION
**Describe pull-request**  
Added a watcher for the default-selected-index & selected-index in order to keep the state aligned with the attribute.

**Solving issue**  
Fixes: - 

**How to test**  
1. Go the the react test environment: https://github.com/scania-digital-design-system/tegel-react-demo/pull/130
2. Check under Tabs -> Link
3. Try switching tab and see that all tabs change the selected tab

