### PR TITLE
refactor(dropdown): cleanup and enhancement setValue & removeValue

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -80,7 +80,7 @@ export class TdsDropdownOption {
   handleSingleSelect = () => {
     if (!this.disabled) {
       this.selected = true;
-      this.parentElement.appendValue({ value: this.value, label: this.label });
+      this.parentElement.appendValue(this.value);
       this.parentElement.close();
       this.tdsSelect.emit({
         value: this.value,
@@ -94,7 +94,7 @@ export class TdsDropdownOption {
   ) => {
     if (!this.disabled) {
       if (event.detail.checked) {
-        this.parentElement.appendValue({ value: this.value, label: this.label });
+        this.parentElement.appendValue(this.value);
         this.selected = true;
         this.tdsSelect.emit({
           value: this.value,

--- a/packages/core/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/core/src/components/dropdown/dropdown.stories.tsx
@@ -246,7 +246,6 @@ const Template = ({
               Option 4
             </tds-dropdown-option>
         </tds-dropdown>
-        <button id="test">Do it!</button>
     </div>
 
     <script>

--- a/packages/core/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/core/src/components/dropdown/dropdown.stories.tsx
@@ -246,15 +246,15 @@ const Template = ({
               Option 4
             </tds-dropdown-option>
         </tds-dropdown>
+        <button id="test">Do it!</button>
     </div>
 
     <script>
-      dropdown = document.querySelector('tds-dropdown')
+    dropdown = document.querySelector('tds-dropdown')
 
-      dropdown.addEventListener('tdsChange', (event) => {
-        console.log(event)
-      })
-
+    dropdown.addEventListener('tdsChange', (event) => {
+      console.log(event)
+    })
     </script>
         
   `);

--- a/packages/core/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/core/src/components/dropdown/dropdown.stories.tsx
@@ -249,11 +249,12 @@ const Template = ({
     </div>
 
     <script>
-    dropdown = document.querySelector('tds-dropdown')
+      dropdown = document.querySelector('tds-dropdown')
 
-    dropdown.addEventListener('tdsChange', (event) => {
-      console.log(event)
-    })
+      dropdown.addEventListener('tdsChange', (event) => {
+        console.log(event)
+      })
+
     </script>
         
   `);

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -312,7 +312,7 @@ export class TdsDropdown {
   };
 
   selectChildrenAsSelectedBasedOnSelectionProp() {
-    this.getChildren().map((element: HTMLTdsDropdownOptionElement) => {
+    this.getChildren().forEach((element: HTMLTdsDropdownOptionElement) => {
       this.value.forEach((selection) => {
         if (element.value !== selection) {
           // If not multiselect, we need to unselect all other options.
@@ -323,7 +323,6 @@ export class TdsDropdown {
           element.setSelected(true);
         }
       });
-      return element;
     });
   }
 

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -118,7 +118,7 @@ export class TdsDropdown {
     }
 
     this.value = nextValue;
-    this.host.setAttribute('value', this.value.map((val) => val).toString());
+    this.host.setAttribute('value', this.value?.map((val) => val).toString());
     this.selectChildrenAsSelectedBasedOnSelectionProp();
     this.handleChange();
 

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -104,8 +104,6 @@ export class TdsDropdown {
     else nextValue = value;
 
     if (!this.multiselect && nextValue.length > 1) {
-      console.log(nextValue);
-      console.log(nextValue.length);
       console.warn('Tried to select multiple items, but multiselect is not enabled.');
       nextValue = [nextValue[0]];
     }

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -148,9 +148,9 @@ export class TdsDropdown {
   async removeValue(oldValue: string) {
     let label: string;
     if (this.multiselect) {
-      this.getChildren().forEach((element: HTMLTdsDropdownOptionElement) => {
+      this.getChildren()?.forEach((element: HTMLTdsDropdownOptionElement) => {
         if (element.value === oldValue) {
-          this.value = this.value.filter((value) => value !== element.value);
+          this.value = this.value?.filter((value) => value !== element.value);
           label = element.textContent.trim();
           element.setSelected(false);
         }
@@ -162,7 +162,7 @@ export class TdsDropdown {
     this.handleChange();
     /* This returns an array of object with a value and label pair. This is ONLY to not break the API. Should be removed for 2.0. */
     // TODO - Clean up and just return this.value for 2.0
-    return this.value.map((value) => ({ value, label }));
+    return this.value?.map((value) => ({ value, label }));
   }
 
   /** Method for closing the Dropdown. */

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -104,6 +104,8 @@ export class TdsDropdown {
     else nextValue = value;
 
     if (!this.multiselect && nextValue.length > 1) {
+      console.log(nextValue);
+      console.log(nextValue.length);
       console.warn('Tried to select multiple items, but multiselect is not enabled.');
       nextValue = [nextValue[0]];
     }

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -87,10 +87,7 @@ export class TdsDropdown {
    * Multiselect example:
    *
    * <code>
-   *  dropdown.setValue([<br />
-   *  &nbsp;{ value: 'option-4', label: 'Option 4' },<br />
-   *  &nbsp;{ value: 'option-1', label: 'Option 1' }<br />
-   *  ]);
+   *  dropdown.setValue(['option-1', 'option-2']);
    * </code>
    */
   @Method()

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -278,6 +278,7 @@ export class TdsDropdown {
     }
   }
 
+  /** Method that resets the dropdown without emitting an event. */
   private internalReset() {
     this.getChildren().forEach((element: HTMLTdsDropdownOptionElement) => {
       element.setSelected(false);

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -124,15 +124,10 @@ export class TdsDropdown {
 
     /* This returns an array of object with a value and label pair. This is ONLY to not break the API. Should be removed for 2.0. */
     // TODO - Clean up and just return this.value for 2.0
-    const selection = this.value?.flatMap((stringValue) => {
-      const matchingElement = this.getChildren().filter(
-        (element: HTMLTdsDropdownOptionElement) => element.value === stringValue,
-      );
-      return matchingElement.map((element: HTMLTdsDropdownOptionElement) => ({
-        value: element.value,
-        label: element.textContent.trim(),
-      }));
-    });
+    const selection = this.getSelectedChildren().map((element: HTMLTdsDropdownOptionElement) => ({
+      value: element.value,
+      label: element.textContent.trim(),
+    }));
     return selection;
   }
 
@@ -267,7 +262,7 @@ export class TdsDropdown {
   handleOpenState() {
     if (this.filter && this.multiselect) {
       if (!this.open) {
-        this.inputElement.value = this.value?.map((value) => value).toString() ?? null;
+        this.inputElement.value = this.getValue();
       }
     }
   }
@@ -288,7 +283,7 @@ export class TdsDropdown {
     this.host.setAttribute('value', null);
   }
 
-  setDefaultOption = () => {
+  private setDefaultOption = () => {
     Array.from(this.host.children)
       .filter((element) => element.tagName === 'TDS-DROPDOWN-OPTION')
       .forEach((element: HTMLTdsDropdownOptionElement) => {
@@ -311,7 +306,7 @@ export class TdsDropdown {
       });
   };
 
-  selectChildrenAsSelectedBasedOnSelectionProp() {
+  private selectChildrenAsSelectedBasedOnSelectionProp() {
     this.getChildren().forEach((element: HTMLTdsDropdownOptionElement) => {
       this.value.forEach((selection) => {
         if (element.value !== selection) {
@@ -346,16 +341,23 @@ export class TdsDropdown {
     return this.openDirection;
   };
 
-  getValue = () => {
-    const labels = this.value
+  private getSelectedChildren = () =>
+    this.value
       ?.map((stringValue) => {
         const matchingElement = this.getChildren().find(
           (element: HTMLTdsDropdownOptionElement) => element.value === stringValue,
         );
-        return matchingElement ? matchingElement.textContent.trim() : null;
+        return matchingElement;
       })
       .filter(Boolean);
 
+  private getSelectedChildrenLabels = () =>
+    this.getSelectedChildren()?.map((element: HTMLTdsDropdownOptionElement) =>
+      element.textContent.trim(),
+    );
+
+  getValue = () => {
+    const labels = this.getSelectedChildrenLabels();
     return this.filter ? labels?.join(', ') : labels?.toString();
   };
 
@@ -383,15 +385,15 @@ export class TdsDropdown {
     }
   };
 
-  handleFocus = (event) => {
+  private handleFocus = (event) => {
     this.tdsFocus.emit(event);
   };
 
-  handleBlur = (event) => {
+  private handleBlur = (event) => {
     this.tdsBlur.emit(event);
   };
 
-  handleChange = () => {
+  private handleChange = () => {
     this.tdsChange.emit({
       name: this.name,
       value: this.value?.map((value) => value).toString() ?? null,

--- a/packages/core/src/components/dropdown/readme.md
+++ b/packages/core/src/components/dropdown/readme.md
@@ -81,10 +81,7 @@ dropdown.setValue('option-1', 'Option 1');
 Multiselect example:
 
 <code>
-dropdown.setValue([<br />
-&nbsp;{ value: 'option-4', label: 'Option 4' },<br />
-&nbsp;{ value: 'option-1', label: 'Option 1' }<br />
-]);
+dropdown.setValue(['option-1', 'option-2']);
 </code>
 
 #### Returns

--- a/packages/core/src/components/dropdown/readme.md
+++ b/packages/core/src/components/dropdown/readme.md
@@ -68,7 +68,7 @@ Type: `Promise<void>`
 
 
 
-### `setValue(value: string | { value: string; label: string; } | { value: string; label: string; }[], label?: string) => Promise<{ value: string; label: string; }[]>`
+### `setValue(value: string | string[], label?: string) => Promise<{ value: string; label: string; }[]>`
 
 Method for setting the value of the Dropdown.
 

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -20,7 +20,7 @@
 
 | Event     | Description                                                                                                                                                          | Type                                                                                      |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "desc" \| "asc"; }>` |
+| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to in order to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
 
 
 ----------------------------------------------


### PR DESCRIPTION
**Describe pull-request**  
This PR builds further on the `setValue()` and `removeValue()` methods. This removes the dependency on `label` as an attribute to the methods. 

The user should still be able to interact with the `setValue` method by passing in two attributes (value, label). However the label passed in is not used, this is only there to not break the API. The user can now also pass in a string array that should have one entry per value they want selected.

**Solving issue**  
Fixes: -


**How to test:**
1. Checkout branch.
2. Try updating the dropdown using the `setValue` method.
3. Test it for default, filter and multiselect dropdown
4. Verify that the dropdown works as before