### PR TITLE
build(tsconfig): eliminate conflicts

### DIFF
--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -11,10 +11,10 @@
       "moduleResolution": "node",
       "target": "es2017",
       "skipLibCheck": true,
-      "jsx": "react",
+      "jsx": "react-jsx",
       "allowSyntheticDefaultImports": true,
       "declaration": true,
-      "declarationDir": "./dist/types"
+      "declarationDir": "./dist/types",
     },
     "include": ["lib"],
     "exclude": ["node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "target": "es2017",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "jsx": "react-jsx"
   },
   "include": ["packages/core/src"]
 }


### PR DESCRIPTION
**Describe pull-request**  
In our root `tscinfig` we had previously set the `"jsx":"react"` and `"jsxFactory":"h"` because this is what we use in `core/`, however this is not the case for `react`. This PR removes jsx and jsxFactory in the root and leaves it up to the tsconfig in the packages to determine this.


**Solving issue**  
Fixes:: - 

**How to se error:**  
1. I develop branch
2. Open accordion.tsx
3. You should se an error in the import of `h`.

**How to test:**
1. Check out this branch
2. Open accordion.tsx
3. There should be no errors.
4. From root, run `npm run build` and `npm run build-react`
5. They should both succeed. 

