### PR TITLE
fix(icon): switched title for svgTitle since title is a reserved attribute name

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -17,7 +17,7 @@ export class Icon {
   @Prop({ reflect: true }) size: string = '16px';
 
   /** Override the default title for the svg. */
-  @Prop() title: string;
+  @Prop() svgTitle: string;
 
   @State() icons_object: string = iconsCollection;
 
@@ -49,7 +49,7 @@ export class Icon {
             height={this.size}
             width={this.size}
           >
-            <title>{this.title ?? `${element.name} icon`}</title>
+            <title>{this.svgTitle ?? `${element.name} icon`}</title>
             <path fill="currentColor" d={element.definition} />
           </svg>
         );

--- a/packages/core/src/components/icon/readme.md
+++ b/packages/core/src/components/icon/readme.md
@@ -5,11 +5,11 @@
 
 ## Properties
 
-| Property | Attribute | Description                                                                                                                                   | Type     | Default     |
-| -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| `name`   | `name`    | Pass a name of the icon. For icon names, refer to Storybook Icon controls dropdown or https://tegel.scania.com/foundations/icons/icon-library | `string` | `'truck'`   |
-| `size`   | `size`    | Pass a size of icon as a string, for example: 32px, 1rem, 4em...                                                                              | `string` | `'16px'`    |
-| `title`  | `title`   | Override the defualt title for the svg.                                                                                                       | `string` | `undefined` |
+| Property   | Attribute   | Description                                                                                                                                   | Type     | Default     |
+| ---------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| `name`     | `name`      | Pass a name of the icon. For icon names, refer to Storybook Icon controls dropdown or https://tegel.scania.com/foundations/icons/icon-library | `string` | `'truck'`   |
+| `size`     | `size`      | Pass a size of icon as a string, for example: 32px, 1rem, 4em...                                                                              | `string` | `'16px'`    |
+| `svgTitle` | `svg-title` | Override the default title for the svg.                                                                                                       | `string` | `undefined` |
 
 
 ## Dependencies


### PR DESCRIPTION
**Describe pull-request**  
Switched title for `svgTitle` since title is a reserved attribute name. The previous prop name gave a warning on build.


**Solving issue**  
Fixes: -