### PR TITLE
docs(datetime): updated the max prop to use correct prop

### DIFF
--- a/packages/core/src/components/datetime/datetime.stories.tsx
+++ b/packages/core/src/components/datetime/datetime.stories.tsx
@@ -209,7 +209,7 @@ const datetimeTemplate = ({
       ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}
       type="${typeLookup[type]}"      
       ${minValue ? `min=${minValue}` : ''}
-      ${maxValue ? `min=${maxValue}` : ''}
+      ${maxValue ? `max=${maxValue}` : ''}
       size="${sizeLookup[size]}"
       state="${stateLookup[state]}"
       ${disabled ? 'disabled' : ''}


### PR DESCRIPTION
**Describe pull-request**  
The max control in storybook was used to set the min prop. This PR fixes that.

**How to test**  
1. Go to Datetime
2. Set a min/max value
3. Make sure the props work properly.


