### PR TITLE
build(stencil.config): prepare stencil build for wrappers

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,6 +7,8 @@
 **/conf.js
 **/.www
 
+
+core/components
 core/loader
 core/stencil.config.ts
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 www/
 loader/
+core/components
 
 *~
 *.sw[mnpcod]

--- a/core/package.json
+++ b/core/package.json
@@ -27,7 +27,7 @@
   "files": [
     "dist/",
     "loader/",
-    "components"
+    "components/"
   ],
   "publishConfig": {
     "access": "public"

--- a/core/package.json
+++ b/core/package.json
@@ -26,7 +26,8 @@
   },
   "files": [
     "dist/",
-    "loader/"
+    "loader/",
+    "components"
   ],
   "publishConfig": {
     "access": "public"

--- a/core/stencil.config.ts
+++ b/core/stencil.config.ts
@@ -18,6 +18,8 @@ export const config: Config = {
     {
       type: 'dist-custom-elements',
       generateTypeDeclarations: true,
+      dir: 'components',
+      customElementsExportBehavior: 'auto-define-custom-elements',
     },
     {
       type: 'docs-readme',


### PR DESCRIPTION
**Describe pull-request**  
Updated stencil config to put dist-custom-elements in correct folder and switched behaviour to auto-define-custom-elements. Also update ignore config to ignore stencil built components folder.


**Solving issue**  
Fixes: -

**How to test**  
1. Checkout branch
2. Run `npm build` in core.
3. Check that a `components` folder was generate (next to dist and loader)

