### PR TITLE
fix(block): updating block modeVariant in runtime

### DIFF
--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -16,7 +16,7 @@ export class TdsBlock {
 
   children: Array<HTMLTdsBlockElement>;
 
-  connectedCallback() {
+  componentDidRender() {
     this.children = Array.from(this.host.children).filter(
       (item) => item.tagName === 'TDS-BLOCK',
     ) as HTMLTdsBlockElement[];

--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -16,11 +16,12 @@ export class TdsBlock {
 
   children: Array<HTMLTdsBlockElement>;
 
-  componentDidRender() {
+  setModeVariantOnChildBlocks() {
     this.children = Array.from(this.host.children).filter(
       (item) => item.tagName === 'TDS-BLOCK',
     ) as HTMLTdsBlockElement[];
-    this.children.forEach((item) => {
+
+    this.children?.forEach((item) => {
       if (!this.modeVariant) {
         item.setAttribute('mode-variant', 'secondary');
       } else {
@@ -30,6 +31,7 @@ export class TdsBlock {
   }
 
   render() {
+    this.setModeVariantOnChildBlocks();
     return (
       <div
         class={`tds-block ${


### PR DESCRIPTION
**Describe pull-request**  
Placed the setting of child blocks in side the render function. This will ensure us that the function `setModeVariantOnChildBlocks` run every time the block is rerender or on initial render.

**Solving issue**  
Fixes: [CDEP-2434](https://tegel.atlassian.net/browse/CDEP-2434)

**How to test**  
1. Go to Block
2. Update the modeVariant of the parent block in runtime
For example, add the following inte the template in the block story file: 

```
      <button id="test">test</button>

      <script>
      block = document.querySelector('#block')
      button = document.querySelector('#test')

      button.addEventListener('click', () => {
        block.modeVariant = block.modeVariant === 'primary' ? 'secondary':'primary';
      })

      
      </script>
```
3. Make sure this changes the modeVariant of the child element



[CDEP-2434]: https://tegel.atlassian.net/browse/CDEP-2434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ