### PR TITLE
fix: indentation on installation page in storybook

### DIFF
--- a/packages/core/src/stories/Installation/installation.stories.ts
+++ b/packages/core/src/stories/Installation/installation.stories.ts
@@ -48,8 +48,7 @@ export const Installation = {
             <li>
                 <p>Paste the following into that file:</p>
                 <pre>
-<code>import &#123; defineCustomElements, JSX as LocalJSX &#125; from
-    '@scania/tegel/loader';
+<code>import &#123; defineCustomElements, JSX as LocalJSX &#125; from '@scania/tegel/loader';
 import &#123; DetailedHTMLProps, HTMLAttributes &#125; from 'react';
 
 type StencilProps&lt;T&gt; = &#123;
@@ -83,8 +82,7 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import './register-webcomponents';
 
-const root = ReactDOM.createRoot(document.
-    getElementById('root') as HTMLElement);
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
 &lt;React.StrictMode&gt;
     &lt;App /&gt;
@@ -119,8 +117,7 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { defineCustomElements } from '@scania/tegel/loader';
 
-const root = ReactDOM.createRoot(document.
-    getElementById('root') as HTMLElement);
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
 &lt;React.StrictMode&gt;
     &lt;App /&gt;
@@ -149,8 +146,7 @@ defineCustomElements();</code>
             <li>
                 <p>In your main.ts import and call the function <code>defineCustomElements()</code></p>
                 <pre>
-                    <code>import { platformBrowserDynamic } from
-                        '@angular/platform-browser-dynamic';
+                    <code>import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { defineCustomElements } from '@scania/tegel/loader';
 import { AppModule } from './app/app.module';
 


### PR DESCRIPTION
**Describe pull-request**  
Off indentation in Storybook
**Solving issue**  
Fixes: [CDEP-2699](https://tegel.atlassian.net/browse/CDEP-2699)

**How to test**  
1. Go to Storybook
2. Check in Installation, and compare to production.

[CDEP-2699]: https://tegel.atlassian.net/browse/CDEP-2699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ