### PR TITLE
docs(banner): no undefined icon in error and info variant

### DIFF
--- a/packages/core/src/components/banner/banner.stories.tsx
+++ b/packages/core/src/components/banner/banner.stories.tsx
@@ -80,7 +80,7 @@ const Template = ({ variant, icon, header, subheader, actions }) =>
   formatHtmlPreview(`
       <tds-banner
           ${variant !== 'Default' ? `variant="${variant.toLowerCase()}"` : ''}
-          ${icon !== 'none' ? `icon="${icon}"` : ''}
+          ${icon !== 'none' && variant === 'Default' ? `icon="${icon}"` : ''}
           ${header !== '' ? `header="${header}"` : ''}
           ${subheader ? `subheader="${subheader}"` : ''}       
           >


### PR DESCRIPTION
**Describe pull-request**  
The banner story shows undefined under the icon prop for the "Error" and "Information" variants.

**Solving issue**  
Fixes: [CDEP-2645](https://tegel.atlassian.net/browse/CDEP-2645)

**How to test**  
1. Open Storybook preview
2. Check Banner component
3. Set it to the Information or Error variant
4. Observe "Docs" tab - icon prop should not be there
5. Compare with [prod Storybook](https://tegel-storybook.netlify.app/?path=/story/components-banner--default), issue is present there - icon is "undefined" for those two varinats

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events




[CDEP-2645]: https://tegel.atlassian.net/browse/CDEP-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ