### PR TITLE
build(stencil): upgrade to 4.7.1

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
-        "@stencil/core": "^4.4.0",
+        "@stencil/core": "^4.7.1",
         "dotenv": "^16.0.3",
         "prettier": "^2.7.1"
       },
@@ -4228,9 +4228,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.4.0.tgz",
-      "integrity": "sha512-YlLyCqGBsMEuZb3XTO/STT0TX9eSwjoVhCJgtjVfQOF+ebIMVlojTh40CmDveWiWbth687cbr6S2heeussV8Sg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.7.1.tgz",
+      "integrity": "sha512-KDWA/3qDiABA5LqtHCmTVwORuzgu/YdC0FpSBwVmwlw6K8jUjbTA5JB6Q03da2F+EQlDHOVgbW0TNtHCm54uXQ==",
       "bin": {
         "stencil": "bin/stencil"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
-    "@stencil/core": "^4.4.0",
+    "@stencil/core": "^4.7.1",
     "dotenv": "^16.0.3",
     "prettier": "^2.7.1"
   },


### PR DESCRIPTION
**Describe pull-request**  
Upgrading Stencil to version 4.7.1

**Solving issue**  
Fixes: [CDEP-2305](https://tegel.atlassian.net/browse/CDEP-2305)

**How to test**  
1. Check if you can run your local environment using this branch
2. Check if the Storybook starts as usual



[CDEP-2305]: https://tegel.atlassian.net/browse/CDEP-2305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ