### PR TITLE
feat(table): add inderminate state & updated selected prop

### DIFF
--- a/packages/core/src/components/table/table-component-multiselect.stories.tsx
+++ b/packages/core/src/components/table/table-component-multiselect.stories.tsx
@@ -46,7 +46,7 @@ export default {
       },
     },
     allIndeterminate: {
-      name: 'All selected',
+      name: 'All indeterminate',
       description: `Controls the indeterminate state of the "all-selected"-checkbox.`,
       control: {
         type: 'boolean',

--- a/packages/core/src/components/table/table-component-multiselect.stories.tsx
+++ b/packages/core/src/components/table/table-component-multiselect.stories.tsx
@@ -168,8 +168,8 @@ const MultiselectTemplate = ({
           modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''
         }
     >
-          <tds-table-header ${allSelected ? 'all-selected' : ''} ${
-    allIndeterminate ? 'all-indeterminate' : ''
+          <tds-table-header ${allSelected ? 'checked' : ''} ${
+    allIndeterminate ? 'indeterminate' : ''
   }>
               <tds-header-cell cell-key='truck' cell-value='Truck type' ${
                 column1Width ? `custom-width="${column1Width}"` : ''

--- a/packages/core/src/components/table/table-component-multiselect.stories.tsx
+++ b/packages/core/src/components/table/table-component-multiselect.stories.tsx
@@ -168,7 +168,7 @@ const MultiselectTemplate = ({
           modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''
         }
     >
-          <tds-table-header ${allSelected ? 'checked' : ''} ${
+          <tds-table-header ${allSelected ? 'selected' : ''} ${
     allIndeterminate ? 'indeterminate' : ''
   }>
               <tds-header-cell cell-key='truck' cell-value='Truck type' ${

--- a/packages/core/src/components/table/table-component-multiselect.stories.tsx
+++ b/packages/core/src/components/table/table-component-multiselect.stories.tsx
@@ -38,6 +38,20 @@ export default {
         defaultValue: { summary: 'Inherit from parent' },
       },
     },
+    allSelected: {
+      name: 'All selected',
+      description: `Controls the checked state of the "all-selected"-checkbox.`,
+      control: {
+        type: 'boolean',
+      },
+    },
+    allIndeterminate: {
+      name: 'All selected',
+      description: `Controls the indeterminate state of the "all-selected"-checkbox.`,
+      control: {
+        type: 'boolean',
+      },
+    },
     compactDesign: {
       name: 'Compact design',
       description: 'Enables compact design of the Table, rows with less height.',
@@ -116,6 +130,8 @@ export default {
   },
   args: {
     modeVariant: 'Inherit from parent',
+    allSelected: false,
+    allIndeterminate: false,
     compactDesign: false,
     responsiveDesign: false,
     verticalDivider: false,
@@ -129,6 +145,8 @@ export default {
 
 const MultiselectTemplate = ({
   modeVariant,
+  allSelected,
+  allIndeterminate,
   compactDesign,
   responsiveDesign,
   verticalDivider,
@@ -150,7 +168,9 @@ const MultiselectTemplate = ({
           modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''
         }
     >
-          <tds-table-header>
+          <tds-table-header ${allSelected ? 'all-selected' : ''} ${
+    allIndeterminate ? 'all-indeterminate' : ''
+  }>
               <tds-header-cell cell-key='truck' cell-value='Truck type' ${
                 column1Width ? `custom-width="${column1Width}"` : ''
               }></tds-header-cell>

--- a/packages/core/src/components/table/table-header/readme.md
+++ b/packages/core/src/components/table/table-header/readme.md
@@ -7,9 +7,10 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                                                     | Type      | Default |
-| ------------- | -------------- | ------------------------------------------------------------------------------- | --------- | ------- |
-| `allSelected` | `all-selected` | Prop for controling the checked/unchecked state of the "all selected"-checkbox. | `boolean` | `false` |
+| Property           | Attribute           | Description                                                                     | Type      | Default |
+| ------------------ | ------------------- | ------------------------------------------------------------------------------- | --------- | ------- |
+| `allIndeterminate` | `all-indeterminate` | Prop for controling the interdeminate state of the "all selected"-checkbox      | `boolean` | `false` |
+| `allSelected`      | `all-selected`      | Prop for controling the checked/unchecked state of the "all selected"-checkbox. | `boolean` | `false` |
 
 
 ## Events

--- a/packages/core/src/components/table/table-header/readme.md
+++ b/packages/core/src/components/table/table-header/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property           | Attribute           | Description                                                                     | Type      | Default |
-| ------------------ | ------------------- | ------------------------------------------------------------------------------- | --------- | ------- |
-| `allIndeterminate` | `all-indeterminate` | Prop for controling the interdeminate state of the "all selected"-checkbox      | `boolean` | `false` |
-| `allSelected`      | `all-selected`      | Prop for controling the checked/unchecked state of the "all selected"-checkbox. | `boolean` | `false` |
+| Property        | Attribute       | Description                                                                                  | Type      | Default     |
+| --------------- | --------------- | -------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `allSelected`   | `all-selected`  | <span style="color:red">**[DEPRECATED]**</span> Deprecated, use selected instead..<br/><br/> | `boolean` | `false`     |
+| `indeterminate` | `indeterminate` | Prop for controling the indeterminate state of the "All selected"-checkbox.                  | `boolean` | `false`     |
+| `selected`      | `selected`      | Prop for controling the checked/unchecked state of the "All selected"-checkbox.              | `boolean` | `undefined` |
 
 
 ## Events

--- a/packages/core/src/components/table/table-header/table-header.tsx
+++ b/packages/core/src/components/table/table-header/table-header.tsx
@@ -29,7 +29,10 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
 })
 export class TdsTableHeaderRow {
   /** Prop for controling the checked/unchecked state of the "all selected"-checkbox. */
-  @Prop({ reflect: true, mutable: true }) allSelected: boolean = false;
+  @Prop({ reflect: true }) allSelected: boolean = false;
+
+  /** Prop for controling the interdeminate state of the "all selected"-checkbox */
+  @Prop() allIndeterminate: boolean = false;
 
   @State() multiselect: boolean = false;
 
@@ -147,6 +150,7 @@ export class TdsTableHeaderRow {
               <div class="tds-form-label tds-form-label--table">
                 <tds-checkbox
                   checked={this.allSelected}
+                  indeterminate={this.allIndeterminate}
                   onTdsChange={(event) => this.handleCheckboxChange(event)}
                 ></tds-checkbox>
               </div>

--- a/packages/core/src/components/table/table-header/table-header.tsx
+++ b/packages/core/src/components/table/table-header/table-header.tsx
@@ -28,11 +28,14 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
   shadow: true,
 })
 export class TdsTableHeaderRow {
-  /** Prop for controling the checked/unchecked state of the "all selected"-checkbox. */
-  @Prop({ reflect: true }) allSelected: boolean = false;
+  /** @deprecated Deprecated, use selected instead.. */
+  @Prop({ reflect: true, mutable: true }) allSelected: boolean = false;
 
-  /** Prop for controling the interdeminate state of the "all selected"-checkbox */
-  @Prop() allIndeterminate: boolean = false;
+  /** Prop for controling the checked/unchecked state of the "All selected"-checkbox. */
+  @Prop({ reflect: true, mutable: true }) selected: boolean;
+
+  /** Prop for controling the indeterminate state of the "All selected"-checkbox. */
+  @Prop() indeterminate: boolean = false;
 
   @State() multiselect: boolean = false;
 
@@ -149,8 +152,8 @@ export class TdsTableHeaderRow {
             <th class="tds-table__header-cell tds-table__header-cell--checkbox">
               <div class="tds-form-label tds-form-label--table">
                 <tds-checkbox
-                  checked={this.allSelected}
-                  indeterminate={this.allIndeterminate}
+                  checked={this.allSelected || this.selected}
+                  indeterminate={this.indeterminate}
                   onTdsChange={(event) => this.handleCheckboxChange(event)}
                 ></tds-checkbox>
               </div>


### PR DESCRIPTION
This PR adds a prop to the `table-header` component, `indeterminate`. This allows the user to toggle the indeterminate state of the checkbox present in the header, if the table is a multiselect one.  It also introduces an alternative prop to toggle the checke state of the "all selected"-checkbox, `selected` and adds a deprecation warning on the `allSelected` prop. 

This is done to align the prop names with the ones used in the `tds-table-body-row`.


**Solving issue**  
Fixes: [CDEP-2884](https://tegel.atlassian.net/browse/CDEP-2884)

**How to test**  
1. Go to Table -> Multiselect
2. Toggle the `All Indeterminate` control


[CDEP-2884]: https://tegel.atlassian.net/browse/CDEP-2884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ