### PR TITLE
docs(datetime): updated default value and max properties

### DIFF
--- a/packages/core/src/components/datetime/datetime.stories.tsx
+++ b/packages/core/src/components/datetime/datetime.stories.tsx
@@ -67,7 +67,7 @@ export default {
     defaultValue: {
       name: 'Default value',
       description:
-        'Sets max value. Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM.',
+        'Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM.',
       control: {
         type: 'radio',
       },
@@ -89,7 +89,7 @@ export default {
     },
     maxValue: {
       description:
-        'Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"',
+        'Sets max value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"',
       name: 'Max value',
       control: {
         type: 'text',


### PR DESCRIPTION
**Describe pull-request**  
Updated the documentation for default value and max properties.

**Solving issue**  
Fixes: [CDEP-2653](https://tegel.atlassian.net/browse/CDEP-2653)

**How to test**  
1. Go to Datetime
2. Check the documentation of the controls


[CDEP-2653]: https://tegel.atlassian.net/browse/CDEP-2653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ