### PR TITLE
fix(dropdown): setValue method

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -100,7 +100,6 @@ export class TdsDropdownOption {
           value: this.value,
           selected: this.selected,
         });
-        event.stopPropagation();
       } else {
         this.parentElement.removeValue(this.value);
         this.selected = false;
@@ -109,6 +108,7 @@ export class TdsDropdownOption {
           selected: this.selected,
         });
       }
+      event.stopPropagation();
     }
   };
 

--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -80,7 +80,7 @@ export class TdsDropdownOption {
   handleSingleSelect = () => {
     if (!this.disabled) {
       this.selected = true;
-      this.parentElement.setValue(this.value, this.label);
+      this.parentElement.appendValue({ value: this.value, label: this.label });
       this.parentElement.close();
       this.tdsSelect.emit({
         value: this.value,
@@ -94,7 +94,7 @@ export class TdsDropdownOption {
   ) => {
     if (!this.disabled) {
       if (event.detail.checked) {
-        this.parentElement.setValue(this.value, this.label);
+        this.parentElement.appendValue({ value: this.value, label: this.label });
         this.selected = true;
         this.tdsSelect.emit({
           value: this.value,

--- a/packages/core/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/core/src/components/dropdown/dropdown.stories.tsx
@@ -255,7 +255,6 @@ const Template = ({
               Option 7
             </tds-dropdown-option>
         </tds-dropdown>
-        <button id="test">Do it!</button>
     </div>
 
     <script>

--- a/packages/core/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/core/src/components/dropdown/dropdown.stories.tsx
@@ -234,7 +234,7 @@ const Template = ({
           open-direction="${openDirection.toLowerCase()}"
           >
             <tds-dropdown-option value="option-1">
-              Övergripande Ålder Är En MYCKET LÄNGRE SAK
+              Option 1
             </tds-dropdown-option>
             <tds-dropdown-option disabled value="option-2">
               Option 2
@@ -255,10 +255,12 @@ const Template = ({
               Option 7
             </tds-dropdown-option>
         </tds-dropdown>
+        <button id="test">Do it!</button>
     </div>
 
     <script>
     dropdown = document.querySelector('tds-dropdown')
+
     dropdown.addEventListener('tdsChange', (event) => {
       console.log(event)
     })

--- a/packages/core/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/core/src/components/dropdown/dropdown.stories.tsx
@@ -245,24 +245,16 @@ const Template = ({
             <tds-dropdown-option value="option-4">
               Option 4
             </tds-dropdown-option>
-            <tds-dropdown-option value="option-5">
-              Option 5
-            </tds-dropdown-option>
-            <tds-dropdown-option value="option-6">
-              Option 6
-            </tds-dropdown-option>
-            <tds-dropdown-option value="option-7">
-              Option 7
-            </tds-dropdown-option>
         </tds-dropdown>
     </div>
 
     <script>
-    dropdown = document.querySelector('tds-dropdown')
+      dropdown = document.querySelector('tds-dropdown')
 
-    dropdown.addEventListener('tdsChange', (event) => {
-      console.log(event)
-    })
+      dropdown.addEventListener('tdsChange', (event) => {
+        console.log(event)
+      })
+
     </script>
         
   `);

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -268,7 +268,7 @@ export class TdsDropdown {
   }
 
   private internalReset() {
-    this.children = this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
+    this.getChildren().forEach((element: HTMLTdsDropdownOptionElement) => {
       element.setSelected(false);
       return element;
     });
@@ -302,7 +302,7 @@ export class TdsDropdown {
   };
 
   selectChildrenAsSelectedBasedOnSelectionProp() {
-    this.children = this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
+    this.getChildren().forEach((element: HTMLTdsDropdownOptionElement) => {
       this.selection.forEach((selection) => {
         if (element.value !== selection.value) {
           // If not multiselect, we need to unselect all other options.

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -104,8 +104,6 @@ export class TdsDropdown {
     else nextValue = value;
 
     if (!this.multiselect && nextValue.length > 1) {
-      console.log(nextValue);
-      console.log(nextValue.length);
       console.warn('Tried to select multiple items, but multiselect is not enabled.');
       nextValue = [nextValue[0]];
     }

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -81,28 +81,56 @@ export class TdsDropdown {
     this.handleChange();
   }
 
-  /** Method for setting the value of the Dropdown. */
+  /** Method for setting the value of the Dropdown.
+   *
+   * Single selection example:
+   *
+   * <code>
+   *  dropdown.setValue('option-1', 'Option 1');
+   * </code>
+   *
+   * Multiselect example:
+   *
+   * <code>
+   *  dropdown.setValue([<br />
+   *  &nbsp;{ value: 'option-4', label: 'Option 4' },<br />
+   *  &nbsp;{ value: 'option-1', label: 'Option 1' }<br />
+   *  ]);
+   * </code>
+   */
   @Method()
-  async setValue(newValue: string, newValueLabel: string) {
-    const optionExist = this.getChildren().some(
-      (element: HTMLTdsDropdownOptionElement) => element.value === newValue,
-    );
-    // Check if any of the dropdown options has the value that is passed to the method.
-    if (optionExist) {
-      if (this.multiselect) {
-        this.selection = this.selection
-          ? [...this.selection, { value: newValue, label: newValueLabel }]
-          : [{ value: newValue, label: newValueLabel }];
-      } else {
-        this.selection = [{ value: newValue, label: newValueLabel }];
-      }
-      this.host.setAttribute(
-        'value',
-        this.selection.map((selection) => selection.value).toString(),
-      );
-      this.selectChildrenAsSelectedBasedOnSelectionProp();
-      this.handleChange();
+  async setValue(
+    value: string | { value: string; label: string } | { value: string; label: string }[],
+    label?: string,
+  ) {
+    let nextValue: Array<{ value: string; label: string }>;
+    if (typeof value === 'string') nextValue = [{ value, label }];
+    else if (!Array.isArray(value)) nextValue = [value];
+    else nextValue = value;
+
+    if (!this.multiselect && nextValue.length > 1) {
+      console.warn('Tried to select multiple items, but multiselect is not enabled.');
+      nextValue = [nextValue[0]];
     }
+
+    this.reset();
+
+    for (let i = 0; i < nextValue.length; i++) {
+      const optionExist = this.getChildren().some(
+        (element: HTMLTdsDropdownOptionElement) => element.value === nextValue[i].value,
+      );
+      if (!optionExist) {
+        nextValue.splice(i, 1);
+      }
+    }
+
+    this.selection = nextValue;
+
+    this.host.setAttribute('value', this.selection.map((selection) => selection.value).toString());
+
+    this.selectChildrenAsSelectedBasedOnSelectionProp();
+    this.handleChange();
+
     return this.selection;
   }
 

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -134,6 +134,14 @@ export class TdsDropdown {
     return this.selection;
   }
 
+  /**
+   * @internal
+   */
+  @Method()
+  async appendValue(value: { value: string; label: string }) {
+    this.setValue([...this.selection, value]);
+  }
+
   /** Method for removing a selected value in the Dropdown. */
   @Method()
   async removeValue(oldValue: string) {

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -97,8 +97,6 @@ export class TdsDropdown {
         return element;
       });
     }
-    this.handleChange();
-    this.host.setAttribute('value', this.selection.map((selection) => selection.value).toString());
     return this.selection;
   }
 
@@ -252,6 +250,19 @@ export class TdsDropdown {
         return element;
       });
   };
+
+  selectChildrenAsSelectedBasedOnSelectionProp() {
+    this.children = this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
+      this.selection.forEach((selection) => {
+        if (element.value !== selection.value) {
+          element.setSelected(false);
+        } else {
+          element.setSelected(true);
+        }
+      });
+      return element;
+    });
+  }
 
   /* Returns a list of all children that are are tds-dropdown-option elements */
   private getChildren = () =>

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -84,18 +84,24 @@ export class TdsDropdown {
   /** Method for setting the value of the Dropdown. */
   @Method()
   async setValue(newValue: string, newValueLabel: string) {
-    if (this.multiselect) {
-      this.selection = this.selection
-        ? [...this.selection, { value: newValue, label: newValueLabel }]
-        : [{ value: newValue, label: newValueLabel }];
-    } else {
-      this.selection = [{ value: newValue, label: newValueLabel }];
-      this.getChildren().forEach((element: HTMLTdsDropdownOptionElement) => {
-        if (element.value !== newValue) {
-          element.setSelected(false);
-        }
-        return element;
-      });
+    const optionExist = this.getChildren().some(
+      (element: HTMLTdsDropdownOptionElement) => element.value === newValue,
+    );
+    // Check if any of the dropdown options has the value that is passed to the method.
+    if (optionExist) {
+      if (this.multiselect) {
+        this.selection = this.selection
+          ? [...this.selection, { value: newValue, label: newValueLabel }]
+          : [{ value: newValue, label: newValueLabel }];
+      } else {
+        this.selection = [{ value: newValue, label: newValueLabel }];
+      }
+      this.host.setAttribute(
+        'value',
+        this.selection.map((selection) => selection.value).toString(),
+      );
+      this.selectChildrenAsSelectedBasedOnSelectionProp();
+      this.handleChange();
     }
     return this.selection;
   }

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -255,7 +255,7 @@ export class TdsDropdown {
     this.children = this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
       this.selection.forEach((selection) => {
         if (element.value !== selection.value) {
-          // If it not multiselect we need to unselect all other options.
+          // If not multiselect, we need to unselect all other options.
           if (!this.multiselect) {
             element.setSelected(false);
           }

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -72,12 +72,7 @@ export class TdsDropdown {
   /** Method that resets the Dropdown, marks all children as non-selected and resets the value to null. */
   @Method()
   async reset() {
-    this.getChildren().forEach((element: HTMLTdsDropdownOptionElement) => {
-      element.setSelected(false);
-      return element;
-    });
-    this.selection = null;
-    this.host.setAttribute('value', null);
+    this.internalReset();
     this.handleChange();
   }
 
@@ -109,11 +104,13 @@ export class TdsDropdown {
     else nextValue = value;
 
     if (!this.multiselect && nextValue.length > 1) {
+      console.log(nextValue);
+      console.log(nextValue.length);
       console.warn('Tried to select multiple items, but multiselect is not enabled.');
       nextValue = [nextValue[0]];
     }
 
-    this.reset();
+    this.internalReset();
 
     for (let i = 0; i < nextValue.length; i++) {
       const optionExist = this.getChildren().some(
@@ -139,7 +136,11 @@ export class TdsDropdown {
    */
   @Method()
   async appendValue(value: { value: string; label: string }) {
-    this.setValue([...this.selection, value]);
+    if (this.multiselect && this.selection) {
+      this.setValue([...this.selection, value]);
+    } else {
+      this.setValue(value);
+    }
   }
 
   /** Method for removing a selected value in the Dropdown. */
@@ -266,6 +267,15 @@ export class TdsDropdown {
     if (this.defaultValue) {
       this.setDefaultOption();
     }
+  }
+
+  private internalReset() {
+    this.children = this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
+      element.setSelected(false);
+      return element;
+    });
+    this.selection = null;
+    this.host.setAttribute('value', null);
   }
 
   setDefaultOption = () => {

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -255,7 +255,10 @@ export class TdsDropdown {
     this.children = this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
       this.selection.forEach((selection) => {
         if (element.value !== selection.value) {
-          element.setSelected(false);
+          // If it not multiselect we need to unselect all other options.
+          if (!this.multiselect) {
+            element.setSelected(false);
+          }
         } else {
           element.setSelected(true);
         }

--- a/packages/core/src/components/dropdown/readme.md
+++ b/packages/core/src/components/dropdown/readme.md
@@ -68,9 +68,24 @@ Type: `Promise<void>`
 
 
 
-### `setValue(newValue: string, newValueLabel: string) => Promise<{ value: string; label: string; }[]>`
+### `setValue(value: string | { value: string; label: string; } | { value: string; label: string; }[], label?: string) => Promise<{ value: string; label: string; }[]>`
 
 Method for setting the value of the Dropdown.
+
+Single selection example:
+
+<code>
+dropdown.setValue('option-1', 'Option 1');
+</code>
+
+Multiselect example:
+
+<code>
+dropdown.setValue([<br />
+&nbsp;{ value: 'option-4', label: 'Option 4' },<br />
+&nbsp;{ value: 'option-1', label: 'Option 1' }<br />
+]);
+</code>
 
 #### Returns
 

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -20,7 +20,7 @@
 
 | Event     | Description                                                                                                                                                          | Type                                                                                      |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
+| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "desc" \| "asc"; }>` |
 
 
 ----------------------------------------------

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -20,7 +20,7 @@
 
 | Event     | Description                                                                                                                                                          | Type                                                                                      |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "desc" \| "asc"; }>` |
+| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
 
 
 ----------------------------------------------


### PR DESCRIPTION
**Describe pull-request**  
The setValue method updated the `selection` of the dropdown without updating the selected state of its children. 

This PR updates the `setValue` method to enable for both value and label pair, object and array of object as it parameters. It also fixes a previous issue with double events firing on selection on multiselect. 


**Solving issue**  
Fixes: [CDEP-2656](https://tegel.atlassian.net/browse/CDEP-2656)

**How to test**  
1. Go to Dropdown
2. Update the selection using the setValue method.


[CDEP-2656]: https://tegel.atlassian.net/browse/CDEP-2656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ