### PR TITLE
build: test files and stories removed from shipping

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -12,5 +12,6 @@
     "jsx": "react",
     "jsxFactory": "h"
   },
-  "include": ["src/**/*"]
+  "exclude": ["src/components/**/test/*", "**/**.stories.*", "src/stories/**"],
+  "include": ["src/**/*"],
 }


### PR DESCRIPTION
**Describe pull-request**  
Removing test and story files from shipping in npm package as users do not need them, plus it reduces the size of the package.

**How to test**  
1. Open branch on local
2. Delete "dist" folder under packages/core
3. Run build command
4. Run npm pack
5. Check the size of package, it should be 3.6MB
6. Check "dist" folder and see if you can see any of test or story files in.
7. Do the same but on develop branch, size should be 4.1MB


