### PR TITLE
build(core/react/angular): added release actions for all packages

### DIFF
--- a/.github/workflows/release-angular.yml
+++ b/.github/workflows/release-angular.yml
@@ -44,10 +44,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Angular - CD into correct folder
-        run: echo "cd packages/angular"
+        run: cd packages/angular
 
       - name: Angular - Remove package-lock
-        run: echo "rm -rf package-lock.json"
+        run: rm -rf package-lock.json
 
       - name: Angular - Install latest tegel package
         run: npm install @scania/tegel@${{ github.event.inputs.tegelVersion }}

--- a/.github/workflows/release-angular.yml
+++ b/.github/workflows/release-angular.yml
@@ -1,0 +1,87 @@
+name: Release @scania/tegel-angular
+on:
+  workflow_dispatch:
+    inputs:
+      tegelVersion:
+        description: 'Tegel version'
+        required: true
+        type: string
+
+      nodeVersion:
+        description: 'Node version'
+        required: true
+        default: '18.16.0'
+        type: string
+
+      tags:
+        description: 'Tag'
+        required: true
+        default: 'beta'
+        type: choice
+        options:
+          - latest
+          - beta
+          - dev
+
+      dryRun:
+        description: 'Dry run'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up node
+        # Setup .npmrc file to publish to npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ github.event.inputs.tegelVersion }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Angular - CD into correct folder
+        run: echo "cd packages/angular"
+
+      - name: Angular - Remove package-lock
+        run: echo "rm -rf package-lock.json"
+
+      - name: Angular - Install latest tegel package
+        run: npm install @scania/tegel@${{ github.event.inputs.tegelVersion }}
+
+      - name: Set user
+        run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
+
+      - name: Angular - Bump version
+        run: npm version ${{ github.event.inputs.tegelVersion }}
+
+      - name: Angular - Read Package.json Version
+        id: version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+
+      - name: Check out new branch
+        run: git checkout -b "release/${{ steps.version.outputs.version }}"
+
+      - name: Angular - Run build
+        run: npm run build
+
+      - name: Angular - Publish
+        run: |
+          if [ "${{ github.event.inputs.dryRun }}" == "true" ]; then
+            npm publish --tag ${{ github.event.inputs.tags }} --dry-run
+          else
+            npm publish --tag ${{ github.event.inputs.tags }}
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Core - Create PR
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: release/@scania/tegel-react@${{ steps.version.outputs.version }}
+          commit-message: Release of @scania/tegel@${{ steps.version.outputs.version }}
+          branch: release/${{ steps.version.outputs.version }}
+          delete-branch: true

--- a/.github/workflows/release-angular.yml
+++ b/.github/workflows/release-angular.yml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Notify on Failure
+      - name: Remove branch and git tag on failure
         env:
           npm_version: ${{ github.event.inputs.tegelVersion }}
         run: |

--- a/.github/workflows/release-angular.yml
+++ b/.github/workflows/release-angular.yml
@@ -30,7 +30,7 @@ on:
         type: boolean
 
 jobs:
-  Release:
+  release-angular:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -43,8 +43,14 @@ jobs:
           node-version: ${{ github.event.inputs.nodeVersion }}
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Set Tegel user
+        run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
+
       - name: Angular - CD into correct folder
         run: cd packages/angular
+
+      - name: Angular - Bump version
+        run: npm version ${{ github.event.inputs.tegelVersion }}
 
       - name: Angular - Remove package-lock
         run: rm -rf package-lock.json
@@ -52,18 +58,8 @@ jobs:
       - name: Angular - Install latest tegel package
         run: npm install @scania/tegel@${{ github.event.inputs.tegelVersion }}
 
-      - name: Set user
-        run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
-
-      - name: Angular - Bump version
-        run: npm version ${{ github.event.inputs.tegelVersion }}
-
-      - name: Angular - Read Package.json Version
-        id: version
-        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
-
       - name: Check out new branch
-        run: git checkout -b "release/${{ steps.version.outputs.version }}"
+        run: git checkout -b "release/${{ github.event.inputs.tegelVersion }}
 
       - name: Angular - Run build
         run: npm run build
@@ -78,10 +74,22 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Core - Create PR
+      - name: Angular - Create PR
         uses: peter-evans/create-pull-request@v3
         with:
-          title: release/@scania/tegel-react@${{ steps.version.outputs.version }}
-          commit-message: Release of @scania/tegel@${{ steps.version.outputs.version }}
-          branch: release/${{ steps.version.outputs.version }}
+          title: release/@scania/tegel-react@${{ github.event.inputs.tegelVersion }}
+          commit-message: Release of @scania/tegel@${{ github.event.inputs.tegelVersion }}
+          branch: release/${{ github.event.inputs.tegelVersion }}
           delete-branch: true
+  on-failure:
+    needs: release-angular
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Notify on Failure
+        env:
+          npm_version: ${{ github.event.inputs.tegelVersion }}
+        run: |
+          if [ "${{ job.status }}" == "failure" ]; then
+            git push origin --delete @scania/tegel@${{ github.event.inputs.tegelVersion }}
+          fi

--- a/.github/workflows/release-angular.yml
+++ b/.github/workflows/release-angular.yml
@@ -40,7 +40,7 @@ jobs:
         # Setup .npmrc file to publish to npm
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ github.event.inputs.tegelVersion }}
+          node-version: ${{ github.event.inputs.nodeVersion }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Angular - CD into correct folder

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Notify on Failure
+      - name: Remove branch and git tag on failure
         env:
           npm_version: ${{ needs.release.outputs.version }}
         run: |

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -1,0 +1,92 @@
+name: Release @scania/tegel
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+
+      nodeVersion:
+        description: 'Node version'
+        required: true
+        default: '18.16.0'
+        type: string
+
+      tags:
+        description: 'Tag'
+        required: true
+        default: 'beta'
+        type: choice
+        options:
+          - latest
+          - beta
+          - dev
+
+      dryRun:
+        description: 'Dry run'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up node
+        # Setup .npmrc file to publish to npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.16.0'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Set Tegel user
+        run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
+
+      - name: Core - CD into correct folder
+        run: echo "cd packages/core"
+
+      - name: Core - Bump version
+        run: npm version ${{ github.event.inputs.version }}
+
+      - name: Core - Read Package.json Version
+        id: version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+
+      - name: Core - Create git tag
+        run: git tag @scania/tegel@${{ steps.version.outputs.version }}
+
+      - name: Core - Push git tag
+        run: git push origin @scania/tegel@${{ steps.version.outputs.version }}
+
+      - name: Core - npm install
+        run: npm install
+
+      - name: Core - Run build
+        run: npm run build
+
+      - name: Core - Publish
+        run: |
+          if [ "${{ github.event.inputs.dryRun }}" == "true" ]; then
+            npm publish --tag ${{ github.event.inputs.tags }} --dry-run
+          else
+            npm publish --tag ${{ github.event.inputs.tags }}
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Core - Create PR
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: release/@scania/tegel@${{ steps.version.outputs.version }}
+          commit-message: Release of @scania/tegel@${{ steps.version.outputs.version }}
+          branch: release/${{ steps.version.outputs.version }}
+          delete-branch: true

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -45,7 +45,7 @@ jobs:
         # Setup .npmrc file to publish to npm
         uses: actions/setup-node@v3
         with:
-          node-version: '18.16.0'
+          node-version: ${{ github.event.inputs.nodeVersion }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Set Tegel user

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -90,3 +90,18 @@ jobs:
           commit-message: Release of @scania/tegel@${{ steps.version.outputs.version }}
           branch: release/${{ steps.version.outputs.version }}
           delete-branch: true
+  on-failure:
+    needs: release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Notify on Failure
+        env:
+          npm_version: ${{ needs.release.outputs.version }}
+        run: |
+          if [ "${{ job.status }}" == "failure" ]; then
+            tagname="@scania/tegel@$npm_version"
+            git push --delete origin $tagname
+            branchname="release/@scania/tegel@$npm_version"
+            git push origin --delete branch_name
+          fi

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -103,5 +103,5 @@ jobs:
             tagname="@scania/tegel@$npm_version"
             git push --delete origin $tagname
             branchname="release/@scania/tegel@$npm_version"
-            git push origin --delete branch_name
+            git push origin --delete $branchname
           fi

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -35,7 +35,7 @@ on:
         type: boolean
 
 jobs:
-  release:
+  release-core:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -52,7 +52,7 @@ jobs:
         run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
 
       - name: Core - CD into correct folder
-        run: echo "cd packages/core"
+        run: cd packages/core
 
       - name: Core - Bump version
         run: npm version ${{ github.event.inputs.version }}
@@ -91,7 +91,7 @@ jobs:
           branch: release/${{ steps.version.outputs.version }}
           delete-branch: true
   on-failure:
-    needs: release
+    needs: release-core
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-react.yml
+++ b/.github/workflows/release-react.yml
@@ -40,7 +40,7 @@ jobs:
         # Setup .npmrc file to publish to npm
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ github.event.inputs.tegelVersion }}
+          node-version: ${{ github.event.inputs.nodeVersion }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: React - CD into correct folder

--- a/.github/workflows/release-react.yml
+++ b/.github/workflows/release-react.yml
@@ -44,10 +44,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: React - CD into correct folder
-        run: echo "cd packages/react"
+        run: cd packages/react
 
       - name: React - Remove package-lock
-        run: echo "rm -rf package-lock.json"
+        run: rm -rf package-lock.json
 
       - name: React - npm install
         run: npm install

--- a/.github/workflows/release-react.yml
+++ b/.github/workflows/release-react.yml
@@ -1,0 +1,95 @@
+name: Release @scania/tegel-react
+on:
+  workflow_dispatch:
+    inputs:
+      tegelVersion:
+        description: 'Tegel version'
+        required: true
+        type: string
+
+      nodeVersion:
+        description: 'Node version'
+        required: true
+        default: '18.16.0'
+        type: string
+
+      tags:
+        description: 'Tag'
+        required: true
+        default: 'beta'
+        type: choice
+        options:
+          - latest
+          - beta
+          - dev
+
+      dryRun:
+        description: 'Dry run'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up node
+        # Setup .npmrc file to publish to npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ github.event.inputs.tegelVersion }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: React - CD into correct folder
+        run: echo "cd packages/react"
+
+      - name: React - Remove package-lock
+        run: echo "rm -rf package-lock.json"
+
+      - name: React - npm install
+        run: npm install
+
+      - name: React - Install latest tegel package
+        run: npm @scania/tegel@${{ github.event.inputs.tegelVersion }}
+
+      - name: Set user
+        run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
+
+      - name: React - Bump version
+        run: npm version ${{ github.event.inputs.tegelVersion }}
+
+      - name: React - Read Package.json Version
+        id: version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+
+      - name: Check out new branch
+        run: git checkout -b "release/${{ steps.version.outputs.version }}"
+
+      - name: React - Run build
+        run: npm run build
+
+      - name: Push branch
+        run: git commit -am "release/${{ steps.version.outputs.version }}" && git push --set-upstream origin "release/${{ steps.version.outputs.version }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: React - Publish
+        run: |
+          if [ "${{ github.event.inputs.dryRun }}" == "true" ]; then
+            npm publish --tag ${{ github.event.inputs.tags }} --dry-run
+          else
+            npm publish --tag ${{ github.event.inputs.tags }}
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Core - Create PR
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: release/@scania/tegel-react@${{ steps.version.outputs.version }}
+          commit-message: Release of @scania/tegel@${{ steps.version.outputs.version }}
+          branch: release/${{ steps.version.outputs.version }}
+          delete-branch: true

--- a/.github/workflows/release-react.yml
+++ b/.github/workflows/release-react.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Notify on Failure
+      - name: Remove branch and git tag on failure
         env:
           npm_version: ${{ github.event.inputs.tegelVersion }}
         run: |

--- a/.github/workflows/release-react.yml
+++ b/.github/workflows/release-react.yml
@@ -30,7 +30,7 @@ on:
         type: boolean
 
 jobs:
-  Release:
+  release-react:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -43,38 +43,29 @@ jobs:
           node-version: ${{ github.event.inputs.nodeVersion }}
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Set Tegel user
+        run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
+
       - name: React - CD into correct folder
         run: cd packages/react
-
-      - name: React - Remove package-lock
-        run: rm -rf package-lock.json
-
-      - name: React - npm install
-        run: npm install
-
-      - name: React - Install latest tegel package
-        run: npm @scania/tegel@${{ github.event.inputs.tegelVersion }}
-
-      - name: Set user
-        run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
 
       - name: React - Bump version
         run: npm version ${{ github.event.inputs.tegelVersion }}
 
-      - name: React - Read Package.json Version
-        id: version
-        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+      - name: React - Install latest tegel package
+        run: npm @scania/tegel@${{ github.event.inputs.tegelVersion }}
+
+      - name: React - Remove package-lock
+        run: rm -rf package-lock.json
+
+      - name: React - Install with latest tegel package
+        run: npm install @scania/tegel@${{ github.event.inputs.tegelVersion }}
 
       - name: Check out new branch
-        run: git checkout -b "release/${{ steps.version.outputs.version }}"
+        run: git checkout -b "release/${{ github.event.inputs.tegelVersion }}"
 
       - name: React - Run build
         run: npm run build
-
-      - name: Push branch
-        run: git commit -am "release/${{ steps.version.outputs.version }}" && git push --set-upstream origin "release/${{ steps.version.outputs.version }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: React - Publish
         run: |
@@ -86,10 +77,22 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Core - Create PR
+      - name: React - Create PR
         uses: peter-evans/create-pull-request@v3
         with:
-          title: release/@scania/tegel-react@${{ steps.version.outputs.version }}
-          commit-message: Release of @scania/tegel@${{ steps.version.outputs.version }}
-          branch: release/${{ steps.version.outputs.version }}
+          title: release/@scania/tegel-react@${{ github.event.inputs.tegelVersion }}
+          commit-message: Release of @scania/tegel@${{ github.event.inputs.tegelVersion }}
+          branch: release/${{ github.event.inputs.tegelVersion }}
           delete-branch: true
+  on-failure:
+    needs: release-react
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Notify on Failure
+        env:
+          npm_version: ${{ github.event.inputs.tegelVersion }}
+        run: |
+          if [ "${{ job.status }}" == "failure" ]; then
+            git push origin --delete @scania/tegel@${{ github.event.inputs.tegelVersion }}
+          fi


### PR DESCRIPTION
**Describe pull-request**  
This PR adds three github actions:
 - release-core
 - release-react
 - release-angular
 
 This are all actions that are triggered manually and they do a release to npm for each package.
 
 The `release-core` actions requires the following input:
  - Release type (major, minor, patch)
  - Node version (18.16.0 by default) -> this specifies which node package should be built with.
  - Tag -> specifies what npm tag the release should have
  - Dry run -> if true the `npm publish` will run with a dry-run flag

The `release-react` and `release-angular` requires the following input:
  - Tegel version -> which tegel version is the dependency for the package. This will also be the version of the built an published package. For example: if Tegel version is 1.1.0, the tegel-angular package will be built as @scania/tegel@1.1.0 as a dependency **and** released @scania/tegel-angular package will be of version 1.1.0
  - Node version (18.16.0 by default) -> this specifies which node package should be built with.
  - Tag -> specifies what npm tag the release should have
  - Dry run -> if true the `npm publish` will run with a dry-run flag


Example of ran actions: https://github.com/scania-digital-design-system/tegel-react-demo/actions
_These were all run with dry run: true_
 
**Solving issue**  
Fixes:
 - [CDEP-2754](https://tegel.atlassian.net/browse/CDEP-2754)
 - [CDEP-2755](https://tegel.atlassian.net/browse/CDEP-2755)
 - [CDEP-2756](https://tegel.atlassian.net/browse/CDEP-2756)


**How to test**  
Not testable today.



[CDEP-2754]: https://tegel.atlassian.net/browse/CDEP-2754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ