### PR TITLE
build: removed dotenv dependency

### DIFF
--- a/packages/core/.storybook/main.cjs
+++ b/packages/core/.storybook/main.cjs
@@ -1,5 +1,3 @@
-require('dotenv').config();
-
 let addons = [
   '@storybook/addon-links',
   '@storybook/addon-essentials',
@@ -7,10 +5,6 @@ let addons = [
   '@storybook/addon-notes/register',
   'storybook-version',
 ];
-
-if (process.env.STORYBOOK_ENV === 'development') {
-  addons = [...addons, 'storybook-addon-designs', '@storybook/addon-a11y', 'addon-screen-reader'];
-}
 
 module.exports = {
   addons: addons,

--- a/packages/core/.storybook/main.cjs
+++ b/packages/core/.storybook/main.cjs
@@ -6,6 +6,10 @@ let addons = [
   'storybook-version',
 ];
 
+if (process.env.STORYBOOK_ENV === 'development') {
+  addons = [...addons, 'storybook-addon-designs', '@storybook/addon-a11y', 'addon-screen-reader'];
+}
+
 module.exports = {
   addons: addons,
   features: {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@stencil/core": "^4.7.1",
-        "dotenv": "^16.0.3",
         "prettier": "^2.7.1"
       },
       "devDependencies": {
@@ -11323,17 +11322,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
-    },
-    "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
-      }
     },
     "node_modules/dotenv-expand": {
       "version": "5.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "@popperjs/core": "^2.11.8",
     "@stencil/core": "^4.7.1",
-    "dotenv": "^16.0.3",
     "prettier": "^2.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
It is no longer needed as of node 20. We are also not really using it today, so I removed our only implementation of it in the storybook main.js. 

Our only use for it was to hide/show certain addons in production. I do not think we are really using these in development today, so I would suggest we remove them all together. 

**Solving issue**  
Fixes: https://github.com/scania-digital-design-system/tegel/issues/407

**How to test**  
1. Check out branch
2. Run `npm i` in core
3. Start storybook
4. Make sure everything runs as before.

