### PR TITLE
fix(modal): prevent text selection when toggling modal

### DIFF
--- a/packages/core/src/components/modal/modal.scss
+++ b/packages/core/src/components/modal/modal.scss
@@ -90,29 +90,6 @@ $modals: (
   }
 }
 
-@mixin modal-host {
-  left: 0;
-  top: 0;
-  position: fixed;
-  height: 100%;
-  width: 100%;
-  z-index: tds-z-index(modal);
-  background-color: var(--tds-modal-backdrop);
-  padding: 0 16px;
-
-  @media (max-width: $screen-s) {
-    padding: 0;
-  }
-
-  &.show {
-    display: flex;
-  }
-
-  &.hide {
-    display: none;
-  }
-}
-
 @mixin modal-header {
   display: flex;
   padding-bottom: var(--tds-spacing-element-8);
@@ -155,6 +132,14 @@ $modals: (
   }
 }
 
+@mixin modal-position {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
 /* MODAL STYLING */
 
 .tds-modal {
@@ -167,6 +152,7 @@ $modals: (
   padding: 16px;
   max-height: 85vh;
   overflow-y: auto;
+  pointer-events: auto;
 
   @include modal-scroll-outer;
 
@@ -243,7 +229,10 @@ slot[name='header']::slotted(*) {
 
 .tds-modal-backdrop {
   @include tds-box-sizing;
-  @include modal-host;
+  @include modal-position;
+
+  background-color: var(--tds-modal-backdrop);
+  pointer-events: auto;
 }
 
 button.tds-modal-close {
@@ -300,8 +289,11 @@ button.tds-modal-close {
 /* WEB COMPONENT STUFF */
 
 :host {
-  @include tds-box-sizing;
-  @include modal-host;
+  @include modal-position;
+
+  padding: 0 16px;
+  z-index: tds-z-index(modal);
+  pointer-events: none;
 
   .tds-modal-close {
     border: none;
@@ -311,6 +303,18 @@ button.tds-modal-close {
   .tds-modal-close-btn {
     border: none;
     background-color: transparent;
+  }
+
+  @media (max-width: $screen-s) {
+    padding: 0;
+  }
+
+  &.show {
+    display: flex;
+  }
+
+  &.hide {
+    display: none;
   }
 }
 

--- a/packages/core/src/components/modal/modal.scss
+++ b/packages/core/src/components/modal/modal.scss
@@ -289,6 +289,7 @@ button.tds-modal-close {
 /* WEB COMPONENT STUFF */
 
 :host {
+  @include tds-box-sizing;
   @include modal-position;
 
   padding: 0 16px;

--- a/packages/core/src/components/modal/modal.stories.tsx
+++ b/packages/core/src/components/modal/modal.stories.tsx
@@ -65,6 +65,13 @@ export default {
         type: 'boolean',
       },
     },
+    prevent: {
+      name: 'Prevent',
+      description: 'Disables closing Modal on clicking on overlay area.',
+      control: {
+        type: 'boolean',
+      },
+    },
   },
   args: {
     actionsPosition: 'Static',
@@ -73,6 +80,7 @@ export default {
     bodyContent:
       'The steps fell lightly and oddly, with a certain swing, for all they went so slowly; it was different indeed from the heavy creaking tread of Henry Jekyll. Utterson sighed. “Is there never anything else?” he asked.',
     showModal: true,
+    prevent: false,
   },
 };
 
@@ -83,7 +91,7 @@ const sizeLookUp = {
   'Extra small': 'xs',
 };
 
-const ModalTemplate = ({ actionsPosition, size, headerText, bodyContent, showModal }) =>
+const ModalTemplate = ({ actionsPosition, size, headerText, bodyContent, showModal, prevent }) =>
   formatHtmlPreview(
     `
  <!-- The button below is just for demo purposes -->
@@ -91,11 +99,13 @@ const ModalTemplate = ({ actionsPosition, size, headerText, bodyContent, showMod
   
   
   <tds-modal 
-  header="${headerText}"
-  selector="#my-modal-button"   
-   ${showModal ? 'show' : ''} 
-   id="my-modal" size="${sizeLookUp[size]}" 
-   actions-position="${actionsPosition.toLowerCase()}">          
+    header="${headerText}"
+    selector="#my-modal-button"   
+    ${showModal ? 'show' : ''} 
+    id="my-modal" size="${sizeLookUp[size]}" 
+    actions-position="${actionsPosition.toLowerCase()}"
+    prevent="${prevent}"
+  >          
       <span slot="body">
           ${bodyContent}
       </span>      

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -71,7 +71,7 @@ export class TdsModal {
   tdsClose: EventEmitter<any>;
 
   connectedCallback() {
-    if (this.show !== null) {
+    if (this.show !== undefined) {
       this.isShown = this.show;
     }
     this.setDismissButtons();
@@ -96,19 +96,19 @@ export class TdsModal {
   };
 
   /** Checks if click on Modal is on overlay, if so it closes the Modal if prevent is not true. */
-  handleOverlayClick(event) {
+  handleOverlayClick = (event: PointerEvent) => {
     const targetList = event.composedPath();
-    const target = targetList[0];
+    const target = targetList[0] as HTMLElement;
     if (
       target.classList[0] === 'tds-modal-close' ||
       (target.classList[0] === 'tds-modal-backdrop' && this.prevent === false)
     ) {
       this.handleClose(event);
     }
-  }
+  };
 
   /** Adds an event listener to the reference element that shows/closes the Modal. */
-  initializeReferenceElement = (referenceEl) => {
+  initializeReferenceElement = (referenceEl: HTMLElement) => {
     if (referenceEl) {
       referenceEl.addEventListener('click', (event) => {
         if (this.isShown) {
@@ -142,33 +142,31 @@ export class TdsModal {
   render() {
     const usesHeaderSlot = hasSlot('header', this.host);
     const usesActionsSlot = hasSlot('actions', this.host);
+
     return (
       <Host
-        onClick={(event) => {
-          this.handleOverlayClick(event);
-        }}
-        class={`tds-modal-backdrop ${this.isShown ? 'show' : 'hide'}`}
+        class={`${this.isShown ? 'show' : 'hide'}`}
+        onClick={(event) => this.handleOverlayClick(event)}
       >
+        <div class="tds-modal-backdrop" />
         <div class={`tds-modal tds-modal__actions-${this.actionsPosition} tds-modal-${this.size}`}>
           <div class="header">
             {this.header && <div class="header">{this.header}</div>}
-            {usesHeaderSlot && <slot name="header"></slot>}
+            {usesHeaderSlot && <slot name="header" />}
             <button
               class="tds-modal-close"
               aria-label="close"
-              onClick={(event) => {
-                this.handleClose(event);
-              }}
+              onClick={(event) => this.handleClose(event)}
             >
-              <tds-icon name="cross" size="20px"></tds-icon>
+              <tds-icon name="cross" size="20px" />
             </button>
           </div>
 
           <div class="body">
-            <slot name="body"></slot>
+            <slot name="body" />
           </div>
 
-          {usesActionsSlot && <slot name="actions"></slot>}
+          {usesActionsSlot && <slot name="actions" />}
         </div>
       </Host>
     );


### PR DESCRIPTION
**Describe pull-request**  
This fixes an issue where text in the modal was selected when quickly toggling its visibility, or double clicking on the backdrop of a modal that had the `prevent` prop set to `true`.

**How to test** 
1. Spam click on the "Open Modal" button in Storybook.
2. Double click anywhere on the backdrop of a modal that has `prevent` set to `true`.

Modal content should still be selectable and interactable. It should still be possible to close the modal by clicking on the modals backdrop when `prevent` is set to `false`.

**Screenshots**

Before:
![modal-before](https://github.com/scania-digital-design-system/tegel/assets/52670379/973fcd1f-c14e-4305-afc0-b4eae84096f3)

After:
![modal-after](https://github.com/scania-digital-design-system/tegel/assets/52670379/a148af6c-59e0-4d67-abbf-5b71de49becb)
