### PR TITLE
fix(modal): medium screen and xs size

### DIFF
--- a/packages/core/src/components/modal/modal.scss
+++ b/packages/core/src/components/modal/modal.scss
@@ -20,7 +20,7 @@ $modals: (
     lg: 100%,
   ),
   $screen-md: (
-    xs: 75%,
+    xs: 50%,
     sm: 62.5%,
     md: 75%,
     lg: 100%,


### PR DESCRIPTION
**Describe pull-request**  
Fixing value for the extra small size of modal on medium screen size.

**Solving issue**  
Fixes: [CDEP-3095](https://tegel.atlassian.net/browse/CDEP-3095)

**How to test**  
1. Check if the new value extra small size of the modal on medium screen is 50%.





[CDEP-3095]: https://tegel.atlassian.net/browse/CDEP-3095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ