### PR TITLE
fix(text field): update description for no-min-width prop

### DIFF
--- a/core/src/components/text-field/readme.md
+++ b/core/src/components/text-field/readme.md
@@ -17,7 +17,7 @@
 | `maxLength`     | `max-length`     | Max length of input                         | `number`                              | `undefined`  |
 | `modeVariant`   | `mode-variant`   | Mode variant of the Text Field              | `"primary" \| "secondary"`            | `null`       |
 | `name`          | `name`           | Name property                               | `string`                              | `''`         |
-| `noMinWidth`    | `no-min-width`   | With setting                                | `boolean`                             | `false`      |
+| `noMinWidth`    | `no-min-width`   | Unset minimum width of 208px.               | `boolean`                             | `false`      |
 | `placeholder`   | `placeholder`    | Placeholder text                            | `string`                              | `''`         |
 | `readOnly`      | `read-only`      | Set input in readonly state                 | `boolean`                             | `false`      |
 | `size`          | `size`           | Size of the input                           | `"lg" \| "md" \| "sm"`                | `'lg'`       |

--- a/core/src/components/text-field/text-field.tsx
+++ b/core/src/components/text-field/text-field.tsx
@@ -47,7 +47,7 @@ export class TdsTextField {
   /** Mode variant of the Text Field */
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
-  /** With setting */
+  /** Unset minimum width of 208px. */
   @Prop() noMinWidth: boolean = false;
 
   /** Name property */


### PR DESCRIPTION
**Describe pull-request**  
Updated description for no-min-width prop to match same prop in Textarea

**Solving issue**  
Fixes: [CDEP-2589](https://tegel.atlassian.net/jira/software/projects/CDEP/boards/1?selectedIssue=CDEP-2589)

**How to test**  
1. Go to Storybook link below
2. Check in Text Field -> Notes
3. Check that the no-min-width prop has the same description as the corresponding prop in Textarea component


[CDEP-2589]: https://tegel.atlassian.net/browse/CDEP-2589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ