### PR TITLE
feat(dropdown, checkbox): make multiselect items clickable everywhere

### DIFF
--- a/core/src/components/checkbox/checkbox.scss
+++ b/core/src/components/checkbox/checkbox.scss
@@ -1,5 +1,18 @@
 @import '../../mixins/box-sizing';
 
+:host {
+  // If the user sets a custom height on the checkbox
+  // (height 100%, to fill a list item in a dropdown, for example)
+  // The default behavior is to center the label and checkbox vertically.
+  align-items: center;
+
+  // Limit the clickable area to the bounds of the host element.
+  position: relative;
+
+  // If the user adds paddings to the host element, we it to stay the same size.
+  box-sizing: border-box;
+}
+
 .tds-checkbox {
   @include tds-box-sizing;
 
@@ -31,6 +44,16 @@
       cursor: pointer;
       display: flex;
       align-items: center;
+
+      // This makes the whole of <tds-checkbox> clickable, even if its :host element is resized by the user.
+      &::before {
+        content: '';
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        left: 0;
+        top: 0;
+      }
     }
 
     &::before,

--- a/core/src/components/dropdown/dropdown-option/dropdown-option.scss
+++ b/core/src/components/dropdown/dropdown-option/dropdown-option.scss
@@ -50,15 +50,14 @@
     }
 
     .multiselect {
-      padding: 0 16px;
       width: 100%;
+      height: 100%;
 
-      // This is to make the entire button clickable
-      tds-checkbox,
-      .tds-checkbox-webcomponent,
-      label {
+      tds-checkbox {
+        display: flex;
         height: 100%;
         width: 100%;
+        padding: 0 16px;
       }
     }
 


### PR DESCRIPTION
**Describe pull-request**  
Make multiselect items clickable everywhere. Done by modifications to checkboxes clickable area.

Reintroduces fixes made in: https://github.com/scania-digital-design-system/tegel/pull/267/commits/48fc0aa8dbad702eeb570231669022750449338d


**Solving issue**  
Fixes: [CDEP-2160](https://tegel.atlassian.net/browse/CDEP-2160)

**How to test**  
1. Go to Dropdown
2. Make it multiselect
3. Make sure the entire dropdown-option area is clickable.



[CDEP-2160]: https://tegel.atlassian.net/browse/CDEP-2160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ