### PR TITLE
fix(banner): removed docs and implementation of unused event

### DIFF
--- a/core/src/components/banner/banner.stories.tsx
+++ b/core/src/components/banner/banner.stories.tsx
@@ -92,9 +92,6 @@ const Template = ({ variant, icon, header, subheader, actions }) =>
         document.addEventListener('tdsClose', (event) => {
           console.log(event)
         })
-        document.addEventListener('tdsShow', (event) => {
-          console.log(event)
-        })
       </script>
     `);
 export const Default = Template.bind({});

--- a/core/src/components/banner/banner.tsx
+++ b/core/src/components/banner/banner.tsx
@@ -47,17 +47,6 @@ export class TdsBanner {
     bannerId: string;
   }>;
 
-  /** Sends the unique Banner identifier when the close button is pressed. */
-  @Event({
-    eventName: 'tdsShow',
-    composed: true,
-    cancelable: true,
-    bubbles: true,
-  })
-  tdsShow: EventEmitter<{
-    bannerId: string;
-  }>;
-
   /** Hides the Banner. */
   @Method()
   async hideBanner() {
@@ -84,15 +73,6 @@ export class TdsBanner {
     });
     if (!tdsCloseEvent.defaultPrevented) {
       this.hidden = true;
-    }
-  };
-
-  handleShow = () => {
-    const tdsCloseEvent = this.tdsShow.emit({
-      bannerId: this.bannerId,
-    });
-    if (!tdsCloseEvent.defaultPrevented) {
-      this.hidden = false;
     }
   };
 

--- a/core/src/components/banner/readme.md
+++ b/core/src/components/banner/readme.md
@@ -19,10 +19,9 @@
 
 ## Events
 
-| Event      | Description                                                          | Type                                 |
-| ---------- | -------------------------------------------------------------------- | ------------------------------------ |
-| `tdsClose` | Sends a unique Banner identifier when the close button is pressed.   | `CustomEvent<{ bannerId: string; }>` |
-| `tdsShow`  | Sends the unique Banner identifier when the close button is pressed. | `CustomEvent<{ bannerId: string; }>` |
+| Event      | Description                                                        | Type                                 |
+| ---------- | ------------------------------------------------------------------ | ------------------------------------ |
+| `tdsClose` | Sends a unique Banner identifier when the close button is pressed. | `CustomEvent<{ bannerId: string; }>` |
 
 
 ## Methods


### PR DESCRIPTION
**Describe pull-request**  
Removed docs and implementation of unused event. This event could never get emitted so this is not a breaking change.

**Solving issue**  
Fixes: -

**How to test**  
1. Go to Banner
2. Check in Notes
3. Make sure the only event is the tdsClose event.

