### PR TITLE
feat(footer): copyright slot

### DIFF
--- a/packages/core/src/components/footer/footer.tsx
+++ b/packages/core/src/components/footer/footer.tsx
@@ -18,7 +18,7 @@ export class TdsFooter {
   /** Mode variant of the component, based on current mode. */
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
-  const copyrightText = 'Copyright © ' + new Date().getFullYear() + ' Scania';
+  const copyrightText = `Copyright © ${new Date().getFullYear()} Scania`;
 
   render() {
     const usesTopSlot = hasSlot('top', this.host);

--- a/packages/core/src/components/footer/footer.tsx
+++ b/packages/core/src/components/footer/footer.tsx
@@ -18,7 +18,7 @@ export class TdsFooter {
   /** Mode variant of the component, based on current mode. */
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
-  copyrightText = 'Copyright © ' + new Date().getFullYear() + ' Scania';
+  const copyrightText = 'Copyright © ' + new Date().getFullYear() + ' Scania';
 
   render() {
     const usesTopSlot = hasSlot('top', this.host);

--- a/packages/core/src/components/footer/footer.tsx
+++ b/packages/core/src/components/footer/footer.tsx
@@ -4,7 +4,7 @@ import hasSlot from '../../utils/hasSlot';
 /**
  * @slot top - Slot for the top part of the Footer.
  * @slot start - Slot for start (left side) of the Footers main part.
- * @slot end - Slot for an end (right side) of the Footers main part.
+ * @slot end - Slot for the end (right side) of the Footers main part.
  * @slot copyright - Slot for copyright area (bottom left) of the Footer.
  */
 @Component({

--- a/packages/core/src/components/footer/footer.tsx
+++ b/packages/core/src/components/footer/footer.tsx
@@ -4,7 +4,8 @@ import hasSlot from '../../utils/hasSlot';
 /**
  * @slot top - Slot for the top part of the Footer.
  * @slot start - Slot for start (left side) of the Footers main part.
- * @slot end - Slot for end (right side) of the Footers main part.
+ * @slot end - Slot for an end (right side) of the Footers main part.
+ * @slot copyright - Slot for copyright area (bottom left) of the Footer.
  */
 @Component({
   tag: 'tds-footer',
@@ -17,10 +18,13 @@ export class TdsFooter {
   /** Mode variant of the component, based on current mode. */
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
+  copyrightText = 'Copyright © ' + new Date().getFullYear() + ' Scania';
+
   render() {
     const usesTopSlot = hasSlot('top', this.host);
     const usesStartSlot = hasSlot('start', this.host);
     const usesEndSlot = hasSlot('end', this.host);
+    const usesCopyrightSlot = hasSlot('copyright', this.host);
     return (
       <Host class={`${this.modeVariant ? `tds-mode-variant-${this.modeVariant}` : ''}`}>
         <footer>
@@ -31,7 +35,9 @@ export class TdsFooter {
               {usesEndSlot && <slot name="end"></slot>}
             </div>
             <div class="footer-main-bottom">
-              <small class="copyright">Copyright &#169; {new Date().getFullYear()} Scania</small>
+              <small class="copyright">
+                {usesCopyrightSlot ? <slot name="copyright"></slot> : this.copyrightText}
+              </small>
               <div class="brand">
                 <p>Scania</p>
               </div>

--- a/packages/core/src/components/footer/readme.md
+++ b/packages/core/src/components/footer/readme.md
@@ -14,11 +14,12 @@
 
 ## Slots
 
-| Slot      | Description                                          |
-| --------- | ---------------------------------------------------- |
-| `"end"`   | Slot for end (right side) of the Footers main part.  |
-| `"start"` | Slot for start (left side) of the Footers main part. |
-| `"top"`   | Slot for the top part of the Footer.                 |
+| Slot          | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| `"copyright"` | Slot for copyright area (bottom left) of the Footer.   |
+| `"end"`       | Slot for an end (right side) of the Footers main part. |
+| `"start"`     | Slot for start (left side) of the Footers main part.   |
+| `"top"`       | Slot for the top part of the Footer.                   |
 
 
 ----------------------------------------------


### PR DESCRIPTION
**Describe pull-request**  
Slot is enabling customization of copyright text. This is mainly done for projects in China as they need to translate it to mandarin. Reason for using slot over the prop is due to posible special signs/characters that may be used.  

**Solving issue**  
Fixes: [CDEP-3053](https://tegel.atlassian.net/browse/CDEP-3053)

**How to test**  
1. Branch out
2. Change story file so you inject slot at the bottom with custom text.
3. Default copyright text should be relaced with custom one
4. Delete slot
5. Check if original test appers again.


**Additional context**  
I was thinking to use name "bottom" as opposite to "top" slot, but as this one changes only copyright on the bottom left I tought this was good. 


[CDEP-3053]: https://tegel.atlassian.net/browse/CDEP-3053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ