### PR TITLE
docs(tooltip,modal,popover): referenceEl usage in Angular/React

### DIFF
--- a/packages/core/src/components/modal/readme.md
+++ b/packages/core/src/components/modal/readme.md
@@ -14,6 +14,21 @@ If you are using the `<tds-modal>` in an Angular environment and want to use the
 </tds-modal>
 
 ```
+
+
+### Usage in React
+If you are using the `<TdsModal>` in an React environment and want to
+use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
+
+```jsx
+<div ref={myReference.current}>
+  <TdsButton text="Button"></TdsButton>
+</div>
+<TdsModal referenceEl={myReference}>
+  
+</TdsModal>
+
+```
 <!-- Auto Generated Below -->
 
 

--- a/packages/core/src/components/modal/readme.md
+++ b/packages/core/src/components/modal/readme.md
@@ -16,7 +16,7 @@ If you are using the `<tds-modal>` in an Angular environment and want to use the
 ```
 
 
-### Usage in React
+### Usage with @scania/tegel-react
 If you are using the `<TdsModal>` in an React environment and want to
 use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
 

--- a/packages/core/src/components/modal/readme.md
+++ b/packages/core/src/components/modal/readme.md
@@ -2,7 +2,7 @@
 
 
 
-### Usage in Angular
+### Usage with @scania/tegel-angular
 If you are using the `<tds-modal>` in an Angular environment and want to use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
 
 ```html

--- a/packages/core/src/components/popover-canvas/readme.md
+++ b/packages/core/src/components/popover-canvas/readme.md
@@ -1,6 +1,6 @@
 # tds-popover-canvas
 
-### Usage in Angular
+### Usage with @scania/tegel-angular
 If you are using the `<tds-popover-canvas>` in an Angular environment and want to
 use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
 
@@ -14,7 +14,7 @@ use the `referenceEl` prop rather than the `selector` the referenced element can
 
 ```
 
-### Usage in React
+### Usage with @scania/tegel-react
 If you are using the `<TdsPopoverCanvas>` in an React environment and want to
 use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
 

--- a/packages/core/src/components/popover-canvas/readme.md
+++ b/packages/core/src/components/popover-canvas/readme.md
@@ -13,6 +13,20 @@ use the `referenceEl` prop rather than the `selector` the referenced element can
 </tds-popover-canvas>
 
 ```
+
+### Usage in React
+If you are using the `<TdsPopoverCanvas>` in an React environment and want to
+use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
+
+```jsx
+<div ref={myReference.current}>
+  <TdsButton text="Button"></TdsButton>
+</div>
+<TdsPopoverCanvas referenceEl={myReference}>
+  <h2 class="tds-headline-02 tds-u-mt0">A Popover Canvas!</h2>
+</TdsPopoverCanvas>
+
+```
 <!-- Auto Generated Below -->
 
 

--- a/packages/core/src/components/popover-menu/readme.md
+++ b/packages/core/src/components/popover-menu/readme.md
@@ -17,7 +17,7 @@ use the `referenceEl` prop rather than the `selector` the referenced element can
 
 ```
 
-### Usage in React
+### Usage with @scania/tegel-react
 If you are using the `<TdsPopoverMenu>` in an React environment and want to
 use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
 

--- a/packages/core/src/components/popover-menu/readme.md
+++ b/packages/core/src/components/popover-menu/readme.md
@@ -1,7 +1,7 @@
 # tds-popover-menu
 
 
-### Usage in Angular
+### Usage with @scania/tegel-angular
 If you are using the `<tds-popover-menu>` in an Angular environment and want to
 use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
 

--- a/packages/core/src/components/popover-menu/readme.md
+++ b/packages/core/src/components/popover-menu/readme.md
@@ -16,6 +16,22 @@ use the `referenceEl` prop rather than the `selector` the referenced element can
 </tds-popover-menu>
 
 ```
+
+### Usage in React
+If you are using the `<TdsPopoverMenu>` in an React environment and want to
+use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
+
+```jsx
+<div ref={myReference.current}>
+  <TdsButton text="Button"></TdsButton>
+</div>
+<TdsPopoverMenu referenceEl={myReference}>
+  <TdsPopoverMenuItem>
+    <a href="#">Action</a>
+  </TdsPopoverMenuItem>
+</TdsPopoverMenu>
+
+```
 <!-- Auto Generated Below -->
 
 

--- a/packages/core/src/components/tooltip/readme.md
+++ b/packages/core/src/components/tooltip/readme.md
@@ -15,7 +15,7 @@ use the `referenceEl` prop rather than the `selector` the referenced element can
 
 ```
 
-### Usage in React
+### Usage with @scania/tegel-react
 If you are using the `<TdsTooltip>` in an React environment and want to
 use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
 

--- a/packages/core/src/components/tooltip/readme.md
+++ b/packages/core/src/components/tooltip/readme.md
@@ -1,7 +1,33 @@
 # tds-tooltip
 
 
+### Usage in Angular
+If you are using the `<tds-toolip>` in an Angular environment and want to
+use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
 
+```html
+<div #myReference>
+  <tds-button text="Button"></tds-button>
+</div>
+<tds-toolip [referenceEl]="myReference">
+
+</tds-toolip>
+
+```
+
+### Usage in React
+If you are using the `<TdsTooltip>` in an React environment and want to
+use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
+
+```jsx
+<div ref={myReference.current}>
+  <TdsButton text="Button"></TdsButton>
+</div>
+<TdsTooltip referenceEl={myReference}>
+
+</TdsTooltip>
+
+```
 <!-- Auto Generated Below -->
 
 

--- a/packages/core/src/components/tooltip/readme.md
+++ b/packages/core/src/components/tooltip/readme.md
@@ -1,7 +1,7 @@
 # tds-tooltip
 
 
-### Usage in Angular
+### Usage with @scania/tegel-angular
 If you are using the `<tds-toolip>` in an Angular environment and want to
 use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
 


### PR DESCRIPTION
**Describe pull-request**  
This PR adds documentation on how to use the referenceEl prop in with our React/Angular wrappers.

**Solving issue**  
Fixes: [CDEP-2766](https://tegel.atlassian.net/browse/CDEP-2766)

**How to test**  
1. Go to Modal, Tooltip, Popover Menu/Canvas
2. Check under Notes
3. Check the documentation on Angular/React usage.



[CDEP-2766]: https://tegel.atlassian.net/browse/CDEP-2766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ