### PR TITLE
build(stencil): 4.12.0

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
-        "@stencil/core": "^4.9.0",
+        "@stencil/core": "^4.12.0",
         "prettier": "^2.7.1"
       },
       "devDependencies": {
@@ -4227,9 +4227,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.9.0.tgz",
-      "integrity": "sha512-aWSkhBmk3yPwRAkUwBbzRwmdhb8hKiQ/JMr9m5jthpBZLjtppYbzz6PN2MhSMDfRp6K93eQw5WogSEH4HHuB6w==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.12.0.tgz",
+      "integrity": "sha512-qAQcfNmp2sdxAh1DlyUhHfDmIUS7mhI+5LAhPphg74zK9sKgFL5vpLzgjs0wohpjlmI4msgJFYiRB8lxVPqjPg==",
       "bin": {
         "stencil": "bin/stencil"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
-    "@stencil/core": "^4.9.0",
+    "@stencil/core": "^4.12.0",
     "prettier": "^2.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
**Describe pull-request**  
Adding a newer version of Stencil core.
More about it [here](https://github.com/ionic-team/stencil/releases).

**How to test**  
1. Checkout branch
2. Navigate to packages/core
3. Run npm i
4. Check if the library builds and starts without issues

**Additional context**  
The issue with Stencil watcher not triggered when change is done in nested CSS files seems to be fixed in version 4.11. Nice for us as we have a lot of nested CSS files. 
