### PR TITLE
fix(tabs): unset z index

### DIFF
--- a/packages/core/src/components/tabs/folder-tabs/folder-tab/folder-tab.scss
+++ b/packages/core/src/components/tabs/folder-tabs/folder-tab/folder-tab.scss
@@ -1,5 +1,4 @@
 @import '../../../../mixins/focus-state';
-@import '../../../../mixins/z-index';
 @import '../../../../mixins/box-sizing';
 
 :host {

--- a/packages/core/src/components/tabs/folder-tabs/folder-tabs.scss
+++ b/packages/core/src/components/tabs/folder-tabs/folder-tabs.scss
@@ -1,6 +1,5 @@
 @import '../../../mixins/focus-state';
 @import '../../../mixins/box-sizing';
-@import '../../../mixins/z-index';
 
 :host {
   @include tds-box-sizing;
@@ -20,12 +19,12 @@
   }
 
   .scroll-right-button {
-    z-index: calc(tds-z-index(tab) + 1);
+    z-index: 1;
     right: 0;
   }
 
   .scroll-left-button {
-    z-index: calc(tds-z-index(tab) + 1);
+    z-index: 1;
     left: 0;
   }
 

--- a/packages/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
+++ b/packages/core/src/components/tabs/inline-tabs/inline-tab/inline-tab.scss
@@ -1,11 +1,9 @@
 @import '../../../../mixins/focus-state';
-@import '../../../../mixins/z-index';
 @import '../../../../mixins/box-sizing';
 
 :host {
   @include tds-box-sizing;
 
-  z-index: tds-z-index(tab);
   display: block;
   position: relative;
 

--- a/packages/core/src/components/tabs/inline-tabs/inline-tabs.scss
+++ b/packages/core/src/components/tabs/inline-tabs/inline-tabs.scss
@@ -1,6 +1,5 @@
 @import '../../../mixins/focus-state';
 @import '../../../mixins/box-sizing';
-@import '../../../mixins/z-index';
 
 :host {
   @include tds-box-sizing;
@@ -35,12 +34,12 @@
 
   .scroll-right-button {
     right: 0;
-    z-index: calc(tds-z-index(tab) + 1);
+    z-index: 1;
   }
 
   .scroll-left-button {
     left: 0;
-    z-index: calc(tds-z-index(tab) + 1);
+    z-index: 1;
   }
 
   .scroll-right-button,

--- a/packages/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
+++ b/packages/core/src/components/tabs/navigation-tabs/navigation-tab/navigation-tab.scss
@@ -1,11 +1,9 @@
 @import '../../../../mixins/focus-state';
-@import '../../../../mixins/z-index';
 @import '../../../../mixins/box-sizing';
 
 :host {
   @include tds-box-sizing;
 
-  z-index: tds-z-index(tab);
   display: block;
 
   ::slotted(*) {

--- a/packages/core/src/components/tabs/navigation-tabs/navigation-tabs.scss
+++ b/packages/core/src/components/tabs/navigation-tabs/navigation-tabs.scss
@@ -1,6 +1,5 @@
 @import '../../../mixins/focus-state';
 @import '../../../mixins/box-sizing';
-@import '../../../mixins/z-index';
 
 :host {
   @include tds-box-sizing;
@@ -35,12 +34,12 @@
 
   .scroll-right-button {
     right: 0;
-    z-index: calc(tds-z-index(tab) + 1);
+    z-index: 1;
   }
 
   .scroll-left-button {
     left: 0;
-    z-index: calc(tds-z-index(tab) + 1);
+    z-index: 1;
   }
 
   .scroll-right-button,


### PR DESCRIPTION
z index were unnecessarily high.

NOTE: Might technically be a breaking change. However, I believe users getting negatively affected would be very rare. As such, I think leaving it will cause far more issues for users than removing it (z-index).

**How to test:**
Open the deploy preview and check that:
- tabs have no z-index set
- scroll buttons still appear and work as expected
- check for other issues