### PR TITLE
docs(popover/tooltip): used selector over referenceEl

### DIFF
--- a/packages/core/src/components/popover-menu/popover-menu.stories.tsx
+++ b/packages/core/src/components/popover-menu/popover-menu.stories.tsx
@@ -101,6 +101,7 @@ const Template = ({ menuPosition, icons, fluidWidth }) => {
       id="my-popover-menu"
       placement="${menuPosLookup[menuPosition]}"
       ${fluidWidth ? 'fluid-width' : ''}
+      selector="#my-popover-button"
       >
         <tds-popover-menu-item>
           <a href="#"> ${icons ? '<tds-icon name="share"></tds-icon>' : ''} Action </a>
@@ -145,10 +146,7 @@ const Template = ({ menuPosition, icons, fluidWidth }) => {
       </tds-button>
     </div>
     
-    <script>
-      // The 'selector' prop on Popover-Menu can be used instead, but it might be less ideal in frameworks like React 
-      document.getElementById('my-popover-menu').referenceEl = document.getElementById('my-popover-button');
-    </script>
+    
     `,
   );
 };

--- a/packages/core/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/core/src/components/tooltip/tooltip.stories.tsx
@@ -117,8 +117,6 @@ const ComponentTooltip = ({ tooltipPosition, mouseOverTooltip, text, slot }) =>
     </style>
 
    <div class="demo-wrapper">
-   <!-- The 'referenceEl' prop can be used instead of 'selector',
-    which might be preferable in frameworks like React -->
    <tds-tooltip
       placement="${positionLookup[tooltipPosition]}"
       text="${text}"

--- a/packages/core/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/core/src/components/tooltip/tooltip.stories.tsx
@@ -120,24 +120,16 @@ const ComponentTooltip = ({ tooltipPosition, mouseOverTooltip, text, slot }) =>
    <!-- The 'referenceEl' prop can be used instead of 'selector',
     which might be preferable in frameworks like React -->
    <tds-tooltip
-      id="tooltip-1"
       placement="${positionLookup[tooltipPosition]}"
       text="${text}"
+      selector="#my-tooltip-button"
       mouse-over-tooltip="${mouseOverTooltip}">
       ${slot}
     </tds-tooltip>
 
     <!-- Demo button for presentation purposes -->
-    <tds-button size= 'sm' id="button-1" text='Hover me'></tds-button>
+    <tds-button size= 'sm' id="my-tooltip-button" text='Hover me'></tds-button>
    </div>
-   <script>
-   (() => {
-     const tooltip = document.getElementById('tooltip-1');
-     const button = document.getElementById('button-1');
-
-     tooltip.referenceEl = button;
-    })();
-   </script>
   `,
   );
 


### PR DESCRIPTION
**Describe pull-request**  
Updated storybook to document `selector` over `referenceEl` due to unstable support of referenceEl in framework wrappers.

**Solving issue**  
Fixes: [CDEP-2651](https://tegel.atlassian.net/browse/CDEP-2651)

**How to test**  
1. Go to Tooltip/Popover Menu
2. Test that the component works as intended

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events




[CDEP-2651]: https://tegel.atlassian.net/browse/CDEP-2651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ