### PR TITLE
docs(tabs): update naming of Tab sub components in notes tab

### DIFF
--- a/core/src/components/tabs/folder-tabs/folder-tabs.stories.tsx
+++ b/core/src/components/tabs/folder-tabs/folder-tabs.stories.tsx
@@ -8,7 +8,7 @@ export default {
   parameters: {
     notes: {
       'Folder Tabs': readme,
-      'Folder Tabs item': readmeItem,
+      'Folder Tab': readmeItem,
     },
     backgrounds: { default: 'white' },
     design: [

--- a/core/src/components/tabs/inline-tabs/inline-tabs.stories.tsx
+++ b/core/src/components/tabs/inline-tabs/inline-tabs.stories.tsx
@@ -7,8 +7,8 @@ export default {
   title: `${ComponentsFolder}/Tabs`,
   parameters: {
     notes: {
-      'Inline tabs': readme,
-      'Inline tab': readmeTab,
+      'Inline Tabs': readme,
+      'Inline Tab': readmeTab,
     },
     design: [
       {


### PR DESCRIPTION
**Describe pull-request**  
Updated naming of Tab subcomponents for Inline and Folder Tabs in notes tab on Storybook

**Solving issue**  
Fixes: [CDEP-2458](https://tegel.atlassian.net/jira/software/projects/CDEP/boards/1?selectedIssue=CDEP-2458)

**How to test**  
1. Go to Storybook link below
2. Check in Tabs -> Folder Tabs -> Notes _and_ Tabs -> Inline Tabs -> Notes
3. Check that components/subcomponents are called _Folder Tabs_ / _Folder Tab_ and _Inline Tabs_ / _Inline Tab_ respectively

**Screenshots**  
**CURRENT**
![image](https://github.com/scania-digital-design-system/tegel/assets/48509966/e33c5c2f-e859-4a4c-8333-0b10f1709918)

![image](https://github.com/scania-digital-design-system/tegel/assets/48509966/0160b4ed-2e54-473e-bb0d-759050e412c6)


**EXPECTED**
![image](https://github.com/scania-digital-design-system/tegel/assets/48509966/8c42f669-abff-4e88-94c0-47ea609d6e7e)

![image](https://github.com/scania-digital-design-system/tegel/assets/48509966/ccdf551c-688b-498e-84e6-26ab4e546e71)
