### PR TITLE
fix(footer): link/title correct font

### DIFF
--- a/packages/core/src/components/footer/footer-item/footer-item.scss
+++ b/packages/core/src/components/footer/footer-item/footer-item.scss
@@ -23,12 +23,9 @@
   &.top-part-child {
     ::slotted(a),
     ::slotted(button) {
+      font: var(--tds-headline-07);
+      letter-spacing: var(--tds-headline-07-ls);
       color: var(--tds-footer-top-links);
-      font-family: 'Scania Sans Semi Condensed', 'Scania Sans Condensed', arial, helvetica,
-        sans-serif;
-      font-weight: bold;
-      font-size: 14px;
-      line-height: 18px;
     }
 
     ::slotted(a:focus-visible),

--- a/packages/core/src/components/footer/footer-item/footer-item.scss
+++ b/packages/core/src/components/footer/footer-item/footer-item.scss
@@ -3,8 +3,8 @@
 [role='listitem'] {
   ::slotted(a),
   ::slotted(button) {
-    font: var(--tds-headline-06);
-    letter-spacing: var(--tds-headline-06-ls);
+    font: var(--tds-headline-07);
+    letter-spacing: var(--tds-headline-07-ls);
     color: var(--tds-footer-main-links);
     opacity: var(--tds-footer-main-links-opacity);
     text-decoration: none;


### PR DESCRIPTION
**Describe pull-request**  
This PR updates all the footer links to use the correct font (headline-07)

**Solving issue**  
Fixes: [CDEP-2839](https://tegel.atlassian.net/browse/CDEP-2839)

**How to test**  
1. Go to Footer
2. Add a top part (via controls)
3. Check the links and make sure they use headline-07


[CDEP-2839]: https://tegel.atlassian.net/browse/CDEP-2839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ