### PR TITLE
fix(dropdown): error focus state style alignment

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-button.scss
+++ b/packages/core/src/components/dropdown/dropdown-button.scss
@@ -49,6 +49,20 @@
 
     &.error {
       border-bottom: 1px solid var(--tds-negative);
+
+      &:focus {
+        border-bottom-color: transparent;
+
+        &::before {
+          content: '';
+          position: absolute;
+          bottom: 0;
+          left: 0;
+          width: 100%;
+          height: 2px;
+          background: var(--tds-negative);
+        }
+      }
     }
 
     &:disabled {

--- a/packages/core/src/components/dropdown/dropdown-filter.scss
+++ b/packages/core/src/components/dropdown/dropdown-filter.scss
@@ -81,6 +81,24 @@
       }
     }
 
+    &.error {
+      border-bottom: 1px solid var(--tds-negative);
+
+      &.focus {
+        border-bottom-color: transparent;
+
+        &::before {
+          content: '';
+          position: absolute;
+          bottom: 0;
+          left: 0;
+          width: 100%;
+          height: 2px;
+          background: var(--tds-negative);
+        }
+      }
+    }
+
     input {
       flex: 1;
       all: unset;

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -487,6 +487,9 @@ export class TdsDropdown {
               <tds-icon
                 onClick={() => {
                   this.open = !this.open;
+                  if (this.open) {
+                    this.inputElement.focus();
+                  }
                 }}
                 class={`${this.open ? 'open' : 'closed'}`}
                 name="chevron_down"

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -437,8 +437,12 @@ export class TdsDropdown {
         <div class={`dropdown-select ${this.size} ${this.disabled ? 'disabled' : ''}`}>
           {this.filter ? (
             <div
-              class={`filter ${this.filterFocus ? 'focus' : ''}
-            ${this.disabled ? 'disabled' : ''}`}
+              class={{
+                filter: true,
+                focus: this.filterFocus,
+                disabled: this.disabled,
+                error: this.error,
+              }}
             >
               <div class="value-wrapper">
                 {this.label && this.labelPosition === 'inside' && this.placeholder && (


### PR DESCRIPTION
This PR fixes the issue of the error state not being correct whenever a Dropdown was focused/opened. 

It also makes sure that the filter input is focus whenever the icon in the dropdown is clicked. 

Before: 
<img width="359" alt="Screenshot 2023-10-30 at 12 02 03" src="https://github.com/scania-digital-design-system/tegel/assets/62651103/419c4d5f-0005-49c7-8b0b-22596d712b00">

After:
<img width="428" alt="Screenshot 2023-10-30 at 12 01 49" src="https://github.com/scania-digital-design-system/tegel/assets/62651103/482478a1-7839-4456-97a6-986b37e675da">

**Solving issue**  
Fixes: -

**How to test**  
1. Go to Dropdown
2. Set error to true
3. Open the Dropdown
4. Make sure the error state aligns with design

