### PR TITLE
feat(table-footer): correct color of pagination button icons for both modes

### DIFF
--- a/core/src/components/table/table-footer/table-footer.scss
+++ b/core/src/components/table/table-footer/table-footer.scss
@@ -72,6 +72,7 @@
         width: 32px;
         border-radius: 4px;
         transition: background-color 250ms ease;
+        color: var(--tds-table-footer-page-selector-icon);
 
         &:hover {
           background-color: var(--tds-table-footer-btn-hover);
@@ -79,7 +80,7 @@
 
         &:disabled {
           cursor: default;
-          opacity: 0.38;
+          color: var(--tds-table-footer-page-selector-icon-disabled);
 
           &:hover {
             background-color: transparent;

--- a/core/src/components/table/table-vars.scss
+++ b/core/src/components/table/table-vars.scss
@@ -27,10 +27,9 @@
   --tds-table-footer-background: var(--tds-grey-100);
   --tds-table-footer-page-selector-input-background: var(--tds-grey-50);
   --tds-table-footer-page-selector-input-background-hover: var(--tds-white);
-  --tds-table-footer-page-selector-input-background-disabled: var(
-    --tds-grey-600
-  ); //Should this be 400?
-
+  --tds-table-footer-page-selector-input-background-disabled: var(--tds-grey-600);
+  --tds-table-footer-page-selector-icon: var(--tds-grey-958);
+  --tds-table-footer-page-selector-icon-disabled: var(--tds-grey-600);
   --tds-table-footer-btn-hover: var(--tds-grey-300);
 
   /* Table-header */
@@ -82,6 +81,8 @@
   --tds-table-footer-page-selector-input-background-hover: var(--tds-grey-958);
   --tds-table-footer-page-selector-input-background-disabled: var(--tds-grey-700);
   --tds-table-footer-btn-hover: var(--tds-grey-900);
+  --tds-table-footer-page-selector-icon: var(--tds-grey-50);
+  --tds-table-footer-page-selector-icon-disabled: var(--tds-grey-600);
 
   /* Table-header */
   --tds-table-header-background: var(--tds-grey-800);


### PR DESCRIPTION
**Describe pull-request**  
- Introduces two new variables for table-footer (for both modes):
  `--tds-table-footer-page-selector-icon`
  `--tds-table-footer-page-selector-icon-disabled`
- Used these variables to color the pagination button icons

**Solving issue**  
Fixes: [CDEP-2438](https://tegel.atlassian.net/browse/CDEP-2438)

**How to test**  
1. Go to Table -> Pagination
2. Check the color of the icons in the pagination buttons.
3. Do this check for both modes.


[CDEP-2438]: https://tegel.atlassian.net/browse/CDEP-2438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ