### PR TITLE
docs(readme): amplify links updates

### DIFF
--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -10,7 +10,7 @@ This guide [here](https://stenciljs.com/docs/angular) has served as base for the
 
 Official website: https://tegel.scania.com/
 
-Storybook: https://tegel-storybook.netlify.app/
+Storybook: https://tds-storybook.tegel.scania.com/
 
 The design system supports the design and development of digital solutions at Scania. The purpose is to secure a coherent, premium brand and user experience across all of Scania's digital touchpoints.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -10,13 +10,14 @@
 
 Official website: https://tegel.scania.com/
 
-Storybook: https://tegel-storybook.netlify.app/
+Storybook: https://tds-storybook.tegel.scania.com/
 
 The design system supports the design and development of digital solutions at Scania. The purpose is to secure a coherent, premium brand and user experience across all of Scania's digital touchpoints.
 
 ## Status
 
-This package is currently in a **beta** stage. We are now working hard towards a 1.0 release, but if you want to try out the package today you can!
+This package is currently considered a **beta**. 
+Version 1.0.0 and later are released, and we see no braking changes coming in near future. 
 
 ## Installation
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -10,7 +10,7 @@ This guide [here](https://stenciljs.com/docs/react) has served as base for the c
 
 Official website: https://tegel.scania.com/
 
-Storybook: https://tegel-storybook.netlify.app/
+Storybook: https://tds-storybook.tegel.scania.com/
 
 The design system supports the design and development of digital solutions at Scania. The purpose is to secure a coherent, premium brand and user experience across all of Scania's digital touchpoints.
 


### PR DESCRIPTION
**Describe pull-request**  
Updating link to reflect Amplify links

**Solving issue**  
Fixes: [CDEP-2893](https://tegel.atlassian.net/browse/CDEP-2893)

**How to test**  
1. Check changes in this PR
2. Readme files should have updated links that are pointing to tds-storybook hosted under tegel.scania.com domain and not under netlify.



[CDEP-2893]: https://tegel.atlassian.net/browse/CDEP-2893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ