### PR TITLE
feat(text-field): adding number type and min-max attributes

### DIFF
--- a/packages/core/src/components/text-field/readme.md
+++ b/packages/core/src/components/text-field/readme.md
@@ -14,7 +14,9 @@
 | `helper`        | `helper`         | Helper text                                 | `string`                              | `undefined`  |
 | `label`         | `label`          | Label text                                  | `string`                              | `''`         |
 | `labelPosition` | `label-position` | Position of the label for the Text Field.   | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
+| `max`           | `max`            | Max allowed value for input type number     | `number \| string`                    | `undefined`  |
 | `maxLength`     | `max-length`     | Max length of input                         | `number`                              | `undefined`  |
+| `min`           | `min`            | Min allowed value for input type number     | `number \| string`                    | `undefined`  |
 | `modeVariant`   | `mode-variant`   | Mode variant of the Text Field              | `"primary" \| "secondary"`            | `null`       |
 | `name`          | `name`           | Name property                               | `string`                              | `''`         |
 | `noMinWidth`    | `no-min-width`   | Unset minimum width of 208px.               | `boolean`                             | `false`      |
@@ -22,7 +24,7 @@
 | `readOnly`      | `read-only`      | Set input in readonly state                 | `boolean`                             | `false`      |
 | `size`          | `size`           | Size of the input                           | `"lg" \| "md" \| "sm"`                | `'lg'`       |
 | `state`         | `state`          | Error state of input                        | `"default" \| "error" \| "success"`   | `'default'`  |
-| `type`          | `type`           | Which input type, text, password or similar | `"password" \| "text"`                | `'text'`     |
+| `type`          | `type`           | Which input type, text, password or similar | `"number" \| "password" \| "text"`    | `'text'`     |
 | `value`         | `value`          | Value of the input text                     | `string`                              | `''`         |
 
 

--- a/packages/core/src/components/text-field/text-field.stories.tsx
+++ b/packages/core/src/components/text-field/text-field.stories.tsx
@@ -50,9 +50,31 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Text', 'Password'],
+      options: ['Text', 'Password', 'Number'],
       table: {
         defaultValue: { summary: 'text' },
+      },
+    },
+    min: {
+      name: 'Min',
+      description: 'Minumum acceptable value when input type is number',
+      control: {
+        type: 'number',
+      },
+      if: {
+        arg: 'type',
+        eq: 'Number',
+      },
+    },
+    max: {
+      name: 'Max',
+      description: 'Maximum acceptable value when input type is number',
+      control: {
+        type: 'number',
+      },
+      if: {
+        arg: 'type',
+        eq: 'Number', 
       },
     },
     size: {
@@ -181,6 +203,8 @@ export default {
     prefixType: 'Icon',
     suffix: false,
     suffixType: 'Icon',
+    min: "0",
+    max: "10",
     maxLength: 0,
     noMinWidth: 'Default',
     readonly: false,
@@ -192,6 +216,8 @@ const Template = ({
   modeVariant,
   state,
   type,
+  min,
+  max,
   size,
   label,
   labelPosition,
@@ -207,6 +233,8 @@ const Template = ({
   disabled,
 }) => {
   const maxlength = maxLength > 0 ? `max-length="${maxLength}"` : '';
+  min = min  ? `min="${min}"` : '';
+  max = max  ? `max="${max}"` : '';
   const stateValue = state.toLowerCase();
   const sizeLookUp = {
     Large: 'lg',
@@ -233,6 +261,8 @@ const Template = ({
       label-position="${labelPosition.toLowerCase()}"
       ${helper ? `helper="${helper}"` : ''}
       ${maxlength}
+      ${min}
+      ${max}
       ${disabled ? 'disabled' : ''}
       ${readonly ? 'read-only' : ''}
       ${noMinWidth ? 'no-min-width' : ''}

--- a/packages/core/src/components/text-field/text-field.stories.tsx
+++ b/packages/core/src/components/text-field/text-field.stories.tsx
@@ -57,7 +57,7 @@ export default {
     },
     min: {
       name: 'Min',
-      description: 'Minumum acceptable value when input type is number',
+      description: 'Minimum acceptable value when input type is number',
       control: {
         type: 'number',
       },

--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -18,13 +18,19 @@ export class TdsTextField {
   textInput?: HTMLInputElement;
 
   /** Which input type, text, password or similar */
-  @Prop({ reflect: true }) type: 'text' | 'password' = 'text';
+  @Prop({ reflect: true }) type: 'text' | 'password' | 'number' = 'text';
 
   /** Position of the label for the Text Field. */
   @Prop() labelPosition: 'inside' | 'outside' | 'no-label' = 'no-label';
 
   /** Label text */
   @Prop() label: string = '';
+
+   /** Min allowed value for input type number */
+  @Prop() min: string | number;
+
+   /** Max allowed value for input type number */
+  @Prop() max: string | number;
 
   /** Helper text */
   @Prop() helper: string;
@@ -174,6 +180,8 @@ export class TdsTextField {
               autofocus={this.autofocus}
               maxlength={this.maxLength}
               name={this.name}
+              min={this.min}
+              max={this.max}
               onInput={(event) => this.handleInput(event)}
               onChange={(event) => this.handleChange(event)}
               onFocus={(event) => {


### PR DESCRIPTION
**Describe pull-request**  

Currently from our application can pass type=number attribute to tegel-text field, but we cant define min, max attributes from our-side. That effects how user can interact with increase/decrease buttons inside the input field.

**Solving issue**  
Adding support for  customisable min, max values for the input type number.

**How to test**  
_Add description how to test if possible_
1. Go to text-field storybook
2. select input type number
3. define min,max values,
4. interact with increment/decrement buttons

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  
_If applicable, add screenshots to help explain_
![Screenshot 2024-01-30 at 14 14 20](https://github.com/scania-digital-design-system/tegel/assets/5589187/81440443-8c3b-46f9-8463-35834750bce7)
![Screenshot 2024-01-30 at 14 14 03](https://github.com/scania-digital-design-system/tegel/assets/5589187/3efcdde6-b652-4081-b5b0-4123ae6a8eb6)

**Additional context**  
_Add any other context about the pull-request here._
