### PR TITLE
fix(chip): updated tdsChange to include the updated checked value

### DIFF
--- a/core/src/components/chip/chip.tsx
+++ b/core/src/components/chip/chip.tsx
@@ -29,7 +29,7 @@ export class TdsChip {
   @Prop() chipId: string = generateUniqueId();
 
   /** Controls component's checked attribute. Valid only for type checkbox and radio. */
-  @Prop() checked: boolean = false;
+  @Prop({ reflect: true }) checked: boolean = false;
 
   /** Name for the checkbox or radio input element. Also creates a reference between label and input. Valid only for type checkbox and radio. */
   @Prop() name: string;
@@ -50,11 +50,14 @@ export class TdsChip {
   tdsChange: EventEmitter<{
     chipId: string;
     value: string;
+    checked?: boolean;
   }>;
 
   private handleChange = () => {
+    this.checked = !this.checked;
     this.tdsChange.emit({
       chipId: this.chipId,
+      checked: this.checked,
       value: this.value,
     });
   };

--- a/core/src/components/chip/readme.md
+++ b/core/src/components/chip/readme.md
@@ -19,10 +19,10 @@
 
 ## Events
 
-| Event       | Description                                                                                                                                                                                                                                                           | Type                                              |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| `tdsChange` | Sends unique Chip identifier and value when it is changed (checked/unchecked). Valid only for type checkbox and radio. If no ID is specified, a random one will be generated. To use this listener, don't use the randomized ID, use a specific one of your choosing. | `CustomEvent<{ chipId: string; value: string; }>` |
-| `tdsClick`  | Sends unique Chip identifier when Chip is clicked. Valid only for type button. If no ID is specified, a random one will be generated. To use this listener, don't use the randomized ID, use a specific one of your choosing.                                         | `CustomEvent<{ chipId: string; }>`                |
+| Event       | Description                                                                                                                                                                                                                                                           | Type                                                                 |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `tdsChange` | Sends unique Chip identifier and value when it is changed (checked/unchecked). Valid only for type checkbox and radio. If no ID is specified, a random one will be generated. To use this listener, don't use the randomized ID, use a specific one of your choosing. | `CustomEvent<{ chipId: string; value: string; checked?: boolean; }>` |
+| `tdsClick`  | Sends unique Chip identifier when Chip is clicked. Valid only for type button. If no ID is specified, a random one will be generated. To use this listener, don't use the randomized ID, use a specific one of your choosing.                                         | `CustomEvent<{ chipId: string; }>`                                   |
 
 
 ## Slots


### PR DESCRIPTION
**Describe pull-request**  
updated the tdsChange event emitted from the chip to optionally include a checked key/value for checkboxes.

**Solving issue**  
Fixes: [CDEP-2453](https://tegel.atlassian.net/browse/CDEP-2453)

**How to test**  
1. Go to Chip
2. Check/Uncheck a checkbox
3. Check the console for a log of the event
4. Check the detail.checked value

