### PR TITLE
docs(installation): corrected spelling in HTML installation guide

### DIFF
--- a/core/src/stories/Installation/installation.stories.ts
+++ b/core/src/stories/Installation/installation.stories.ts
@@ -194,7 +194,7 @@ export class AppModule {}</code>
     <section>
         <ol>
             <li><p>Run <code>npm init</code> to generate a package.json</p></li>
-            <li><p>Run <code>npm istall @scania/tegel</code></p></li>
+            <li><p>Run <code>npm install @scania/tegel</code></p></li>
             <li><p>Import the package and stylesheet in your <code>&lt;head&gt;</code></p>
                 <pre>
                     <code>&lt;script type="module"&gt;


### PR DESCRIPTION
**Describe pull-request**  
Corrected spelling in HTML installation guide.


**Solving issue**  
Fixes: [CDEP-2568](https://tegel.atlassian.net/browse/CDEP-2568)

**How to test**  
1. Go to Installation
2. Check under HTML
3. Check the spelling of `install`


[CDEP-2568]: https://tegel.atlassian.net/browse/CDEP-2568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ