### PR TITLE
feat(icon): switch title to text element in svg

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -46,7 +46,7 @@ export class Icon {
             height={this.size}
             width={this.size}
           >
-            <title>{`icon ${element.name}`}</title>
+            <text>{`${element.name} icon`}</text>
             <path fill="currentColor" d={element.definition} />
           </svg>
         );


### PR DESCRIPTION
**Describe pull-request**  
Since out current tds-icon components svg has a title element it displays the title when the icon is being hovered.
See image: <img width="324" alt="Screenshot 2023-09-19 at 19 27 22" src="https://github.com/scania-digital-design-system/tegel/assets/62651103/3a148e5b-0807-4795-975c-515ceab3e314">

This PR switches the title element for a text element instead. It should still be as accessible,. but the hover effect is removed. This guide was followed: https://www.smashingmagazine.com/2021/05/accessible-svg-patterns-comparison/



**Solving issue**  
Fixes: [CDEP-2634](https://tegel.atlassian.net/browse/CDEP-2634)

**How to test**  
1. Go to Icon
2. Hover the icon for a couple of seconds
3. Make sure there is not text showing.


[CDEP-2634]: https://tegel.atlassian.net/browse/CDEP-2634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ