### PR TITLE
fix(chip): double click for radio type

### DIFF
--- a/packages/core/src/components/chip/chip.tsx
+++ b/packages/core/src/components/chip/chip.tsx
@@ -62,7 +62,7 @@ export class TdsChip {
       // Always set it to true to enforce visual update for selected state
       this.checked = true;
     } else {
-      console.warn('Unsupported type in Chip component!');
+      console.error('Unsupported type in Chip component!');
     }
 
     this.tdsChange.emit({

--- a/packages/core/src/components/chip/chip.tsx
+++ b/packages/core/src/components/chip/chip.tsx
@@ -30,7 +30,7 @@ export class TdsChip {
   @Prop() chipId: string = generateUniqueId();
 
   /** Controls component's checked attribute. Valid only for type checkbox and radio. */
-  @Prop({ reflect: true }) checked: boolean = false;
+  @Prop({ reflect: true, mutable: true }) checked: boolean = false;
 
   /** Name for the checkbox or radio input element. Also creates a reference between label and input. Valid only for type checkbox and radio. */
   @Prop() name: string;

--- a/packages/core/src/components/chip/chip.tsx
+++ b/packages/core/src/components/chip/chip.tsx
@@ -55,7 +55,16 @@ export class TdsChip {
   }>;
 
   private handleChange = () => {
-    this.checked = !this.checked;
+    if (this.type === 'checkbox') {
+      // Toggle the prop on click
+      this.checked = !this.checked;
+    } else if (this.type === 'radio') {
+      // Always set it to true to enforce visual update for selected state
+      this.checked = true;
+    } else {
+      console.warn('Unsupported type in Chip component!');
+    }
+
     this.tdsChange.emit({
       chipId: this.chipId,
       checked: this.checked,


### PR DESCRIPTION
**Describe pull-request**  
Setting chip to active when type radio should not require to double click. 

**Solving issue**  
Fixes: [CDEP-2995](https://tegel.atlassian.net/browse/CDEP-2995)

**How to test**  
_Add description how to test if possible_
1. Go to Storybook
2. Check in Chip component, and change to type radio, setting to active should not require double click

[CDEP-2995]: https://tegel.atlassian.net/browse/CDEP-2995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ