### PR TITLE
fix(dropdown): use getChildren over fetching children in connectedCallback

### DIFF
--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -72,7 +72,7 @@ export class TdsDropdown {
   /** Method that resets the Dropdown, marks all children as non-selected and resets the value to null. */
   @Method()
   async reset() {
-    this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
+    this.getChildren().forEach((element: HTMLTdsDropdownOptionElement) => {
       element.setSelected(false);
       return element;
     });
@@ -90,7 +90,7 @@ export class TdsDropdown {
         : [{ value: newValue, label: newValueLabel }];
     } else {
       this.selection = [{ value: newValue, label: newValueLabel }];
-      this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
+      this.getChildren().forEach((element: HTMLTdsDropdownOptionElement) => {
         if (element.value !== newValue) {
           element.setSelected(false);
         }
@@ -106,7 +106,7 @@ export class TdsDropdown {
   @Method()
   async removeValue(oldValue: string) {
     if (this.multiselect) {
-      this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
+      this.getChildren().forEach((element: HTMLTdsDropdownOptionElement) => {
         if (element.value === oldValue) {
           this.selection = this.selection.filter((item) => item.value !== element.value);
           element.setSelected(false);
@@ -231,7 +231,7 @@ export class TdsDropdown {
   setDefaultOption = () => {
     Array.from(this.host.children)
       .filter((element) => element.tagName === 'TDS-DROPDOWN-OPTION')
-      .map((element: HTMLTdsDropdownOptionElement) => {
+      .forEach((element: HTMLTdsDropdownOptionElement) => {
         if (this.multiselect) {
           this.defaultValue.split(',').forEach((value) => {
             if (value === element.value) {
@@ -286,7 +286,7 @@ export class TdsDropdown {
     /* Check if the query is empty, and if so, show all options */
     const children = this.getChildren();
     if (query === '') {
-      children.map((element) => {
+      children.forEach((element) => {
         element.removeAttribute('hidden');
         return element;
       });

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -191,20 +191,22 @@ export class TdsDropdown {
       nextElementSibling return the index for the first child in our Dropdown.  */
 
       const startingIndex = activeElement.nextElementSibling
-        ? this.children.findIndex((element) => element === activeElement.nextElementSibling)
+        ? this.getChildren().findIndex((element) => element === activeElement.nextElementSibling)
         : 0;
 
-      const elementIndex = findNextFocusableElement(this.children, startingIndex);
-      this.children[elementIndex].focus();
+      const elementIndex = findNextFocusableElement(this.getChildren(), startingIndex);
+      this.getChildren()[elementIndex].focus();
     } else if (event.key === 'ArrowUp') {
       /* Get the index of the current focus index, if there is no
       previousElementSibling return the index for the first last in our Dropdown.  */
       const startingIndex = activeElement.nextElementSibling
-        ? this.children.findIndex((element) => element === activeElement.previousElementSibling)
+        ? this.getChildren().findIndex(
+            (element) => element === activeElement.previousElementSibling,
+          )
         : 0;
 
-      const elementIndex = findPreviousFocusableElement(this.children, startingIndex);
-      this.children[elementIndex].focus();
+      const elementIndex = findPreviousFocusableElement(this.getChildren(), startingIndex);
+      this.getChildren()[elementIndex].focus();
     } else if (event.key === 'Escape') {
       this.open = false;
     }
@@ -254,7 +256,9 @@ export class TdsDropdown {
 
   /* Returns a list of all children that are are tds-dropdown-option elements */
   private getChildren = () =>
-    Array.from(this.host.children).filter((element) => element.tagName === 'TDS-DROPDOWN-OPTION');
+    Array.from(this.host.children).filter(
+      (element) => element.tagName === 'TDS-DROPDOWN-OPTION',
+    ) as Array<HTMLTdsDropdownOptionElement>;
 
   getOpenDirection = () => {
     if (this.openDirection === 'auto' || !this.openDirection) {
@@ -282,14 +286,14 @@ export class TdsDropdown {
     const query = event.target.value.toLowerCase();
     /* Check if the query is empty, and if so, show all options */
     if (query === '') {
-      this.children = this.children.map((element) => {
+      this.children = this.getChildren().map((element) => {
         element.removeAttribute('hidden');
         return element;
       });
       this.filterResult = null;
       /* Hide the options that do not match the query */
     } else {
-      this.filterResult = this.children.filter((element) => {
+      this.filterResult = this.getChildren().filter((element) => {
         if (!element.textContent.toLowerCase().includes(query.toLowerCase())) {
           element.setAttribute('hidden', '');
         } else {

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -69,12 +69,10 @@ export class TdsDropdown {
 
   private inputElement: HTMLInputElement;
 
-  private children: Array<HTMLTdsDropdownOptionElement>;
-
   /** Method that resets the Dropdown, marks all children as non-selected and resets the value to null. */
   @Method()
   async reset() {
-    this.children = this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
+    this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
       element.setSelected(false);
       return element;
     });
@@ -92,7 +90,7 @@ export class TdsDropdown {
         : [{ value: newValue, label: newValueLabel }];
     } else {
       this.selection = [{ value: newValue, label: newValueLabel }];
-      this.children = this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
+      this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
         if (element.value !== newValue) {
           element.setSelected(false);
         }
@@ -108,7 +106,7 @@ export class TdsDropdown {
   @Method()
   async removeValue(oldValue: string) {
     if (this.multiselect) {
-      this.children = this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
+      this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
         if (element.value === oldValue) {
           this.selection = this.selection.filter((item) => item.value !== element.value);
           element.setSelected(false);
@@ -186,16 +184,17 @@ export class TdsDropdown {
       return;
     }
 
+    const children = this.getChildren();
     if (event.key === 'ArrowDown') {
       /* Get the index of the current focus index, if there is no
       nextElementSibling return the index for the first child in our Dropdown.  */
 
       const startingIndex = activeElement.nextElementSibling
-        ? this.getChildren().findIndex((element) => element === activeElement.nextElementSibling)
+        ? children.findIndex((element) => element === activeElement.nextElementSibling)
         : 0;
 
-      const elementIndex = findNextFocusableElement(this.getChildren(), startingIndex);
-      this.getChildren()[elementIndex].focus();
+      const elementIndex = findNextFocusableElement(children, startingIndex);
+      children[elementIndex].focus();
     } else if (event.key === 'ArrowUp') {
       /* Get the index of the current focus index, if there is no
       previousElementSibling return the index for the first last in our Dropdown.  */
@@ -205,8 +204,8 @@ export class TdsDropdown {
           )
         : 0;
 
-      const elementIndex = findPreviousFocusableElement(this.getChildren(), startingIndex);
-      this.getChildren()[elementIndex].focus();
+      const elementIndex = findPreviousFocusableElement(children, startingIndex);
+      children[elementIndex].focus();
     } else if (event.key === 'Escape') {
       this.open = false;
     }
@@ -230,7 +229,7 @@ export class TdsDropdown {
   }
 
   setDefaultOption = () => {
-    this.children = Array.from(this.host.children)
+    Array.from(this.host.children)
       .filter((element) => element.tagName === 'TDS-DROPDOWN-OPTION')
       .map((element: HTMLTdsDropdownOptionElement) => {
         if (this.multiselect) {
@@ -285,15 +284,16 @@ export class TdsDropdown {
     this.tdsInput.emit(event);
     const query = event.target.value.toLowerCase();
     /* Check if the query is empty, and if so, show all options */
+    const children = this.getChildren();
     if (query === '') {
-      this.children = this.getChildren().map((element) => {
+      children.map((element) => {
         element.removeAttribute('hidden');
         return element;
       });
       this.filterResult = null;
       /* Hide the options that do not match the query */
     } else {
-      this.filterResult = this.getChildren().filter((element) => {
+      this.filterResult = children.filter((element) => {
         if (!element.textContent.toLowerCase().includes(query.toLowerCase())) {
           element.setAttribute('hidden', '');
         } else {


### PR DESCRIPTION
**Describe pull-request**  
The filter and tabbing functionality of the dropdown did not work until a selection had been made in the dropdown. This was due to us fetching children in the connectedCallback. Since all children are rendered after the dropdown we need to get the children before performing a filter or tabbing. This using the `getChildren()` function. 

See video:
https://github.com/scania-digital-design-system/tegel/assets/62651103/56efca81-968a-4643-b058-9d71874d970a

**Solving issue**  
Fixes: [CDEP-2691](https://tegel.atlassian.net/browse/CDEP-2691)

**How to test**  
1. Go to Dropdown
2. Try filtering before any selection have been made.
3. Try filtering after a selection have been made. 
4. Do the same for tabbing.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events



[CDEP-2691]: https://tegel.atlassian.net/browse/CDEP-2691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ