### PR TITLE
fix(dropdown): fixed missplacement issue of the dropdowns focus state

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-button.scss
+++ b/packages/core/src/components/dropdown/dropdown-button.scss
@@ -27,7 +27,7 @@
     }
 
     &:focus {
-      border-bottom-color: transparent;
+      border-bottom-color: var(--tds-dropdown-border-bottom-open);
 
       &::before {
         content: '';
@@ -35,7 +35,7 @@
         bottom: 0;
         left: 0;
         width: 100%;
-        height: 2px;
+        height: 1px;
         background: var(--tds-dropdown-border-bottom-open);
       }
     }

--- a/packages/core/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/core/src/components/dropdown/dropdown.stories.tsx
@@ -197,9 +197,15 @@ const Template = ({
     width: 300px;
     height:200px;
   }
+  .hej {
+    margin-top: 79px;
+  }
   </style>
 
-    <div class="demo-wrapper">
+    <div class="demo-wrapper tds-u-flex">
+        <div class="hej" style="width: 150px;">
+         <tds-divider orientation="horizontal"></tds-divider>
+        </div>
         <tds-dropdown
         ${
           defaultOption && defaultOption !== 'No default'


### PR DESCRIPTION
**Describe pull-request**  
The dropdowns focus state was previously missaligned with its bottom border. This was due to us adding a bottom border of 2px on top of the regular bottom border when it had focus. This PR fixes this issue. 

**Solving issue**  
Fixes: [CDEP-2644](https://tegel.atlassian.net/browse/CDEP-2644)

**How to test**  
1. Go to Dropdown
2. Click the dropdown
3. Make sure the line on the side of the dropdown is still inline with the bottom border.

**NOTE:** The divider needs to be removed before merging.


[CDEP-2644]: https://tegel.atlassian.net/browse/CDEP-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ