### PR TITLE
docs: "native" components -> css class components

### DIFF
--- a/packages/core/src/stories/Migration/Migration.stories.mdx
+++ b/packages/core/src/stories/Migration/Migration.stories.mdx
@@ -6,9 +6,11 @@ import { Meta } from '@storybook/addon-docs';
 
 This document aims to include all the breaking changes when migrating from @scania/components version 4 to @scania/tegel.
 
-## Deprecation of Native Components
+## Deprecation of CSS class components
 
-In @scania/tegel, we have replaced all of our "native" components with their corresponding web component counterparts. As a result, every component previously available as a "native" component in @scania/components now has a web component equivalent in @scania/tegel. It's important to note that this change does not impact the existing @scania/components package.
+In @scania/tegel, we have replaced all "CSS components" with web-components. As a result, every component previously available as a "CSS component" (made with CSS classes) in @scania/components now has a web-component equivalent in @scania/tegel. It's important to note that this change does not impact the existing @scania/components package.
+
+Our switch to web-components should not be limiting you. In case you do find that a web component is limiting you from achieving what your designer has designed, please reach out to us through our support channel and let us know.
 
 ## Event name convention
 

--- a/packages/core/src/stories/Migration/Migration.stories.mdx
+++ b/packages/core/src/stories/Migration/Migration.stories.mdx
@@ -8,9 +8,9 @@ This document aims to include all the breaking changes when migrating from @scan
 
 ## Deprecation of CSS class components
 
-In @scania/tegel, we have replaced all "CSS components" with web-components. As a result, every component previously available as a "CSS component" (made with CSS classes) in @scania/components now has a web-component equivalent in @scania/tegel. It's important to note that this change does not impact the existing @scania/components package.
+In @scania/tegel, we have replaced all "CSS components" with web components. As a result, every component previously available as a "CSS component" (made with CSS classes) in @scania/components now has a web component equivalent in @scania/tegel. It's important to note that this change does not impact the existing @scania/components package.
 
-Our switch to web-components should not be limiting you. In case you do find that a web component is limiting you from achieving what your designer has designed, please reach out to us through our support channel and let us know.
+Our switch to web components should not be limiting you. In case you do find that a web component is limiting you from achieving what your designer has designed, please reach out to us through our support channel and let us know.
 
 ## Event name convention
 

--- a/packages/core/src/stories/announcements/announce-tegel.stories.ts
+++ b/packages/core/src/stories/announcements/announce-tegel.stories.ts
@@ -54,7 +54,7 @@ export const Tegel = {
                         <h4 class="tds-u-mb2">@scania/tegel 🧱</h4>
                         <p>
                             The new
-                            package includes all components as web-components, removes the old CSS class components and makes the
+                            package includes all components as web components, removes the old CSS class components and makes the
                             installation and updates easier. The current prefix for components, CSS variables, and utility classes -
                             "sdds",
                             will be changed. We have also created a new Storybook for @scania/tegel, which allows developers and
@@ -93,7 +93,7 @@ export const Tegel = {
                             And we have saved the best for last, @scania/tegel is 100% web component. Previous packages
                             had
                             some
-                            web-components, but also CSS components, these were utility classes that could be added to a predefined
+                            web components, but also CSS components, these were utility classes that could be added to a predefined
                             HTML
                             structure to create the look and feel of Tegel. Now we are making a big effort to provide all components as
                             web

--- a/packages/core/src/stories/announcements/announce-tegel.stories.ts
+++ b/packages/core/src/stories/announcements/announce-tegel.stories.ts
@@ -54,7 +54,7 @@ export const Tegel = {
                         <h4 class="tds-u-mb2">@scania/tegel 🧱</h4>
                         <p>
                             The new
-                            package includes all components as web components, removes the old "native" components and makes the
+                            package includes all components as web-components, removes the old CSS class components and makes the
                             installation and updates easier. The current prefix for components, CSS variables, and utility classes -
                             "sdds",
                             will be changed. We have also created a new Storybook for @scania/tegel, which allows developers and
@@ -93,7 +93,7 @@ export const Tegel = {
                             And we have saved the best for last, @scania/tegel is 100% web component. Previous packages
                             had
                             some
-                            web components, but also "native" components, these were utility classes that could be added to a predefined
+                            web-components, but also CSS components, these were utility classes that could be added to a predefined
                             HTML
                             structure to create the look and feel of Tegel. Now we are making a big effort to provide all components as
                             web
@@ -134,13 +134,13 @@ export const Tegel = {
                     </section>
                     <section>
                         <h4 class="tds-u-mb2">
-                            Removing "native" components ❌
+                            Removing CSS class components ❌
                         </h4>
 
 
                         <p>
-                            With this new package we are also removing our "native" components and instead introducing web component
-                            counterparts to these. This means that every component that was available as a "native" component in
+                            With this new package we are also removing our CSS components and instead introducing web component
+                            counterparts to these. This means that every component that was available as a CSS component in
                             @scania/components will have a web component alternative in @scania/tegel. This removal will be done in our
                             next
                             release of @scania/tegel. This change does not change the current @scania/components package.

--- a/packages/core/src/stories/tegel.stories.ts
+++ b/packages/core/src/stories/tegel.stories.ts
@@ -76,7 +76,7 @@ export const TegelDesignSystem = {
                         </p>
                         <p>
                             The new
-                            package includes all components as web-components, removes the old CSS class components and makes the
+                            package includes all components as web components, removes the old CSS class components and makes the
                             installation and updates easier. The current prefix for components, CSS variables, and utility classes -
                             "sdds",
                             will be changed. We have also created a new Storybook for @scania/tegel, which allows developers and
@@ -112,13 +112,13 @@ export const TegelDesignSystem = {
                             latest major.
                         </p>
                         <p>
-                            And we have saved the best for last, @scania/tegel is 100% web-components. Previous packages
+                            And we have saved the best for last, @scania/tegel is 100% web components. Previous packages
                             had
                             some
-                            web-components, but also CSS class components, these were utility classes that could be added to a predefined
+                            web components, but also CSS class components, these were utility classes that could be added to a predefined
                             HTML
                             structure to create the look and feel of Tegel. Now we are making a big effort to provide all components as
-                            web-components.
+                            web components.
                         </p>
                     </section>
                     <section>
@@ -160,9 +160,9 @@ export const TegelDesignSystem = {
 
 
                         <p>
-                            With this new package we are also removing our CSS components and instead introducing web-component
+                            With this new package we are also removing our CSS components and instead introducing web component
                             counterparts to these. This means that every component that was available as a CSS component in
-                            @scania/components will have a web-component alternative in @scania/tegel. This removal will be done in our
+                            @scania/components will have a web component alternative in @scania/tegel. This removal will be done in our
                             next
                             release of @scania/tegel. This change does not change the current @scania/components package.
 

--- a/packages/core/src/stories/tegel.stories.ts
+++ b/packages/core/src/stories/tegel.stories.ts
@@ -76,7 +76,7 @@ export const TegelDesignSystem = {
                         </p>
                         <p>
                             The new
-                            package includes all components as web components, removes the old "native" components and makes the
+                            package includes all components as web-components, removes the old CSS class components and makes the
                             installation and updates easier. The current prefix for components, CSS variables, and utility classes -
                             "sdds",
                             will be changed. We have also created a new Storybook for @scania/tegel, which allows developers and
@@ -112,14 +112,13 @@ export const TegelDesignSystem = {
                             latest major.
                         </p>
                         <p>
-                            And we have saved the best for last, @scania/tegel is 100% web component. Previous packages
+                            And we have saved the best for last, @scania/tegel is 100% web-components. Previous packages
                             had
                             some
-                            web components, but also "native" components, these were utility classes that could be added to a predefined
+                            web-components, but also CSS class components, these were utility classes that could be added to a predefined
                             HTML
                             structure to create the look and feel of Tegel. Now we are making a big effort to provide all components as
-                            web
-                            components.
+                            web-components.
                         </p>
                     </section>
                     <section>
@@ -156,14 +155,14 @@ export const TegelDesignSystem = {
                     </section>
                     <section>
                         <h4 class="tds-u-mb2">
-                            Removing "native" components ❌
+                            Removing CSS class components ❌
                         </h4>
 
 
                         <p>
-                            With this new package we are also removing our "native" components and instead introducing web component
-                            counterparts to these. This means that every component that was available as a "native" component in
-                            @scania/components will have a web component alternative in @scania/tegel. This removal will be done in our
+                            With this new package we are also removing our CSS components and instead introducing web-component
+                            counterparts to these. This means that every component that was available as a CSS component in
+                            @scania/components will have a web-component alternative in @scania/tegel. This removal will be done in our
                             next
                             release of @scania/tegel. This change does not change the current @scania/components package.
 


### PR DESCRIPTION
Replace ambiguous term "native" components with css class components.

**Solving issue**  
Fixes: [CDEP-2880](https://tegel.atlassian.net/browse/CDEP-2880)

**To test**
Look at the changes

[CDEP-2880]: https://tegel.atlassian.net/browse/CDEP-2880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ