### PR TITLE
fix: remove extra margin under inputs without helper text

### DIFF
--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -200,14 +200,14 @@ export class TdsDatetime {
           <div class="tds-datetime-bar"></div>
         </div>
 
-        <div class="tds-datetime-helper">
-          {this.helper && (
+        {this.helper && (
+          <div class="tds-datetime-helper">
             <div class="tds-helper">
               {this.state === 'error' && <tds-icon name="error" size="16px"></tds-icon>}
               {this.helper}
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -205,23 +205,25 @@ export class TdsTextField {
           <span class="text-field-icon__readonly-label">This field is non-editable</span>
         </div>
 
-        <div class="text-field-helper">
-          {this.state === 'error' && (
-            <div class="text-field-helper-error-state">
-              <tds-icon name="error" size="16px"></tds-icon>
-              {this.helper}
-            </div>
-          )}
-          {this.state !== 'error' && this.helper}
+        {(this.helper || this.maxLength > 0) && (
+          <div class="text-field-helper">
+            {this.state === 'error' && (
+              <div class="text-field-helper-error-state">
+                <tds-icon name="error" size="16px"></tds-icon>
+                {this.helper}
+              </div>
+            )}
+            {this.state !== 'error' && this.helper}
 
-          {this.maxLength > 0 && (
-            <div class="text-field-textcounter">
-              {this.value === null ? 0 : this.value?.length}
-              <span class="text-field-textcounter-divider"> / </span>
-              {this.maxLength}
-            </div>
-          )}
-        </div>
+            {this.maxLength > 0 && (
+              <div class="text-field-textcounter">
+                {this.value === null ? 0 : this.value?.length}
+                <span class="text-field-textcounter-divider"> / </span>
+                {this.maxLength}
+              </div>
+            )}
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION

**Describe pull-request**  
Some inputs with empty helper text still added some spacing at the bottom. 
This PR fixes that by not rendering the helper text container div when there is no helper text.

**Solving issue**  
Fixes: [CDEP-2701](https://tegel.atlassian.net/browse/CDEP-2701)

**How to test**  
_Add description how to test if possible_
1. Go to storybook
2. Check in Datetime & Textfield
3. Open devtools
4. Verify that the elements are the right height when there are no helper text

**Screenshots**  
![MicrosoftTeams-image (8)](https://github.com/scania-digital-design-system/tegel/assets/8556022/256a55f4-b521-4353-a1b0-e922fd92761d)


[CDEP-2701]: https://tegel.atlassian.net/browse/CDEP-2701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ