### PR TITLE
fix(modal): leaked CSS

### DIFF
--- a/packages/core/src/components/modal/modal.scss
+++ b/packages/core/src/components/modal/modal.scss
@@ -300,6 +300,7 @@ button.tds-modal-close {
 /* WEB COMPONENT STUFF */
 
 :host {
+  @include tds-box-sizing;
   @include modal-host;
 
   .tds-modal-close {

--- a/packages/core/src/global/global.scss
+++ b/packages/core/src/global/global.scss
@@ -41,7 +41,7 @@
 @import '../components/header/header-vars';
 @import '../components/link/link-vars';
 @import '../components/message/message-vars';
-@import '../components/modal/modal';
+@import '../components/modal/modal-vars';
 @import '../components/popover-canvas/popover-canvas-vars';
 @import '../components/popover-menu/popover-menu-vars';
 @import '../components/radio-button/radio-button-vars';


### PR DESCRIPTION
**Describe pull-request**  
Before this change, third-party Stencil applications using Tegel together with @stencil/sass and shadow DOM would get the Tegel modal component styling applied to them, and they'd end up looking pretty strange. 

This happened because the modals `:host` pseudo-class got included in the `tegel.css` dist file *(probably by accident)*.

The classes `.header` and `.body` were also leaking and could cause conflicts with user styling.

**To prevent this from happening again in the future**, it might be a good idea to analyze the dist stylesheet. 
You could perhaps use a second Stylelint config and lint the dist stylesheet after a build to ensure things like `:host` stay out of this file.
https://stylelint.io/user-guide/rules/selector-pseudo-class-disallowed-list/

You probably also want to ensure that all classes in the dist stylesheet always begin with the prefix `.tds-`.


**How to test**

TL;DR:
1. Run storybook.
2. Verify that the modal component looks like it should.
3. Verify that everything else looks like it should.
4. Verify that dist stylesheet does not contain `:host`, `.header` or `.body`.
5. Cry, because you need to follow all of the instructions below in order to actually test the shadow DOM behavior.

*The instructions below are for testing on your local machine.*

1. `git clone https://github.com/lkritsimas/tegel.git`
2. `git checkout fix/modal-component-leaks-css-and-breaks-shadow-dom-in-host-app`
3. `cd tegel`
4. `npm i`
5. `npm run build`
6. `cd ..`
7. Create a new Stencil project `npm init stencil`
8. Select `component` in the first step of Stencil setup.
9. Enter `shadow-dom-test` as project name and complete setup.
10. `cd shadow-dom-test`
11. `npm i @scania/tegel@^1 @stencil/sass` 
12. Create the file `src/global.scss` with the following content *(first step to enable Tegel in the shadow DOM)*:
    ```scss
    @import '~@scania/tegel/dist/tegel/tegel.css'; 
    ```
13. Edit `stencil.config.ts`, add the following code in `config`:
    ```ts
    import { sass } from '@stencil/sass';
    ```
    ```ts
      plugins: [
        sass({
          // Bake the Tegel stylesheet into all components that are using .scss stylesheets, enabling Tegel in shadow DOM.
          // For testing purposes only, you don't want to do this in a real project since it will bloat the build.
          injectGlobalPaths: [
            'src/global.scss'
          ]
        })
      ],
    ```
    Replace the `www` `outputTarget` with the following code to access the Tegel stylesheet in the light DOM on the dev server.
    ```ts
        {
          type: 'www',
          serviceWorker: null, // disable service workers
          copy: [
            {
              src: '../node_modules/@scania/tegel/dist/tegel/tegel.css',
              dest: 'tegel.css'
            }
          ]
        },
    ```
14. Edit `src/index.html` and add the following line to `<head>` to enable Tegel in the "light DOM". Otherwise we can't access things like `:root` styling properly from the shadow DOM. The Tegel web components also depend on this being loaded outside the shadow DOM in order to render with proper styling.
    ```html
    <link rel="stylesheet" href="tegel.css" />
    ```
15. Open `src/components/my-component.tsx` and replace the contents of this default Stencil component with:
    ```tsx
    import { Component, State, h } from '@stencil/core';
    import '@scania/tegel';

    @Component({
      tag: 'my-component',
      styleUrl: 'my-component.scss',
      shadow: true
    })
    export class MyComponent {
      @State() modalTriggerRef?: HTMLElement;

      render() {
        return (
          <div>
            {/*
              This blue headline will only render correctly if the Tegel CSS classes are passed to the shadow DOM.
              Disable `injectGlobalPaths` and restart dev server. Then you'll see that the Tegel web components will render, but "standalone" CSS classes will not.
            */}
            <p class="tds-headline-02 tds-text-blue-500">Main component</p>
            <tds-button ref={(ref) => this.modalTriggerRef = ref} text="Open modal" />
            <tds-modal
              header="Test"
              referenceEl={this.modalTriggerRef}
              size="lg"
              actions-position="static"
            >
              <span slot="body">
                The steps fell lightly and oddly, with a certain swing, for all they went so slowly; it was
                different indeed from the heavy creaking tread of Henry Jekyll. Utterson sighed. “Is there never
                anything else?” he asked.
              </span>
              <span slot="actions">
                <tds-button data-dismiss-modal size="md" text="Sure thing!" />
              </span>
            </tds-modal>
            <my-child-component />
          </div>
        );
      }
    }
    ```
16. Rename `src/components/my-component.css` to `src/components/my-component.scss`
17. Create a new component called `my-child-component.tsx` with the following content:
    ```tsx
    import { Component, h } from '@stencil/core';

    @Component({
      tag: 'my-child-component',
      styleUrl: 'my-child-component.scss',
      shadow: true
    })
    export class MyChildComponent {
      render() {
        return (
          <div>
            {/*
              This red headline will only render correctly if the Tegel CSS classes are passed to the shadow DOM.
              Disable `injectGlobalPaths` and restart dev server. Then you'll see that the Tegel web components will render, but "standalone" CSS classes will not.
            */}
            <p class="tds-headline-02 tds-text-red-500">Child component</p>
            <tds-accordion>
              <tds-accordion-item header="First item">
                This is the panel, which contains associated information with the header. Usually it contains
                text, set in the same size as the header. Lorem ipsum doler sit amet.
              </tds-accordion-item>
              <tds-accordion-item expanded>
                <div slot="header">Second item</div>
                This is the panel, which contains associated information with the header. Usually it contains
                text, set in the same size as the header. Lorem ipsum dolor sit amet, consectetur adipiscing
                elit. Duis laoreet vestibulum fermentum.
              </tds-accordion-item>
            </tds-accordion>
          </div>
        );
      }
    }
    ```
18. Create a new SCSS stylesheet called `my-child-component.scss` next to the component. The contents of this file doesn't matter, but it must exist in order for `injectGlobalPaths` to work.
19. Run the dev server `npm run start`
20. **Notice how the components styling looks pretty weird.**
21. Stop the dev server.
22. Install the local Tegel package that we built earlier `npm i "../tegel/packages/core"`
23. Run the dev server again `npm run start`
24. **Notice how the styling now looks as expected.**
25. Award yourself with a nice break for spending the time following these steps.

**Screenshots**  
Before:
![tegel modal - bad](https://github.com/scania-digital-design-system/tegel/assets/52670379/47090b61-a3a0-43d3-8957-87fb78fea189)

After:
![tegel modal - good](https://github.com/scania-digital-design-system/tegel/assets/52670379/4781e012-31af-49ac-9cb3-4d6d96c79535)

