### PR TITLE
fix(dropdown): override line-height to avoid overflow:hidden

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-button.scss
+++ b/packages/core/src/components/dropdown/dropdown-button.scss
@@ -29,7 +29,7 @@
 
       /** Needed to not get be affected by overflow:hidden 
       The original line-height is 1.14 */
-      line-height: 1.2;
+      line-height: 1.3;
     }
 
     &:focus {

--- a/packages/core/src/components/dropdown/dropdown-button.scss
+++ b/packages/core/src/components/dropdown/dropdown-button.scss
@@ -24,6 +24,12 @@
 
     &.value {
       color: var(--tds-dropdown-value-color);
+      font: var(--tds-detail-02);
+      letter-spacing: var(--tds-detail-02-ls);
+
+      /** Needed to not get be affected by overflow:hidden 
+      The original line-height is 1.14 */
+      line-height: 1.2;
     }
 
     &:focus {

--- a/packages/core/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/core/src/components/dropdown/dropdown.stories.tsx
@@ -202,10 +202,7 @@ const Template = ({
   }
   </style>
 
-    <div class="demo-wrapper tds-u-flex">
-        <div class="hej" style="width: 150px;">
-         <tds-divider orientation="horizontal"></tds-divider>
-        </div>
+    <div class="demo-wrapper">
         <tds-dropdown
         ${
           defaultOption && defaultOption !== 'No default'
@@ -237,7 +234,7 @@ const Template = ({
           open-direction="${openDirection.toLowerCase()}"
           >
             <tds-dropdown-option value="option-1">
-              Option 1
+              Övergripande Ålder Är En MYCKET LÄNGRE SAK
             </tds-dropdown-option>
             <tds-dropdown-option disabled value="option-2">
               Option 2


### PR DESCRIPTION
**Describe pull-request**  
The value in the dropdown is getting cut off (due to overflow: hidden). To combat this we need to up the line-height.

Example: 
<img width="431" alt="Screenshot 2023-09-19 at 20 05 57" src="https://github.com/scania-digital-design-system/tegel/assets/62651103/3c9563c7-e55a-4da9-8808-553216671695">


**Solving issue**  
Fixes: [CDEP-2637](https://tegel.atlassian.net/browse/CDEP-2637)

**How to test**  
1. Go to Dropdown
2. Select the first value
3. Make sure no parts of the word is getting cut off.


[CDEP-2637]: https://tegel.atlassian.net/browse/CDEP-2637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ