### PR TITLE
feat(icon): enable for override of default title

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -16,6 +16,9 @@ export class Icon {
   /** Pass a size of icon as a string, for example: 32px, 1rem, 4em... */
   @Prop({ reflect: true }) size: string = '16px';
 
+  /** Override the defualt title for the svg. */
+  @Prop() title: string;
+
   @State() icons_object: string = iconsCollection;
 
   @State() arrayOfIcons = [];
@@ -46,7 +49,7 @@ export class Icon {
             height={this.size}
             width={this.size}
           >
-            <title>{`icon ${element.name}`}</title>
+            <title>{this.title ?? `${element.name} icon`}</title>
             <path fill="currentColor" d={element.definition} />
           </svg>
         );

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -16,7 +16,7 @@ export class Icon {
   /** Pass a size of icon as a string, for example: 32px, 1rem, 4em... */
   @Prop({ reflect: true }) size: string = '16px';
 
-  /** Override the defualt title for the svg. */
+  /** Override the default title for the svg. */
   @Prop() title: string;
 
   @State() icons_object: string = iconsCollection;

--- a/packages/core/src/components/icon/readme.md
+++ b/packages/core/src/components/icon/readme.md
@@ -5,10 +5,11 @@
 
 ## Properties
 
-| Property | Attribute | Description                                                                                                                                   | Type     | Default   |
-| -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
-| `name`   | `name`    | Pass a name of the icon. For icon names, refer to Storybook Icon controls dropdown or https://tegel.scania.com/foundations/icons/icon-library | `string` | `'truck'` |
-| `size`   | `size`    | Pass a size of icon as a string, for example: 32px, 1rem, 4em...                                                                              | `string` | `'16px'`  |
+| Property | Attribute | Description                                                                                                                                   | Type     | Default     |
+| -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| `name`   | `name`    | Pass a name of the icon. For icon names, refer to Storybook Icon controls dropdown or https://tegel.scania.com/foundations/icons/icon-library | `string` | `'truck'`   |
+| `size`   | `size`    | Pass a size of icon as a string, for example: 32px, 1rem, 4em...                                                                              | `string` | `'16px'`    |
+| `title`  | `title`   | Override the defualt title for the svg.                                                                                                       | `string` | `undefined` |
 
 
 ## Dependencies


### PR DESCRIPTION
**Describe pull-request**  
Adds a prop for users to overrride the default `title` in the Icons `svg`

**Solving issue**  
Fixes: [CDEP-2700](https://tegel.atlassian.net/browse/CDEP-2700)

**How to test**  
1. Checkout branch
2. Set the title prop in the icon story
3. Make sure it overrides the default icon title.



[CDEP-2700]: https://tegel.atlassian.net/browse/CDEP-2700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ