### PR TITLE
fix: typo in Storybook

### DIFF
--- a/packages/core/src/stories/foundations/color/color-semantic.stories.tsx
+++ b/packages/core/src/stories/foundations/color/color-semantic.stories.tsx
@@ -41,4 +41,4 @@ const Template = () =>
     <span>--tds-information</span>
   </div>`);
 
-export const Sematic = Template.bind({});
+export const Semantic = Template.bind({});


### PR DESCRIPTION
**Describe pull-request** 
Fixes old typo in Storybook

**Solving issue**  
Fixes: [CDEP-2658](https://tegel.atlassian.net/browse/CDEP-2658)

**How to test**  
1. Go to Storybook
2. Check under Foundations -> Color, and see that it says "Semantic"

[CDEP-2658]: https://tegel.atlassian.net/browse/CDEP-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ