### PR TITLE
fix: add ESLint rule to prevent importing from Stencils internal package

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -66,6 +66,12 @@
     "no-restricted-syntax": "warn", // TODO: check this - disables for-in related error
     "default-case-last": "warn",
     "no-restricted-exports": "warn",
+    "no-restricted-imports": ["error",
+      {
+        "name": "@stencil/core/internal",
+        "message": "Use @stencil/core instead."
+      }
+    ],
     "radix": ["error", "as-needed"],
     "no-use-before-define": "off",
     "no-console": "off",

--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -1,5 +1,14 @@
-import { Component, Host, h, Prop, State, Element, Event } from '@stencil/core';
-import { EventEmitter, Method } from '@stencil/core/internal';
+import {
+  Component,
+  Host,
+  h,
+  Prop,
+  State,
+  Element,
+  Event,
+  EventEmitter,
+  Method,
+} from '@stencil/core';
 import { TdsCheckboxCustomEvent } from '../../../components';
 
 /**

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -1,5 +1,16 @@
-import { Component, Host, h, Element, State } from '@stencil/core';
-import { Event, EventEmitter, Listen, Method, Prop, Watch } from '@stencil/core/internal';
+import {
+  Component,
+  Host,
+  h,
+  Element,
+  State,
+  Event,
+  EventEmitter,
+  Listen,
+  Method,
+  Prop,
+  Watch,
+} from '@stencil/core';
 import findNextFocusableElement from '../../utils/findNextFocusableElement';
 import findPreviousFocusableElement from '../../utils/findPreviousFocusableElement';
 import appendHiddenInput from '../../utils/appendHiddenInput';

--- a/packages/core/src/components/footer/footer-group/footer-group.tsx
+++ b/packages/core/src/components/footer/footer-group/footer-group.tsx
@@ -1,5 +1,4 @@
-import { Component, Host, h, Prop, Element } from '@stencil/core';
-import { State } from '@stencil/core/internal';
+import { Component, Host, h, Prop, Element, State } from '@stencil/core';
 
 /**
  * @slot <default> - <b>Unnamed slot.</b> For footer items.

--- a/packages/core/src/components/footer/footer.tsx
+++ b/packages/core/src/components/footer/footer.tsx
@@ -1,5 +1,4 @@
-import { Component, h, Element } from '@stencil/core';
-import { Host, Prop } from '@stencil/core/internal';
+import { Component, h, Element, Host, Prop } from '@stencil/core';
 import hasSlot from '../../utils/hasSlot';
 
 /**

--- a/packages/core/src/components/stepper/stepper.tsx
+++ b/packages/core/src/components/stepper/stepper.tsx
@@ -1,5 +1,4 @@
-import { Component, Host, h, Prop, Element, Event } from '@stencil/core';
-import { EventEmitter, Watch } from '@stencil/core/internal';
+import { Component, Host, h, Prop, Element, Event, EventEmitter, Watch } from '@stencil/core';
 import generateUniqueId from '../../utils/generateUniqueId';
 
 type TdsStepperProps = {

--- a/packages/core/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/packages/core/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -1,5 +1,15 @@
-import { Component, Host, State, Element, h, Prop, Event, EventEmitter } from '@stencil/core';
-import { Method, Watch } from '@stencil/core/internal';
+import {
+  Component,
+  Host,
+  State,
+  Element,
+  h,
+  Prop,
+  Event,
+  EventEmitter,
+  Method,
+  Watch,
+} from '@stencil/core';
 
 /**
  * @slot <default> - <b>Unnamed slot.</b> For the tab elements.

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -1,5 +1,4 @@
-import { Component, Host, h, Prop, Element, Event, EventEmitter } from '@stencil/core';
-import { Method } from '@stencil/core/internal';
+import { Component, Host, h, Prop, Element, Event, EventEmitter, Method } from '@stencil/core';
 import generateUniqueId from '../../utils/generateUniqueId';
 import hasSlot from '../../utils/hasSlot';
 


### PR DESCRIPTION
**Describe pull-request**
Some components are currently importing from Stencil's internal package. However, Stencil warns to never do that.
> NOTE!! The @stencil/core/internal package is not meant to be consumed directly by anything other than Stencil internals. It is its own package so that it can be resolved by Stencil, but breaking changes can/will happen at any time. This isn't a "use at your own discretion" moment, but it's more of a "never use this because your code will break" fact.
https://github.com/ionic-team/stencil/blob/main/src/internal/readme.md

Added an ESLint rule to prevent importing from the internals again in the future and changed the imports affected by the rule. 