### PR TITLE
fix(popover-core): show prop read on an initial load

### DIFF
--- a/packages/core/src/components/popover-core/popover-core.tsx
+++ b/packages/core/src/components/popover-core/popover-core.tsx
@@ -86,6 +86,12 @@ export class TdsPopoverCore {
     }
   }
 
+  /* To enable initial loading of a component if user controls show prop*/
+  componentWillLoad() {
+    this.setIsShown(this.show);
+  }
+
+  /* To observe any change of show prop after an initial load */
   @Watch('show')
   onShowChange(newValue: boolean) {
     this.setIsShown(newValue);


### PR DESCRIPTION
**Describe pull-request**  
Fixing the issue from the support channel related to the initial show of Popover-canvas component.
The issue was in fact that once the user sets a value on the `show` prop, the component is fully controlled by the user, aka setting true/false to the component making the component visible/hidden. This was not working on the initial load as we did not have a lifecycle to check what is the status of the `show` prop, but we only had a `@Watcher` decorator who monitors the prop after component has been rendered, but not in the initial load. The solution was to add `componentWillLoad` lifecycle.

**Solving issue**  
Fixes: [CDEP-3000](https://tegel.atlassian.net/browse/CDEP-3000)
Support issue [here](https://teams.microsoft.com/l/message/19:5e33f67fe502441f914fbcdc6e2548f5@thread.skype/1699980068919?tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac&groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&parentMessageId=1699980068919&teamName=Tegel%20Design%20System&channelName=Development%20support&createdTime=1699980068919).

**How to test**  
1. Branch this one on your local
2. Try to set show prop to true in Popover Canvas or Popover Menu
3. The component should show on the initial load and the only way to close it is to set the show prop to false or remove it from the component.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

Note:
Fix is applied in popover-core as that one is shared among 2-3 other components. 

[CDEP-3000]: https://tegel.atlassian.net/browse/CDEP-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ