### PR TITLE
fix(dropdown): fix multiselect & filter getting value "undefined"

### DIFF
--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -369,6 +369,9 @@ export class TdsDropdown {
 
   private getValue = () => {
     const labels = this.getSelectedChildrenLabels();
+    if (!labels) {
+      return '';
+    }
     return this.filter ? labels?.join(', ') : labels?.toString();
   };
 
@@ -462,6 +465,7 @@ export class TdsDropdown {
                   disabled={this.disabled}
                   onInput={(event) => this.handleFilter(event)}
                   onBlur={(event) => {
+                    console.log('blurrr');
                     this.filterFocus = false;
                     this.handleBlur(event);
                   }}

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -465,7 +465,6 @@ export class TdsDropdown {
                   disabled={this.disabled}
                   onInput={(event) => this.handleFilter(event)}
                   onBlur={(event) => {
-                    console.log('blurrr');
                     this.filterFocus = false;
                     this.handleBlur(event);
                   }}


### PR DESCRIPTION
**Describe pull-request**  
Fixes dropdown getting value "undefined" (as a string) when it was a multiselect, filter, and opened and closed without selecting a value.

> "The reason inputElement.value is "undefined" as a string is because when you assign undefined to an input element's value, it gets converted to the string "undefined". This is a standard behavior in JavaScript: when undefined is coerced into a string, it becomes "undefined"."
-- GPT-4

**Solving issue**  
Fixes: [CDEP-2749](https://tegel.atlassian.net/browse/CDEP-2759)

**How to test**  
1. Go to deploy preview
2. Check in dropdown, add multiselect & filter
3. Open and close the dropdown and verify it looks good.

**Screenshots**  

<img width="332" alt="Screenshot 2023-10-09 at 16 02 15" src="https://github.com/scania-digital-design-system/tegel/assets/8556022/5c85fbcd-70b4-449f-b585-268e5a35099e">


[CDEP-2749]: https://tegel.atlassian.net/browse/CDEP-2749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ