### PR TITLE
fix(side-menu): collapsed state on mobile view

### DIFF
--- a/packages/core/src/components/side-menu/side-menu.tsx
+++ b/packages/core/src/components/side-menu/side-menu.tsx
@@ -48,7 +48,7 @@ export class TdsSideMenu {
   @Prop() persistent: boolean = false;
 
   /** If the Side Menu is collapsed. Only a persistent desktop menu can be collapsed.
-   * NOTE: Only use this if you have prevented the automatic collapsing with preventDefault on the tds-Collapse event. */
+   * NOTE: Only use this if you have prevented the automatic collapsing with preventDefault on the tdsCollapse event. */
   @Prop({ mutable: true }) collapsed: boolean = false;
 
   @State() isUpperSlotEmpty: boolean = false;

--- a/packages/core/src/components/side-menu/side-menu.tsx
+++ b/packages/core/src/components/side-menu/side-menu.tsx
@@ -23,7 +23,7 @@ export type InternalTdsSideMenuPropChange = {
   changed: Array<keyof Props>;
 } & Partial<Props>;
 
-const GRID_LG_BREAKPOINT = '992px';
+const GRID_LG_BREAKPOINT: number = 992;
 /**
  * @slot overlay - Used of injection of tds-side-menu-overlay
  * @slot close-button - Used for injection of tds-side-menu-close-button that is show when in mobile view
@@ -49,11 +49,14 @@ export class TdsSideMenu {
 
   /** If the Side Menu is collapsed. Only a persistent desktop menu can be collapsed.
    * NOTE: Only use this if you have prevented the automatic collapsing with preventDefault on the tds-Collapse event. */
-  @Prop() collapsed: boolean = false;
+  @Prop({ mutable: true }) collapsed: boolean = false;
 
   @State() isUpperSlotEmpty: boolean = false;
 
   @State() isCollapsed: boolean = false;
+
+  /* To preserved initial state of collapsed prop as it is changed in runtime */
+  @State() initialCollapsedState: boolean = false;
 
   private matchesLgBreakpointMq: MediaQueryList;
 
@@ -61,13 +64,16 @@ export class TdsSideMenu {
     const isBelowLg = !e.matches;
     if (isBelowLg) {
       this.collapsed = false;
+    } else {
+      this.collapsed = this.initialCollapsedState;
     }
   };
 
   connectedCallback() {
-    this.matchesLgBreakpointMq = window.matchMedia(`(min-width: ${GRID_LG_BREAKPOINT})`);
+    this.matchesLgBreakpointMq = window.matchMedia(`(min-width: ${GRID_LG_BREAKPOINT}px)`);
     this.matchesLgBreakpointMq.addEventListener('change', this.handleMatchesLgBreakpointChange);
     this.isCollapsed = this.collapsed;
+    this.initialCollapsedState = this.collapsed;
   }
 
   componentDidLoad() {
@@ -77,6 +83,9 @@ export class TdsSideMenu {
 
     if (!hasUpperSlotElements) {
       this.isUpperSlotEmpty = true;
+    }
+    if (window.innerWidth < GRID_LG_BREAKPOINT) {
+      this.collapsed = false;
     }
   }
 


### PR DESCRIPTION
**Describe pull-request**  
1. When collapsed state is set initially by user, menu needs to stay collapsed when you switch to mobile view and back to desktop. Until now, logic was resetting it so menu appers in full size even prop collapsed states differently.
2. When loading the page on mobile size when prop collapsed set to true, mobile menu appears off. That is due to the fact that the function to check screen size runs only once user resizes the screen around 992px. On inital load we need to understand width of screen in order to display mobile menu correctly.

Both issues are able to reproduce in main version of Storybook. 

**Solving issue**  
Fixes: [CDEP-3080](https://tegel.atlassian.net/browse/CDEP-3080)

**How to test**  
Issue 1:
1. Set controls Collapsible prop to true and Collapsed to true on Desktop size.
2. Slowly go to mobile view.
3. Check that mobile menu looks OK.
4. Go back to the Desktop view.
5. Menu still needs to be in "collapsed" state.

Issue 2:
1. Set controls Collapsible prop to true and Collapsed to true on mobile size.
2. Refresh page
3. Try to open mobile menu.
4. Mobile menu should look OK.


**Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events




[CDEP-3080]: https://tegel.atlassian.net/browse/CDEP-3080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ