### PR TITLE
fix(css reset/components): added important for slotted(*) targeted elements font styles

### DIFF
--- a/packages/core/src/components/card/card.scss
+++ b/packages/core/src/components/card/card.scss
@@ -77,6 +77,7 @@
   }
 
   slot[name='body']::slotted(*) {
+    /* !important is needed here to prevent this from being overwritten by our CSS-reset. */
     font: var(--tds-detail-03) !important;
     letter-spacing: var(--tds-detail-03-ls) !important;
     color: var(--tds-card-body-color);

--- a/packages/core/src/components/card/card.scss
+++ b/packages/core/src/components/card/card.scss
@@ -77,8 +77,8 @@
   }
 
   slot[name='body']::slotted(*) {
-    font: var(--tds-detail-03);
-    letter-spacing: var(--tds-detail-03-ls);
+    font: var(--tds-detail-03) !important;
+    letter-spacing: var(--tds-detail-03-ls) !important;
     color: var(--tds-card-body-color);
     padding: 0 16px;
     margin-bottom: 16px;

--- a/packages/core/src/components/modal/modal.scss
+++ b/packages/core/src/components/modal/modal.scss
@@ -133,8 +133,8 @@ $modals: (
 
 @mixin modal-header-title {
   color: var(--tds-modal-text);
-  font: var(--tds-headline-05);
-  letter-spacing: var(--tds-headline-05-ls);
+  font: var(--tds-headline-05) !important;
+  letter-spacing: var(--tds-headline-05-ls) !important;
   margin: 0;
   flex: 1;
 }

--- a/packages/core/src/components/modal/modal.scss
+++ b/packages/core/src/components/modal/modal.scss
@@ -133,6 +133,8 @@ $modals: (
 
 @mixin modal-header-title {
   color: var(--tds-modal-text);
+
+  /* !important is needed here to prevent this from being overwritten by our CSS-reset. */
   font: var(--tds-headline-05) !important;
   letter-spacing: var(--tds-headline-05-ls) !important;
   margin: 0;

--- a/packages/core/src/components/tabs/folder-tabs/folder-tab/folder-tab.scss
+++ b/packages/core/src/components/tabs/folder-tabs/folder-tab/folder-tab.scss
@@ -12,8 +12,8 @@
     min-width: 142px;
     display: block;
     width: calc(100% - 32px);
-    font: var(--tds-headline-07);
-    letter-spacing: var(--tds-headline-07-ls);
+    font: var(--tds-headline-07) !important;
+    letter-spacing: var(--tds-headline-07-ls) !important;
     cursor: pointer;
     padding: 16px;
     white-space: nowrap;

--- a/packages/core/src/components/tabs/folder-tabs/folder-tab/folder-tab.scss
+++ b/packages/core/src/components/tabs/folder-tabs/folder-tab/folder-tab.scss
@@ -12,6 +12,8 @@
     min-width: 142px;
     display: block;
     width: calc(100% - 32px);
+
+    /* !important is needed here to prevent this from being overwritten by our CSS-reset. */
     font: var(--tds-headline-07) !important;
     letter-spacing: var(--tds-headline-07-ls) !important;
     cursor: pointer;

--- a/packages/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
+++ b/packages/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
@@ -11,8 +11,8 @@
 
   ::slotted(*) {
     all: unset;
-    font: var(--tds-headline-07);
-    letter-spacing: var(--tds-headline-07-ls);
+    font: var(--tds-headline-07) !important;
+    letter-spacing: var(--tds-headline-07-ls) !important;
     color: var(--tds-navigation-tabs-tab-color);
     text-decoration: none;
     display: block;

--- a/packages/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
+++ b/packages/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
@@ -11,6 +11,8 @@
 
   ::slotted(*) {
     all: unset;
+
+    /* !important is needed here to prevent this from being overwritten by our CSS-reset. */
     font: var(--tds-headline-07) !important;
     letter-spacing: var(--tds-headline-07-ls) !important;
     color: var(--tds-navigation-tabs-tab-color);

--- a/packages/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
+++ b/packages/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
@@ -10,6 +10,8 @@
 
   ::slotted(*) {
     all: unset;
+
+    /* !important is needed here to prevent this from being overwritten by our CSS-reset. */
     font: var(--tds-headline-07) !important;
     letter-spacing: var(--tds-headline-07-ls) !important;
     color: var(--tds-navigation-tabs-tab-color) !important;

--- a/packages/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
+++ b/packages/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
@@ -11,8 +11,8 @@
   ::slotted(*) {
     all: unset;
     font: var(--tds-headline-07);
-    letter-spacing: var(--tds-headline-07-ls);
-    color: var(--tds-navigation-tabs-tab-color);
+    letter-spacing: var(--tds-headline-07-ls) !important;
+    color: var(--tds-navigation-tabs-tab-color) !important;
     text-decoration: none;
     display: block;
     position: relative;

--- a/packages/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
+++ b/packages/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
@@ -10,7 +10,7 @@
 
   ::slotted(*) {
     all: unset;
-    font: var(--tds-headline-07);
+    font: var(--tds-headline-07) !important;
     letter-spacing: var(--tds-headline-07-ls) !important;
     color: var(--tds-navigation-tabs-tab-color) !important;
     text-decoration: none;

--- a/packages/core/src/components/toast/toast.scss
+++ b/packages/core/src/components/toast/toast.scss
@@ -90,16 +90,16 @@
 
     .header,
     slot[name='header']::slotted(*) {
-      font: var(--tds-headline-07);
-      letter-spacing: var(--tds-headline-07-ls);
+      font: var(--tds-headline-07) !important;
+      letter-spacing: var(--tds-headline-07-ls) !important;
       color: var(--tds-toast-headline-color);
     }
 
     .subheader,
     slot[name='subheader']::slotted(*) {
       color: var(--tds-toast-subheadline-color);
-      font: var(--tds-detail-02);
-      letter-spacing: var(--tds-detail-02-ls);
+      font: var(--tds-detail-02) !important;
+      letter-spacing: var(--tds-detail-02-ls) !important;
       max-width: 252px;
       white-space: nowrap;
       overflow: hidden;

--- a/packages/core/src/components/toast/toast.scss
+++ b/packages/core/src/components/toast/toast.scss
@@ -90,6 +90,7 @@
 
     .header,
     slot[name='header']::slotted(*) {
+      /* !important is needed here to prevent this from being overwritten by our CSS-reset. */
       font: var(--tds-headline-07) !important;
       letter-spacing: var(--tds-headline-07-ls) !important;
       color: var(--tds-toast-headline-color);
@@ -97,6 +98,7 @@
 
     .subheader,
     slot[name='subheader']::slotted(*) {
+      /* !important is needed here to prevent this from being overwritten by our CSS-reset. */
       color: var(--tds-toast-subheadline-color);
       font: var(--tds-detail-02) !important;
       letter-spacing: var(--tds-detail-02-ls) !important;


### PR DESCRIPTION
**Describe pull-request**  
Our CSS-reset has a rule:
```css
input,
button,
textarea,
select {
  font: inherit;
}
```
Which was causing issues for the Tabs. There selector (slotted(*)) for targeting slotted buttons was not strong enough and was getting overwritten by the rule above. This resulted in this look:
<img width="710" alt="Screenshot 2023-09-28 at 13 55 39" src="https://github.com/scania-digital-design-system/tegel/assets/62651103/02bca8d3-0342-4978-8efc-710c674c501f">


When it should look like this:
<img width="811" alt="Screenshot 2023-09-28 at 13 56 50" src="https://github.com/scania-digital-design-system/tegel/assets/62651103/06ec200d-3fe3-45e2-adb8-44bcdb390277">


To combat this. I have used `!important` for the `font` and `letter-spacing` in our CSS whenever we are targeting `::slotted(*)`


**Solving issue**  
Fixes: [CDEP-2708](https://tegel.atlassian.net/browse/CDEP-2708)

**How to test**  

To see the error: 
1. Checkout the `develop` branch.
2. In `preview.css` add our CSS-reset
3. Check in Tabs and verify that the text have the wrong styling.

1. Checkout this branch.
3. In `preview.css` add our CSS-reset
5. Check in Tabs that the look of the tabs are intact.



[CDEP-2708]: https://tegel.atlassian.net/browse/CDEP-2708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ