### PR TITLE
fix: stepper hideLabels in runtime

### DIFF
--- a/packages/core/src/components/stepper/step/step.tsx
+++ b/packages/core/src/components/stepper/step/step.tsx
@@ -1,6 +1,13 @@
 import { Component, Host, h, Prop, Element, State, Listen } from '@stencil/core';
 import { InternalTdsStepperPropChange } from '../stepper';
 
+const propToStateMap = {
+  orientation: 'orientation',
+  labelPosition: 'labelPosition',
+  size: 'size',
+  hideLabels: 'hideLabels',
+};
+
 /**
  * @slot label - Slot for the label text.
  */
@@ -16,7 +23,7 @@ export class TdsStep {
   /** State of the Step */
   @Prop() state: 'current' | 'error' | 'success' | 'upcoming' = 'upcoming';
 
-  @State() hideLabel: boolean;
+  @State() hideLabels: boolean;
 
   @State() size: 'sm' | 'lg';
 
@@ -36,7 +43,7 @@ export class TdsStep {
     this.orientation = this.stepperEl.orientation;
     this.labelPosition = this.stepperEl.labelPosition;
     this.size = this.stepperEl.size;
-    this.hideLabel = this.stepperEl.hideLabels;
+    this.hideLabels = this.stepperEl.hideLabels;
     this.stepperId = this.stepperEl.stepperId;
   }
 
@@ -45,12 +52,10 @@ export class TdsStep {
     if (this.stepperId === event.detail.stepperId) {
       event.detail.changed.forEach((changedProp) => {
         if (typeof this[changedProp] === 'undefined') {
-          throw new Error(`Table prop is not supported: ${changedProp}`);
+          throw new Error(`Stepper prop is not supported: ${changedProp}`);
+        } else if (changedProp in propToStateMap) {
+          this[propToStateMap[changedProp]] = event.detail[changedProp];
         }
-        if (this[changedProp] === this.orientation && event.detail[changedProp] === 'vertical') {
-          this.labelPosition = 'aside';
-        }
-        this[changedProp] = event.detail[changedProp];
       });
     }
   }
@@ -61,7 +66,7 @@ export class TdsStep {
         <div
           role="listitem"
           class={`${this.size} ${this.orientation} text-${this.labelPosition} ${
-            this.hideLabel ? 'hide-labels' : ''
+            this.hideLabels ? 'hide-labels' : ''
           }`}
         >
           <div class={`${this.state} content-container`}>
@@ -74,7 +79,7 @@ export class TdsStep {
               this.index
             )}
           </div>
-          {!this.hideLabel && (
+          {!this.hideLabels && (
             <div class={`label ${this.size} ${this.state}`}>
               <slot name="label"></slot>
             </div>

--- a/packages/core/src/components/stepper/stepper.stories.tsx
+++ b/packages/core/src/components/stepper/stepper.stories.tsx
@@ -98,15 +98,6 @@ const Template = ({ size, orientation, labelPosition, hideLabels }) =>
       <div slot="label">Upcoming step</div>
     </tds-step>
   </tds-stepper>
-  <button id="tester">Hide labels i runtime</button>
-
-  <script>
-    stepper = document.querySelector('tds-stepper')
-    button = document.querySelector('#tester')
-    button.addEventListener('click', () => {
-      stepper.hideLabels = !stepper.hideLabels
-    })
-  </script>
         `,
   );
 export const Default = Template.bind({});

--- a/packages/core/src/components/stepper/stepper.stories.tsx
+++ b/packages/core/src/components/stepper/stepper.stories.tsx
@@ -98,6 +98,15 @@ const Template = ({ size, orientation, labelPosition, hideLabels }) =>
       <div slot="label">Upcoming step</div>
     </tds-step>
   </tds-stepper>
+  <button id="tester">Hide labels i runtime</button>
+
+  <script>
+    stepper = document.querySelector('tds-stepper')
+    button = document.querySelector('#tester')
+    button.addEventListener('click', () => {
+      stepper.hideLabels = !stepper.hideLabels
+    })
+  </script>
         `,
   );
 export const Default = Template.bind({});


### PR DESCRIPTION
**Describe pull-request**  
There was a mismatch in the prop name ('hideLabels') in the `tds-stepper` and the state name ('hideLabel') in the tds-step. This was causing an error where the hidden state of the labels could not update in runtime.

This PR fixes this issue by keeping the naming of the prop/state consistent.


**Solving issue**  
Fixes: -

**How to test**  
1. Go to Stepper
2. Click the testing button to update the prop in runtime.
3. Make sure the labels shows/hides.
