### PR TITLE
fix(stepper): change internal event to not be documented in readme file

### DIFF
--- a/packages/core/src/components/stepper/readme.md
+++ b/packages/core/src/components/stepper/readme.md
@@ -16,13 +16,6 @@
 | `stepperId`     | `stepper-id`     | ID used for internal Stepper functionality and events, must be unique.  **NOTE**: If you're listening for Stepper events, you need to set this ID yourself to identify the Stepper, as the default ID is random and will be different every time. | `string`                     | `generateUniqueId()` |
 
 
-## Events
-
-| Event                    | Description | Type                                                                                                 |
-| ------------------------ | ----------- | ---------------------------------------------------------------------------------------------------- |
-| `internalTdsPropsChange` |             | `CustomEvent<{ stepperId: string; changed: (keyof TdsStepperProps)[]; } & Partial<TdsStepperProps>>` |
-
-
 ## Slots
 
 | Slot          | Description                                 |

--- a/packages/core/src/components/stepper/stepper.tsx
+++ b/packages/core/src/components/stepper/stepper.tsx
@@ -51,6 +51,7 @@ export class TdsStepper {
     }
   }
 
+  /** @internal Broadcasts changes to the Stepper props */
   @Event({
     eventName: 'internalTdsPropsChange',
     composed: true,

--- a/packages/core/src/components/stepper/stepper.tsx
+++ b/packages/core/src/components/stepper/stepper.tsx
@@ -51,7 +51,7 @@ export class TdsStepper {
     }
   }
 
-  /** @internal Broadcasts changes to the Stepper props */
+  /** @internal Broadcasts changes in props to the Stepper children */
   @Event({
     eventName: 'internalTdsPropsChange',
     composed: true,


### PR DESCRIPTION
**Describe pull-request**  
Added @internal decorator to 'internalTdsPropsChange' event so it's not documented in the readMe.

**Solving issue**  
Fixes: [CDEP-2749](https://tegel.atlassian.net/browse/CDEP-2749)

**How to test**  
1. Go to Storybook link below
2. Check in Stepper -> Notes
3. Check that the event 'internalTdsPropsChange' is not documented


[CDEP-2749]: https://tegel.atlassian.net/browse/CDEP-2749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ