### PR TITLE
fix(card): clickable card not full width

### DIFF
--- a/packages/core/src/components/card/card.scss
+++ b/packages/core/src/components/card/card.scss
@@ -94,6 +94,7 @@
 }
 
 button {
+  width: 100%;
   border: none;
   text-align: left;
   padding: 0;


### PR DESCRIPTION
**Describe pull-request**  
Made the card 100% width when clickable.

**Solving issue**  
Fixes: [CDEP-2661](https://tegel.atlassian.net/browse/CDEP-2661)

**How to test**  
1. Go to Card
2. Make it `clickable`
3. Make sure it has the same width as the non clickable card.



[CDEP-2661]: https://tegel.atlassian.net/browse/CDEP-2661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ