### PR TITLE
fix(button): correct font-size for icon button

### DIFF
--- a/packages/core/src/components/button/button.scss
+++ b/packages/core/src/components/button/button.scss
@@ -135,8 +135,6 @@ button {
           fill: var(--tds-btn-icon-#{$type}-#{$prop});
           color: var(--tds-btn-icon-#{$type}-#{$prop});
         }
-
-        font-size: 16px; //16px
       }
 
       &:hover {


### PR DESCRIPTION
Corrected the font-size for button text when using icon slot.

**Solving issue**  
Fixes: [CDEP-2900](https://tegel.atlassian.net/browse/CDEP-2900)

**How to test**  
1. Go to Button
2. Add a Icon to the Button
3. Check the font-size of the button text.



[CDEP-2900]: https://tegel.atlassian.net/browse/CDEP-2900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ