### PR TITLE
build(release actions): cleanup of release gh actions

### DIFF
--- a/.github/workflows/bump-npm-version.yml
+++ b/.github/workflows/bump-npm-version.yml
@@ -16,10 +16,10 @@ jobs:
   release-angular:
     runs-on: ubuntu-latest
     steps:
-      - name: Fail if branch is not main
-        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+      - name: Fail if branch is not develop
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/develop'
         run: |
-          echo "This workflow should not be triggered on a branch other than main"
+          echo "This workflow should not be triggered on a branch other than develop"
           exit 1
 
       - name: Check out code
@@ -46,6 +46,7 @@ jobs:
           title: release/@scania/tegel@${{ github.event.inputs.version }}
           commit-message: Release of @scania/tegel@${{ github.event.inputs.version }}
           branch: release/tegel@${{ github.event.inputs.version }}
+          base: main
           delete-branch: true
 
   on-failure:

--- a/.github/workflows/bump-npm-version.yml
+++ b/.github/workflows/bump-npm-version.yml
@@ -47,7 +47,6 @@ jobs:
           commit-message: Release of @scania/tegel@${{ github.event.inputs.version }}
           branch: release/tegel@${{ github.event.inputs.version }}
           base: main
-          delete-branch: true
 
   on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/bump-npm-version.yml
+++ b/.github/workflows/bump-npm-version.yml
@@ -1,0 +1,60 @@
+name: Bump NPM version (core/angular/react)
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+
+jobs:
+  release-angular:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if branch is not main
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: |
+          echo "This workflow should not be triggered on a branch other than main"
+          exit 1
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set Tegel user
+        run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
+
+      - name: Core - Bump version
+        run: npm version ${{ github.event.inputs.version }}
+        working-directory: packages/core
+
+      - name: Angular - Bump version
+        run: npm version ${{ github.event.inputs.version }}
+        working-directory: packages/angular
+
+      - name: React - Bump version
+        run: npm version ${{ github.event.inputs.version }}
+        working-directory: packages/react
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: release/@scania/tegel@${{ github.event.inputs.version }}
+          commit-message: Release of @scania/tegel@${{ github.event.inputs.version }}
+          branch: release/tegel@${{ github.event.inputs.version }}
+          delete-branch: true
+
+  on-failure:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove branch on failure
+        env:
+          npm_version: ${{ github.event.inputs.version }}
+        run: |
+          if [ "${{ job.status }}" == "failure" ]; then
+            git push origin --delete @scania/tegel@${{ github.event.inputs.version }}
+          fi

--- a/.github/workflows/release-angular.yml
+++ b/.github/workflows/release-angular.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       tegelVersion:
-        description: 'Tegel version'
+        description: 'Tegel version - this should represent the latest @scania-tegel version.'
         required: true
         type: string
 
@@ -46,23 +46,24 @@ jobs:
       - name: Set Tegel user
         run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
 
-      - name: Angular - CD into correct folder
-        run: cd packages/angular
-
       - name: Angular - Bump version
         run: npm version ${{ github.event.inputs.tegelVersion }}
+        working-directory: packages/angular
 
       - name: Angular - Remove package-lock
         run: rm -rf package-lock.json
+        working-directory: packages/angular
 
       - name: Angular - Install latest tegel package
         run: npm install @scania/tegel@${{ github.event.inputs.tegelVersion }}
+        working-directory: packages/angular
 
-      - name: Check out new branch
-        run: git checkout -b "release/${{ github.event.inputs.tegelVersion }}
+      - name: Core - Install Tegel
+        run: npm install
+        working-directory: packages/core
 
       - name: Angular - Run build
-        run: npm run build
+        run: npm run build-angular
 
       - name: Angular - Publish
         run: |
@@ -79,7 +80,7 @@ jobs:
         with:
           title: release/@scania/tegel-react@${{ github.event.inputs.tegelVersion }}
           commit-message: Release of @scania/tegel@${{ github.event.inputs.tegelVersion }}
-          branch: release/${{ github.event.inputs.tegelVersion }}
+          branch: release/tegel-react@${{ github.event.inputs.tegelVersion }}
           delete-branch: true
   on-failure:
     needs: release-angular

--- a/.github/workflows/release-angular.yml
+++ b/.github/workflows/release-angular.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: packages/angular
 
       - name: Angular - Install latest tegel package
-        run: npm install @scania/tegel@${{ steps.version.outputs }}
+        run: npm install @scania/tegel@${{ steps.version.outputs.version }}
         working-directory: packages/angular
 
       - name: Core - Install Tegel

--- a/.github/workflows/release-angular.yml
+++ b/.github/workflows/release-angular.yml
@@ -2,11 +2,6 @@ name: Release @scania/tegel-angular
 on:
   workflow_dispatch:
     inputs:
-      tegelVersion:
-        description: 'Tegel version - this should represent the latest @scania-tegel version.'
-        required: true
-        type: string
-
       nodeVersion:
         description: 'Node version'
         required: true
@@ -33,6 +28,13 @@ jobs:
   release-angular:
     runs-on: ubuntu-latest
     steps:
+
+      - name: Fail if branch is not main
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: |
+          echo "This workflow should not be triggered on a branch other than main"
+          exit 1
+      
       - name: Check out code
         uses: actions/checkout@v2
 
@@ -44,10 +46,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Set Tegel user
-        run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
+        run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"r
 
-      - name: Angular - Bump version
-        run: npm version ${{ github.event.inputs.tegelVersion }}
+      - name: Angular - Read package.json Version
+        id: version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
         working-directory: packages/angular
 
       - name: Angular - Remove package-lock
@@ -55,7 +58,7 @@ jobs:
         working-directory: packages/angular
 
       - name: Angular - Install latest tegel package
-        run: npm install @scania/tegel@${{ github.event.inputs.tegelVersion }}
+        run: npm install @scania/tegel@${{ steps.version.outputs }}
         working-directory: packages/angular
 
       - name: Core - Install Tegel
@@ -75,13 +78,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Angular - Create PR
-        uses: peter-evans/create-pull-request@v3
-        with:
-          title: release/@scania/tegel-react@${{ github.event.inputs.tegelVersion }}
-          commit-message: Release of @scania/tegel@${{ github.event.inputs.tegelVersion }}
-          branch: release/tegel-react@${{ github.event.inputs.tegelVersion }}
-          delete-branch: true
   on-failure:
     needs: release-angular
     runs-on: ubuntu-latest
@@ -89,8 +85,8 @@ jobs:
     steps:
       - name: Remove branch and git tag on failure
         env:
-          npm_version: ${{ github.event.inputs.tegelVersion }}
+          npm_version: ${{ needs.release-angular.outputs.version }}
         run: |
           if [ "${{ job.status }}" == "failure" ]; then
-            git push origin --delete @scania/tegel@${{ github.event.inputs.tegelVersion }}
+            git push origin --delete @scania/tegel@${{ needs.release-angular.outputs.version }}
           fi

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           title: release/@scania/tegel@${{ steps.version.outputs.version }}
           commit-message: Release of @scania/tegel@${{ steps.version.outputs.version }}
-          branch: release/${{ steps.version.outputs.version }}
+          branch: release/tegel@${{ steps.version.outputs.version }}
           delete-branch: true
   on-failure:
     needs: release-core

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -2,16 +2,6 @@ name: Release @scania/tegel
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Release type'
-        required: true
-        default: 'patch'
-        type: choice
-        options:
-          - major
-          - minor
-          - patch
-
       nodeVersion:
         description: 'Node version'
         required: true
@@ -38,6 +28,13 @@ jobs:
   release-core:
     runs-on: ubuntu-latest
     steps:
+
+      - name: Fail if branch is not main
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: |
+          echo "This workflow should not be triggered on a branch other than main"
+          exit 1
+
       - name: Check out code
         uses: actions/checkout@v2
 
@@ -51,27 +48,18 @@ jobs:
       - name: Set Tegel user
         run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
 
-      - name: Core - CD into correct folder
-        run: cd packages/core
-
-      - name: Core - Bump version
-        run: npm version ${{ github.event.inputs.version }}
-
       - name: Core - Read Package.json Version
         id: version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
-
-      - name: Core - Create git tag
-        run: git tag @scania/tegel@${{ steps.version.outputs.version }}
-
-      - name: Core - Push git tag
-        run: git push origin @scania/tegel@${{ steps.version.outputs.version }}
+        working-directory: packages/core
 
       - name: Core - npm install
         run: npm install
+        working-directory: packages/core
 
       - name: Core - Run build
         run: npm run build
+        working-directory: packages/core
 
       - name: Core - Publish
         run: |
@@ -80,16 +68,17 @@ jobs:
           else
             npm publish --tag ${{ github.event.inputs.tags }}
           fi
+        working-directory: packages/core
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Core - Create PR
-        uses: peter-evans/create-pull-request@v3
-        with:
-          title: release/@scania/tegel@${{ steps.version.outputs.version }}
-          commit-message: Release of @scania/tegel@${{ steps.version.outputs.version }}
-          branch: release/tegel@${{ steps.version.outputs.version }}
-          delete-branch: true
+      - name: Core - Create git tag
+        run: git tag @scania/tegel@${{ steps.version.outputs.version }}
+
+      - name: Core - Push git tag
+        run: git push origin @scania/tegel@${{ steps.version.outputs.version }}
+
+
   on-failure:
     needs: release-core
     runs-on: ubuntu-latest
@@ -97,11 +86,9 @@ jobs:
     steps:
       - name: Remove branch and git tag on failure
         env:
-          npm_version: ${{ needs.release.outputs.version }}
+          npm_version: ${{ needs.release-core.outputs.version }}
         run: |
           if [ "${{ job.status }}" == "failure" ]; then
             tagname="@scania/tegel@$npm_version"
             git push --delete origin $tagname
-            branchname="release/@scania/tegel@$npm_version"
-            git push origin --delete $branchname
           fi

--- a/.github/workflows/release-react.yml
+++ b/.github/workflows/release-react.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: packages/react
 
       - name: React - Install with latest tegel package
-        run: npm install @scania/tegel@${{ steps.version.outputs }}
+        run: npm install @scania/tegel@${{ steps.version.outputs.version }}
         working-directory: packages/react
 
       - name: Core - Install Tegel

--- a/.github/workflows/release-react.yml
+++ b/.github/workflows/release-react.yml
@@ -2,11 +2,6 @@ name: Release @scania/tegel-react
 on:
   workflow_dispatch:
     inputs:
-      tegelVersion:
-        description: 'Tegel version - this should represent the latest @scania-tegel version.'
-        required: true
-        type: string
-
       nodeVersion:
         description: 'Node version'
         required: true
@@ -33,6 +28,13 @@ jobs:
   release-react:
     runs-on: ubuntu-latest
     steps:
+
+      - name: Fail if branch is not main
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: |
+          echo "This workflow should not be triggered on a branch other than main"
+          exit 1
+
       - name: Check out code
         uses: actions/checkout@v2
 
@@ -46,8 +48,9 @@ jobs:
       - name: Set Tegel user
         run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
 
-      - name: React - Bump version
-        run: npm version ${{ github.event.inputs.tegelVersion }}
+      - name: React - Read package.json Version
+        id: version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
         working-directory: packages/react
 
       - name: React - Remove package-lock
@@ -55,7 +58,7 @@ jobs:
         working-directory: packages/react
 
       - name: React - Install with latest tegel package
-        run: npm install @scania/tegel@${{ github.event.inputs.tegelVersion }}
+        run: npm install @scania/tegel@${{ steps.version.outputs }}
         working-directory: packages/react
 
       - name: Core - Install Tegel
@@ -75,14 +78,6 @@ jobs:
         working-directory: packages/react
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: React - Create PR
-        uses: peter-evans/create-pull-request@v3
-        with:
-          title: release/@scania/tegel-react@${{ github.event.inputs.tegelVersion }}
-          commit-message: Release of @scania/tegel@${{ github.event.inputs.tegelVersion }}
-          branch: release/tegel-react@${{ github.event.inputs.tegelVersion }}
-          delete-branch: true
           
   on-failure:
     needs: release-react
@@ -91,8 +86,8 @@ jobs:
     steps:
       - name: Remove branch and git tag on failure
         env:
-          npm_version: ${{ github.event.inputs.tegelVersion }}
+          npm_version: ${{ needs.release-react.outputs.version }}
         run: |
           if [ "${{ job.status }}" == "failure" ]; then
-            git push origin --delete @scania/tegel@${{ github.event.inputs.tegelVersion }}
+            git push origin --delete @scania/tegel@${{ needs.release-react.outputs.version }}
           fi

--- a/.github/workflows/release-react.yml
+++ b/.github/workflows/release-react.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       tegelVersion:
-        description: 'Tegel version'
+        description: 'Tegel version - this should represent the latest @scania-tegel version.'
         required: true
         type: string
 
@@ -81,7 +81,7 @@ jobs:
         with:
           title: release/@scania/tegel-react@${{ github.event.inputs.tegelVersion }}
           commit-message: Release of @scania/tegel@${{ github.event.inputs.tegelVersion }}
-          branch: release/${{ github.event.inputs.tegelVersion }}
+          branch: release/tegel-react@${{ github.event.inputs.tegelVersion }}
           delete-branch: true
           
   on-failure:


### PR DESCRIPTION
This PR cleans up the github actions used for the releases of @scania/tegel, @scania/tegel-react and @scania/tegel-angular.

For @scania/tegel-react and @scania/tegel-angular, it adds a installation and build step for the core package. This is to be able to generate the wrappers based off of the core package. It also adds the package type (tegel, tegel-react, tegel-angular) to the PR branch it creates when a release is completed.

It also moves the NPM version bump into a seperate action that then creates a PR againt main. 

The release flow would look like this: 

1. Run the `Bump NPM version (core/angular/react)` action
2. Review and merge the PR it created into main
3. Review and merge the same branch into develop
4. Run: `Release @scania/tegel`, `Release @scania/tegel-react` and `Release @scania/tegel-angular`
5. Party 🥳

**Solving issue**  
Fixes: -

