### PR TITLE
docs(side-menu): slots comment structure update

### DIFF
--- a/core/src/components/side-menu/side-menu-user-image/readme.md
+++ b/core/src/components/side-menu/side-menu-user-image/readme.md
@@ -15,9 +15,9 @@
 
 ## Slots
 
-| Slot                                                                                                                            | Description |
-| ------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| `"<default> - <b>Unnamed slot.</b> Used as alternative to props to inject <code><img...</code> element directly into the DOM."` |             |
+| Slot          | Description                                                                                                     |
+| ------------- | --------------------------------------------------------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> Used as alternative to props to inject <code><img...</code> element directly into the DOM. |
 
 
 ## Dependencies

--- a/core/src/components/side-menu/side-menu-user-image/side-menu-user-image.tsx
+++ b/core/src/components/side-menu/side-menu-user-image/side-menu-user-image.tsx
@@ -5,9 +5,8 @@ import { Component, h, Host, Prop } from '@stencil/core';
 // FIXME: Can the logic for it be directly integrated in side-menu-user instead?
 
 /**
- * @slot <default> -
- * <b>Unnamed slot.</b> Used as alternative to props to inject <code><img...</code> element directly into the DOM.
- * */
+ * @slot <default> - <b>Unnamed slot.</b> Used as alternative to props to inject <code><img...</code> element directly into the DOM.
+ */
 
 @Component({
   tag: 'tds-side-menu-user-image',


### PR DESCRIPTION
**Describe pull-request**  
Update on slot comment 

**Solving issue**  
Content of title and description of the slot were previously under "Title" column. [Issue discovered in documentation PR.
](https://github.com/scania-digital-design-system/sdds-website/pull/439#issuecomment-1710182322)

**How to test**  
1. Check under the files here if the content is now separated between the Title and Description columns.

