### PR TITLE
fix(dropdown): stopPropogation on checkbox change event in dropdown-option

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -100,6 +100,7 @@ export class TdsDropdownOption {
           value: this.value,
           selected: this.selected,
         });
+        event.stopPropagation();
       } else {
         this.parentElement.removeValue(this.value);
         this.selected = false;


### PR DESCRIPTION
**Describe pull-request**  
When selecting a muliselect option in the dropdown two `tdsChange` event were being emitted. One from the `tds-dropdown` and one from the `tds-checkbox` inside the `tds-dropdown-option`. This PR stopPropgation on the second event to only emit a `tdsChange` event from the `tds-dropdown`.

**Solving issue**  
Fixes: [CDEP-2639](https://tegel.atlassian.net/browse/CDEP-2639)

**How to test**  
1. Go to Dropdown
2. Add multiselect.
3. Select an option
4. Check the console and make sure only one `tdsChange` evet in being logged.




[CDEP-2639]: https://tegel.atlassian.net/browse/CDEP-2639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ