### PR TITLE
fix(modal): button variant and spacing correction

### DIFF
--- a/packages/core/src/components/modal/modal.stories.tsx
+++ b/packages/core/src/components/modal/modal.stories.tsx
@@ -109,9 +109,9 @@ const ModalTemplate = ({ actionsPosition, size, headerText, bodyContent, showMod
       <span slot="body">
           ${bodyContent}
       </span>      
-      <span slot='actions'>
-        <tds-button data-dismiss-modal size="md" text="Delete" type="danger"></tds-button>
-        <tds-button data-dismiss-modal size="md" text="Cancel"></tds-button>
+      <span slot='actions' class='tds-u-flex tds-u-gap2'>
+        <tds-button data-dismiss-modal size="md" text="Delete" variant="danger"></tds-button>
+        <tds-button data-dismiss-modal size="md" text="Cancel" variant="secondary"></tds-button>
       </span>      
   </tds-modal>
   


### PR DESCRIPTION
**Describe pull-request**  
The modal example in Storybook had old prop for button variation, it was using type.

**Solving issue**  
No ticket, the issue was found in support work.

**How to test**  
1. Go to the Modal component on link below.
2. Check that Modal component has two buttons: "Delete" with variant="danger" and "Cancel" with variant="secondary"
3. Check that between buttons there is spacing
4. Compare with[ prod version](https://tds-storybook.tegel.scania.com/?path=/story/components-modal--default&globals=backgrounds.value:!hex(F9FAFB)) to see changes.


