### PR TITLE
fix(breadcrumb): correct focus state

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
+++ b/packages/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
@@ -13,8 +13,11 @@
     }
   }
 
-  &:focus-visible {
+  ::slotted(*:focus-visible) {
     @include tds-focus-state;
+
+    // Overrides the offset of the tds-focus-state to align with design.
+    outline-offset: -0;
   }
 
   &.current,

--- a/packages/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
+++ b/packages/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
@@ -36,7 +36,7 @@
     }
   }
 
-  ::slotted(*)::after {
+  &::after {
     content: '\203A';
     color: var(--tds-breadcrumb-separator-color);
     margin-right: 4px;
@@ -47,8 +47,8 @@
   }
 }
 
-:host(:last-of-type) {
-  ::slotted(*)::after {
+:host(.last) [role='listitem'] {
+  &::after {
     display: none;
   }
 }

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -9,9 +9,10 @@ import { Component, h, Element } from '@stencil/core';
   shadow: true,
 })
 export class TdsBreadcrumbs {
-  @Element() el: HTMLElement;
+  @Element() host: HTMLElement;
 
   render() {
+    this.host.children[this.host.children.length - 1]?.classList.add('last');
     return (
       <nav>
         <div role="list" class={'tds-breadcrumb'}>


### PR DESCRIPTION
**Describe pull-request**  
Corrects the focus state of the breadcrumb.

**Solving issue**  
Fixes: -

**How to test**  
1. Go to Breadcrumb
2. Put focus on a slotted anchor tag (navigate via keyboard)
3. Check the styling and make sure it is aligned with design

**Screenshots**  
Before:
<img width="196" alt="Screenshot 2023-10-13 at 11 39 50" src="https://github.com/scania-digital-design-system/tegel/assets/62651103/fe6653d8-354c-4176-a7b4-6aedc356cf88">

After:
<img width="196" alt="Screenshot 2023-10-13 at 11 40 08" src="https://github.com/scania-digital-design-system/tegel/assets/62651103/fa20271e-4a60-482f-9dc5-ebc17e22e13d">


