### PR TITLE
fix(side menu): collapsed by default

### DIFF
--- a/packages/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.scss
+++ b/packages/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.scss
@@ -24,10 +24,6 @@
       position: absolute;
       left: 50%;
     }
-
-    ::slotted(*) {
-      background-color: red;
-    }
   }
 }
 

--- a/packages/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.scss
+++ b/packages/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.scss
@@ -24,6 +24,10 @@
       position: absolute;
       left: 50%;
     }
+
+    ::slotted(*) {
+      background-color: red;
+    }
   }
 }
 

--- a/packages/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/packages/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -97,7 +97,7 @@ export class TdsSideMenuCollapseButton {
                   fill="currentColor"
                 />
               </svg>
-              <slot></slot>
+              {!this.collapsed && <slot></slot>}
             </a>
           </tds-side-menu-item>
         </div>

--- a/packages/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
@@ -28,6 +28,7 @@ export class TdsSideMenuDropdownListItem {
 
   connectedCallback() {
     this.sideMenuEl = this.host.closest('tds-side-menu');
+    this.collapsed = this.sideMenuEl.collapsed;
   }
 
   componentDidLoad() {

--- a/packages/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
@@ -28,7 +28,7 @@ export class TdsSideMenuDropdownListItem {
 
   connectedCallback() {
     this.sideMenuEl = this.host.closest('tds-side-menu');
-    this.collapsed = this.sideMenuEl.collapsed;
+    this.collapsed = this.sideMenuEl?.collapsed;
   }
 
   componentDidLoad() {

--- a/packages/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
@@ -23,7 +23,7 @@ export class TdsSideMenuDropdownList {
 
   connectedCallback() {
     this.sideMenuEl = this.host.closest('tds-side-menu');
-    this.collapsed = this.sideMenuEl.collapsed;
+    this.collapsed = this.sideMenuEl?.collapsed;
   }
 
   render() {

--- a/packages/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
@@ -23,6 +23,7 @@ export class TdsSideMenuDropdownList {
 
   connectedCallback() {
     this.sideMenuEl = this.host.closest('tds-side-menu');
+    this.collapsed = this.sideMenuEl.collapsed;
   }
 
   render() {

--- a/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -77,6 +77,7 @@ export class TdsSideMenuDropdown {
 
   connectedCallback() {
     this.sideMenuEl = this.host.closest('tds-side-menu');
+    this.collapsed = this.sideMenuEl.collapsed;
     this.open = this.defaultOpen;
   }
 

--- a/packages/core/src/components/side-menu/side-menu-item/side-menu-item.tsx
+++ b/packages/core/src/components/side-menu/side-menu-item/side-menu-item.tsx
@@ -63,6 +63,7 @@ export class TdsSideMenuItem {
     // closest() will return null if side-menu-item is inside a shadowRoot that
     // does not contain a side-menu. This is the case for the side-menu-dropdown.
     this.sideMenuEl = this.host.closest('tds-side-menu');
+    this.collapsed = this.sideMenuEl.collapsed;
   }
 
   componentDidLoad() {

--- a/packages/core/src/components/side-menu/side-menu-item/side-menu-item.tsx
+++ b/packages/core/src/components/side-menu/side-menu-item/side-menu-item.tsx
@@ -63,7 +63,7 @@ export class TdsSideMenuItem {
     // closest() will return null if side-menu-item is inside a shadowRoot that
     // does not contain a side-menu. This is the case for the side-menu-dropdown.
     this.sideMenuEl = this.host.closest('tds-side-menu');
-    this.collapsed = this.sideMenuEl.collapsed;
+    this.collapsed = this.sideMenuEl?.collapsed;
   }
 
   componentDidLoad() {

--- a/packages/core/src/components/side-menu/side-menu.stories.tsx
+++ b/packages/core/src/components/side-menu/side-menu.stories.tsx
@@ -74,6 +74,7 @@ export default {
   args: {
     persistent: true,
     collapsible: false,
+    collapsed: false,
   },
 };
 

--- a/packages/core/src/components/side-menu/side-menu.stories.tsx
+++ b/packages/core/src/components/side-menu/side-menu.stories.tsx
@@ -62,6 +62,14 @@ export default {
       },
       if: { arg: 'persistent', truthy: true },
     },
+    collapsed: {
+      name: 'Collapsed',
+      description: 'Collapsed Side Menu',
+      control: {
+        type: 'boolean',
+      },
+      if: { arg: 'collapsible', truthy: true },
+    },
   },
   args: {
     persistent: true,
@@ -69,7 +77,7 @@ export default {
   },
 };
 
-const Template = ({ persistent, collapsible }) =>
+const Template = ({ persistent, collapsible, collapsed }) =>
   formatHtmlPreview(
     `
     <script>
@@ -146,7 +154,9 @@ const Template = ({ persistent, collapsible }) =>
 
     <div class="demo-wrap-side-menu-and-main">
       <!-- Note: the "persistent" property keeps the menu open on desktop -->
-      <tds-side-menu aria-label="Side menu" id="demo-side-menu" ${persistent ? 'persistent' : ''}>
+      <tds-side-menu ${collapsed ? 'collapsed' : ''} aria-label="Side menu" id="demo-side-menu" ${
+      persistent ? 'persistent' : ''
+    }>
         <tds-side-menu-overlay slot="overlay" onclick="demoSideMenu.open = false;"></tds-side-menu-overlay>
 
         <tds-side-menu-close-button slot="close-button" aria-label="Close drawer menu" onclick="demoSideMenu.open = false;"></tds-side-menu-close-button>


### PR DESCRIPTION
**Describe pull-request**  
 - Added a `connectedCallback` check in child components to check the default `collapsed` state of the Side Menu.
 - Added a `collapsed` control to storybook.
 - Conditionally rendered the "Collapse" text based on it being collapsed or not. 

**Solving issue**  
Fixes: [CDEP-2714](https://tegel.atlassian.net/browse/CDEP-2714)

**How to test**  
1. Go to Side Menu
2. Set collapsible and collapsed to true
3. Make sure design is looking fiiine.



[CDEP-2714]: https://tegel.atlassian.net/browse/CDEP-2714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ