### PR TITLE
fix(slider): enable for runtime updates of value/readOnly

### DIFF
--- a/packages/core/src/components/slider/slider.stories.tsx
+++ b/packages/core/src/components/slider/slider.stories.tsx
@@ -251,9 +251,15 @@ const Template = ({
         >
       </tds-slider>
     </div>
+    <button id="test">button</button>
      <!-- Script tag for demo purposes -->
     <script>
       slider = document.querySelector('tds-slider')
+      button = document.querySelector('#test')
+
+      button.addEventListener('click', () => {
+        slider.readOnly = !slider.readOnly
+      })
       
       slider.removeEventListener('tdsChange', null)
       slider.addEventListener('tdsChange', (event) => {

--- a/packages/core/src/components/slider/slider.stories.tsx
+++ b/packages/core/src/components/slider/slider.stories.tsx
@@ -251,16 +251,10 @@ const Template = ({
         >
       </tds-slider>
     </div>
-
-    <button id="test">test</button>
      <!-- Script tag for demo purposes -->
     <script>
       slider = document.querySelector('tds-slider')
-      button = document.querySelector("#test")
-      button.addEventListener('click', () => {
-        slider.value = 20;
-      })
-
+      
       slider.removeEventListener('tdsChange', null)
       slider.addEventListener('tdsChange', (event) => {
         console.log(event);

--- a/packages/core/src/components/slider/slider.stories.tsx
+++ b/packages/core/src/components/slider/slider.stories.tsx
@@ -251,15 +251,10 @@ const Template = ({
         >
       </tds-slider>
     </div>
-    <button id="test">button</button>
+    
      <!-- Script tag for demo purposes -->
     <script>
       slider = document.querySelector('tds-slider')
-      button = document.querySelector('#test')
-
-      button.addEventListener('click', () => {
-        slider.readOnly = !slider.readOnly
-      })
       
       slider.removeEventListener('tdsChange', null)
       slider.addEventListener('tdsChange', (event) => {

--- a/packages/core/src/components/slider/slider.stories.tsx
+++ b/packages/core/src/components/slider/slider.stories.tsx
@@ -252,9 +252,14 @@ const Template = ({
       </tds-slider>
     </div>
 
+    <button id="test">test</button>
      <!-- Script tag for demo purposes -->
     <script>
       slider = document.querySelector('tds-slider')
+      button = document.querySelector("#test")
+      button.addEventListener('click', () => {
+        slider.value = 20;
+      })
 
       slider.removeEventListener('tdsChange', null)
       slider.addEventListener('tdsChange', (event) => {

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, Listen, EventEmitter, Event, Method } from '@stencil/core';
+import { Component, h, Prop, Listen, EventEmitter, Event, Method, Watch } from '@stencil/core';
 import { generateUniqueId } from '../../utils/utils';
 
 @Component({
@@ -175,6 +175,13 @@ export class TdsSlider {
     }
 
     this.thumbCore(event);
+  }
+
+  @Watch('value')
+  handleValueUpdate(newVal) {
+    this.calculateThumbLeftFromValue(newVal);
+    this.updateValueForced(newVal);
+    this.updateTrack();
   }
 
   updateSupposedValueSlot(localLeft) {

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -77,8 +77,6 @@ export class TdsSlider {
 
   private tickValues: Array<number> = [];
 
-  private readonlyState: boolean = false;
-
   private useControls: boolean = false;
 
   private useInput: boolean = false;
@@ -363,7 +361,7 @@ export class TdsSlider {
   }
 
   grabThumb() {
-    if (this.readonlyState) {
+    if (this.readOnly) {
       return;
     }
     this.thumbGrabbed = true;
@@ -375,7 +373,7 @@ export class TdsSlider {
   }
 
   controlsStep(delta) {
-    if (this.readonlyState || this.disabled) {
+    if (this.readOnly || this.disabled) {
       return;
     }
 
@@ -437,8 +435,6 @@ export class TdsSlider {
       this.tickValues.push(this.getMax());
     }
 
-    this.readonlyState = this.readOnly;
-
     this.useInput = false;
     this.useControls = false;
 
@@ -464,7 +460,7 @@ export class TdsSlider {
 
   render() {
     return (
-      <div class={`tds-slider-wrapper ${this.readonlyState ? 'read-only' : ''}`}>
+      <div class={`tds-slider-wrapper ${this.readOnly ? 'read-only' : ''}`}>
         <input
           class="tds-slider-native-element"
           type="range"
@@ -587,7 +583,7 @@ export class TdsSlider {
               <div class="tds-slider__input-field-wrapper">
                 <input
                   onFocus={(e) => {
-                    if (this.readonlyState) {
+                    if (this.readOnly) {
                       e.preventDefault();
                       this.inputElement.blur();
                     }


### PR DESCRIPTION
**Describe pull-request**  
Added a watcher on value to allow for runtime updates. 
Removed the internal `readOnlyState` which was being set in `componentWillLoad`, this enabled for runtime updates of the `readOnly` prop.

**Solving issue**  
Fixes: [CDEP-2587](https://tegel.atlassian.net/browse/CDEP-2587), [CDEP-2655](https://tegel.atlassian.net/browse/CDEP-2655)

**How to test**  
1. Checkout branch and run storybook
2. Go to Slider 
3. Update the readOnly / value props in runtime.
4. Make sure the sliders readOnly prop is being toggled.


[CDEP-2587]: https://tegel.atlassian.net/browse/CDEP-2587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CDEP-2655]: https://tegel.atlassian.net/browse/CDEP-2655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ