### PR TITLE
feat: number input

### DIFF
--- a/packages/core/src/components/icon/readme.md
+++ b/packages/core/src/components/icon/readme.md
@@ -31,6 +31,7 @@
  - [tds-message](../message)
  - [tds-modal](../modal)
  - [tds-navigation-tabs](../tabs/navigation-tabs)
+ - [tds-number-field](../number-field)
  - [tds-side-menu-close-button](../side-menu/side-menu-close-button)
  - [tds-side-menu-dropdown](../side-menu/side-menu-dropdown)
  - [tds-slider](../slider)
@@ -58,6 +59,7 @@ graph TD;
   tds-message --> tds-icon
   tds-modal --> tds-icon
   tds-navigation-tabs --> tds-icon
+  tds-number-field --> tds-icon
   tds-side-menu-close-button --> tds-icon
   tds-side-menu-dropdown --> tds-icon
   tds-slider --> tds-icon

--- a/packages/core/src/components/number-field/number-field-vars.scss
+++ b/packages/core/src/components/number-field/number-field-vars.scss
@@ -1,0 +1,129 @@
+:root,
+.tds-mode-light {
+  --tds-number-field-background-primary: var(--tds-grey-50);
+  --tds-number-field-background-secondary: var(--tds-white);
+  --tds-number-field-background: var(--tds-number-field-background-primary);
+  --tds-number-field-color: var(--tds-grey-600);
+  --tds-number-field-placeholder: var(--tds-grey-500);
+  --tds-number-field-data-color: var(--tds-grey-868);
+
+  //Disabled
+  --tds-number-field-background-disabled-primary: var(--tds-grey-50);
+  --tds-number-field-background-disabled-secondary: var(--tds-white);
+  --tds-number-field-background-disabled: var(--tds-number-field-background-disabled-primary);
+  --tds-number-field-color-disabled: var(--tds-grey-400);
+  --tds-number-field-placeholder-disabled: var(--tds-grey-400);
+  --tds-number-field-label-disabled: var(--tds-grey-400);
+  --tds-number-field-ps-color-disabled: var(--tds-grey-400);
+
+  //Label
+  --tds-number-field-label-color: var(--tds-grey-700);
+  --tds-number-field-label-inside-color: var(--tds-grey-700);
+  --tds-number-field-placeholder-focus-color: var(--tds-grey-500);
+
+  //Highlight bar
+  --tds-number-field-bar: var(--tds-blue-400);
+
+  //helper
+  --tds-number-field-helper: var(--tds-grey-600);
+
+  //error
+  --tds-number-field-border-bottom-error: var(--tds-negative);
+  --tds-number-field-helper-error: var(--tds-negative);
+  --tds-number-field-bar-error: var(--tds-negative);
+  --tds-number-field-icon-error: var(--tds-negative);
+
+  //Textcounter
+  --tds-number-field-textcounter: var(--tds-grey-700);
+  --tds-number-field-textcounter-divider: var(--tds-grey-500);
+
+  //Prefix and Suffix
+  --tds-number-field-ps-color: var(--tds-grey-600);
+  --tds-number-field-ps-color-error: var(--tds-negative);
+
+  // number-field resize icon
+  --tds-number-field-resize-icon: var(--tds-grey-500);
+
+  // Border bottom
+  --tds-number-field-border-bottom: var(--tds-grey-600);
+  --tds-number-field-border-bottom-hover: var(--tds-grey-800);
+  --tds-number-field-border-bottom-success: var(--tds-grey-958);
+
+  // Read only
+  --tds-number-field-icon-read-only-color: var(--tds-grey-958);
+  --tds-number-field-icon-read-only-label-color: var(--tds-grey-958);
+
+  .tds-mode-variant-primary {
+    --tds-number-field-background: var(--tds-number-field-background-primary);
+    --tds-number-field-background-disabled: var(--tds-number-field-background-disabled-primary);
+  }
+
+  .tds-mode-variant-secondary {
+    --tds-number-field-background: var(--tds-number-field-background-secondary);
+    --tds-number-field-background-disabled: var(--tds-number-field-background-disabled-secondary);
+  }
+}
+
+.tds-mode-dark {
+  --tds-number-field-background-primary: var(--tds-grey-900);
+  --tds-number-field-background: var(--tds-number-field-background-primary);
+  --tds-number-field-background-secondary: var(--tds-grey-868);
+  --tds-number-field-color: var(--tds-grey-600);
+  --tds-number-field-placeholder: var(--tds-grey-600);
+  --tds-number-field-data-color: var(--tds-grey-100);
+
+  //Disabled
+  --tds-number-field-ps-color-disabled: var(--tds-grey-700);
+  --tds-number-field-color-disabled: var(--tds-grey-800);
+  --tds-number-field-background-disabled-primary: var(--tds-grey-900);
+  --tds-number-field-background-disabled-secondary: var(--tds-grey-868);
+  --tds-number-field-background-disabled: var(--tds-number-field-background-disabled-primary);
+  --tds-number-field-placeholder-disabled: var(--tds-grey-800);
+  --tds-number-field-label-disabled: var(--tds-grey-700);
+
+  // Label
+  --tds-number-field-label-color: var(--tds-grey-100);
+  --tds-number-field-label-inside-color: var(--tds-grey-700);
+  --tds-number-field-placeholder-focus-color: var(--tds-grey-700);
+
+  //Highlight bar
+  --tds-number-field-bar: var(--tds-blue-400);
+
+  //helper
+  --tds-number-field-helper: var(--tds-grey-600);
+
+  //error
+  --tds-number-field-helper-error: var(--tds-negative);
+  --tds-number-field-bar-error: var(--tds-negative);
+  --tds-number-field-icon-error: var(--tds-negative);
+
+  //Textcounter
+  --tds-number-field-textcounter: var(--tds-grey-600);
+  --tds-number-field-textcounter-divider: var(--tds-grey-700);
+
+  //Prefix and Suffix
+  --tds-number-field-ps-color: var(--tds-grey-100);
+
+  // Textarea resize icon
+  --tds-number-field-resize-icon: var(--tds-grey-500);
+
+  // Border bottom
+  --tds-number-field-border-bottom: var(--tds-grey-600);
+  --tds-number-field-border-bottom-hover: var(--tds-grey-400);
+  --tds-number-field-border-bottom-success: var(--tds-grey-50);
+  --tds-number-field-border-bottom-error: var(--tds-negative);
+
+  // Read only
+  --tds-number-field-icon-read-only-color: var(--tds-grey-100);
+  --tds-number-field-icon-read-only-label-color: var(--tds-grey-50);
+
+  .tds-mode-variant-primary {
+    --tds-number-field-background: var(--tds-number-field-background-primary);
+    --tds-number-field-background-disabled: var(--tds-number-field-background-disabled-primary);
+  }
+
+  .tds-mode-variant-secondary {
+    --tds-number-field-background: var(--tds-number-field-background-secondary);
+    --tds-number-field-background-disabled: var(--tds-number-field-background-disabled-secondary);
+  }
+}

--- a/packages/core/src/components/number-field/number-field.scss
+++ b/packages/core/src/components/number-field/number-field.scss
@@ -1,0 +1,395 @@
+@mixin number-field-base {
+  all: unset;
+  border-radius: 4px 4px 0 0;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  border: none;
+  outline: none;
+  height: 100%;
+  color: var(--tds-number-field-color);
+  background-color: var(--tds-number-field-background);
+
+  &::placeholder {
+    color: var(--tds-number-field-color);
+  }
+
+  &:focus::placeholder {
+    color: var(--tds-number-field-placeholder-focus-color);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    background-color: var(--tds-number-field-background-disabled);
+    color: var(--tds-number-field-color-disabled);
+
+    &::placeholder {
+      color: var(--tds-number-field-placeholder-disabled);
+    }
+
+    ~ .number-field-label-inside {
+      color: var(--tds-number-field-label-disabled);
+    }
+  }
+}
+
+//Sizes
+.number-field-input-lg {
+  @include number-field-base;
+
+  font: var(--tds-detail-02);
+  letter-spacing: var(--tds-detail-02-ls);
+  padding: var(--tds-spacing-element-20) var(--tds-spacing-element-16);
+}
+
+.number-field-input-md {
+  @include number-field-base;
+
+  font: var(--tds-detail-02);
+  letter-spacing: var(--tds-detail-02-ls);
+  padding: var(--tds-spacing-element-16);
+}
+
+.number-field-input-sm {
+  @include number-field-base;
+
+  font: var(--tds-detail-02);
+  letter-spacing: var(--tds-detail-02-ls);
+  padding: var(--tds-spacing-element-16);
+}
+
+//Container for input field and prefix/suffix
+.number-field-container {
+  border-radius: 4px 4px 0 0;
+  display: flex;
+  position: relative;
+  height: 56px;
+  box-sizing: border-box;
+  background-color: var(--tds-number-field-background);
+  border-bottom: 1px solid var(--tds-number-field-border-bottom);
+  transition: border-bottom-color 200ms ease;
+
+  &:hover {
+    border-bottom-color: var(--tds-number-field-border-bottom-hover);
+  }
+
+  .form-number-field-md & {
+    height: 48px;
+  }
+
+  .form-number-field-sm & {
+    height: 40px;
+  }
+}
+
+.number-field-input-container {
+  position: relative;
+  width: 100%;
+}
+
+.number-field-data,
+.number-field-input {
+  color: var(--tds-number-field-data-color);
+}
+
+//number-field label
+
+.number-field-label-outside > * {
+  font: var(--tds-detail-05);
+  letter-spacing: var(--tds-detail-05-ls);
+  display: block;
+  margin-bottom: var(--tds-spacing-element-8);
+  color: var(--tds-number-field-label-color);
+}
+
+.number-field-label-inside {
+  font: var(--tds-detail-02);
+  letter-spacing: var(--tds-detail-02-ls);
+  position: absolute;
+  pointer-events: none;
+  color: var(--tds-number-field-label-inside-color);
+  left: 16px;
+}
+
+@mixin placeholder-label {
+  &::placeholder {
+    color: transparent;
+  }
+
+  ::placeholder {
+    color: transparent;
+  }
+
+  //Input field in focus
+  &:focus::placeholder {
+    transition: color 0.35s ease;
+    color: var(--tds-number-field-placeholder-focus-color);
+  }
+}
+
+@mixin label-inside-transition {
+  transition: 0.1s ease all;
+}
+
+//Form control
+.form-number-field {
+  display: block;
+  min-width: 208px;
+
+  &-nomin {
+    min-width: auto;
+  }
+}
+
+//number-field container with label inside
+//Handling position, focus and transition for label inside
+.form-number-field.number-field-container-label-inside {
+  .number-field-input-lg {
+    padding-top: var(--tds-spacing-element-24);
+    padding-bottom: 15px;
+
+    ~ .number-field-label-inside {
+      top: 20px;
+    }
+
+    @include placeholder-label;
+  }
+
+  .number-field-input-md {
+    padding-top: var(--tds-spacing-element-20);
+    padding-bottom: 11px;
+
+    ~ .number-field-label-inside {
+      top: 16px;
+    }
+
+    @include placeholder-label;
+  }
+
+  .number-field-input-sm {
+    padding-top: var(--tds-spacing-element-20);
+    padding-bottom: 11px;
+
+    ~ .number-field-label-inside {
+      top: 16px;
+    }
+
+    @include placeholder-label;
+  }
+
+  &.number-field-focus,
+  &.number-field-data {
+    .number-field-input-sm ~ .number-field-label-inside {
+      font: var(--tds-detail-07);
+      letter-spacing: var(--tds-detail-07-ls);
+
+      @include label-inside-transition;
+
+      top: 8px;
+    }
+
+    .number-field-input-md ~ .number-field-label-inside {
+      font: var(--tds-detail-07);
+      letter-spacing: var(--tds-detail-07-ls);
+
+      @include label-inside-transition;
+
+      top: 8px;
+    }
+
+    .number-field-input-lg ~ .number-field-label-inside {
+      font: var(--tds-detail-07);
+      letter-spacing: var(--tds-detail-07-ls);
+
+      @include label-inside-transition;
+
+      top: 12px;
+    }
+  }
+}
+
+//number-field bottom bar when in focus
+.number-field-bar {
+  position: absolute;
+  width: 100%;
+
+  &::before,
+  &::after {
+    content: '';
+    height: 2px;
+    top: 54px;
+    width: 0;
+    position: absolute;
+    background: var(--tds-number-field-bar);
+    transition: 0.35s ease all;
+
+    .form-number-field-md & {
+      top: 46px;
+    }
+
+    .form-number-field-sm & {
+      top: 40px;
+    }
+  }
+
+  &::before {
+    left: 50%;
+  }
+
+  &::after {
+    right: 50%;
+  }
+
+  .number-field-focus &::before,
+  .number-field-focus &::after {
+    width: 50%;
+  }
+}
+
+//Helper text
+.number-field-helper {
+  font: var(--tds-detail-05);
+  letter-spacing: var(--tds-detail-05-ls);
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+
+  & .number-field-textcounter {
+    margin-left: auto;
+  }
+
+  flex-basis: 100%;
+  padding-top: var(--tds-spacing-element-4);
+  color: var(--tds-number-field-helper);
+}
+
+//Disabled state
+.form-number-field-disabled {
+  .number-field-container {
+    border-bottom-color: transparent;
+  }
+
+  .number-field-slot-wrap-prefix,
+  .number-field-slot-wrap-suffix {
+    > * {
+      color: var(--tds-number-field-ps-color-disabled);
+    }
+  }
+
+  .number-field-label-outside {
+    > * {
+      color: var(--tds-number-field-label-disabled);
+    }
+  }
+}
+
+//Read only state
+
+.number-field-icon__readonly {
+  display: none;
+  position: absolute;
+  right: 18px;
+  top: 18px;
+  color: var(--tds-number-field-icon-read-only-label-color);
+
+  &-label {
+    display: none;
+    position: absolute;
+    right: 18px;
+    top: 48px;
+    font: var(--tds-detail-05);
+    letter-spacing: var(--tds-detail-05-ls);
+    padding: 8px;
+    white-space: nowrap;
+    border-radius: 4px 0 4px 4px;
+    background-color: var(--tds-number-field-icon-read-only-label-background);
+  }
+}
+
+.form-number-field-readonly {
+  pointer-events: none;
+
+  .number-field-icon__readonly {
+    display: block;
+
+    &:hover {
+      ~ .number-field-icon__readonly-label {
+        display: block;
+      }
+    }
+  }
+
+  .number-field-input {
+    padding-right: 54px;
+    background-color: transparent;
+  }
+}
+
+//Success state
+.form-number-field-success {
+  .number-field-container {
+    border-bottom-color: var(--tds-number-field-border-bottom-success);
+  }
+}
+
+//Error State
+.form-number-field-error {
+  .number-field-helper {
+    color: var(--tds-number-field-helper-error);
+  }
+
+  .number-field-container {
+    border-bottom-color: var(--tds-number-field-border-bottom-error);
+  }
+
+  .number-field-bar {
+    &::before,
+    &::after {
+      background: var(--tds-number-field-bar-error);
+    }
+  }
+}
+
+// .number-field-textcounter {
+.number-field-helper-error-state {
+  display: flex;
+  gap: 8px;
+  flex-wrap: nowrap;
+}
+
+.number-field-textcounter {
+  font: var(--tds-detail-05);
+  letter-spacing: var(--tds-detail-05-ls);
+  color: var(--tds-number-field-textcounter);
+  float: right;
+
+  & .number-field-textcounter-divider {
+    // @include type-style('detail-05');
+    color: var(--tds-number-field-textcounter-divider);
+  }
+}
+
+.number-field-slot-wrap-prefix,
+.number-field-slot-wrap-suffix {
+  align-self: center;
+  font: var(--tds-detail-02);
+  letter-spacing: var(--tds-detail-02-ls);
+  margin: 0 0 0 14px;
+  color: var(--tds-number-field-ps-color);
+
+  &::slotted(:not(tds-icon)) {
+    margin: 0 0 0 2px;
+  }
+
+  &.number-field-error {
+    color: var(--tds-number-field-ps-color-error);
+  }
+}
+
+.number-field-slot-wrap-suffix {
+  margin: 0 14px 0 0;
+
+  &::slotted(:not(tds-icon)) {
+    margin: 0 2px 0 0;
+  }
+}

--- a/packages/core/src/components/number-field/number-field.stories.tsx
+++ b/packages/core/src/components/number-field/number-field.stories.tsx
@@ -1,0 +1,275 @@
+import readme from './readme.md';
+import formatHtmlPreview from '../../stories/formatHtmlPreview';
+import { ComponentsFolder } from '../../utils/constants';
+
+export default {
+  title: `${ComponentsFolder}/Number Field`,
+  parameters: {
+    notes: readme,
+    layout: 'centered',
+    design: [
+      {
+        name: 'Figma',
+        type: 'figma',
+        url: 'https://www.figma.com/file/d8bTgEx7h694MSesi2CTLF/Tegel-UI-Library?node-id=1675%3A76544&t=Ne6myqwca5m00de7-1',
+      },
+      {
+        name: 'Link',
+        type: 'link',
+        url: 'https://www.figma.com/file/d8bTgEx7h694MSesi2CTLF/Tegel-UI-Library?node-id=1675%3A76544&t=Ne6myqwca5m00de7-1',
+      },
+    ],
+  },
+  argTypes: {
+    modeVariant: {
+      name: 'Mode variant',
+      description:
+        'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
+      control: {
+        type: 'radio',
+      },
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
+      table: {
+        defaultValue: { summary: 'Inherit from parent' },
+      },
+    },
+    state: {
+      name: 'State',
+      description: 'Switches between success and error state.',
+      control: {
+        type: 'radio',
+      },
+      options: ['Default', 'Success', 'Error'],
+      table: {
+        defaultValue: { summary: 'default' },
+      },
+    },
+
+    min: {
+      name: 'Min',
+      description: 'Minimum acceptable value when input type is number',
+      control: {
+        type: 'number',
+      },
+    },
+    max: {
+      name: 'Max',
+      description: 'Maximum acceptable value when input type is number',
+      control: {
+        type: 'number',
+      },
+    },
+    size: {
+      name: 'Size',
+      description: 'Switches between different sizes.',
+      control: {
+        type: 'radio',
+      },
+      options: ['Large', 'Medium', 'Small'],
+      table: {
+        defaultValue: { summary: 'lg' },
+      },
+    },
+    label: {
+      name: 'Label text',
+      description: 'Sets the label text.',
+      control: {
+        type: 'text',
+      },
+    },
+    labelPosition: {
+      name: 'Label position',
+      description: 'Sets the label text position.',
+      control: {
+        type: 'radio',
+      },
+      options: ['No label', 'Inside', 'Outside'],
+      table: {
+        defaultValue: { summary: 'no-label' },
+      },
+    },
+    placeholderText: {
+      name: 'Placeholder',
+      description: 'Sets the placeholder text.',
+      control: {
+        type: 'text',
+      },
+    },
+    helper: {
+      name: 'Helper text',
+      description: 'Sets the helper text.',
+      control: {
+        type: 'text',
+      },
+    },
+    prefix: {
+      name: 'Prefix',
+      description: 'Adds a prefix symbol or text before the Text Field.',
+      control: {
+        type: 'boolean',
+      },
+    },
+    prefixType: {
+      name: 'Prefix type',
+      description: 'Switches between icon and text for the prefix.',
+      control: {
+        type: 'radio',
+      },
+      options: ['Icon', 'Text'],
+      if: { arg: 'prefix', eq: true },
+    },
+    suffix: {
+      name: 'Suffix',
+      description: 'Adds a suffix symbol or text after the Text Field.',
+      control: {
+        type: 'boolean',
+      },
+    },
+    suffixType: {
+      name: 'Suffix type',
+      description: 'Swithces between icon or text for the suffix.',
+      control: {
+        type: 'radio',
+      },
+      options: ['Icon', 'Text'],
+      if: { arg: 'suffix', eq: true },
+    },
+    noMinWidth: {
+      name: 'No minimum width',
+      description: 'Enables component to shrink below 208px which is the default width.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
+    readonly: {
+      description: 'Sets the Text Field to read-only state.',
+      name: 'Read Only',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
+    disabled: {
+      description: 'Disables the Text Field.',
+      name: 'Disabled',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
+  },
+  args: {
+    modeVariant: 'Inherit from parent',
+    state: 'Default',
+    size: 'Large',
+    label: 'Label',
+    labelPosition: 'No label',
+    placeholderText: 'Placeholder',
+    helper: '',
+    prefix: false,
+    prefixType: 'Icon',
+    suffix: false,
+    suffixType: 'Icon',
+    min: '0',
+    max: '10',
+    noMinWidth: 'Default',
+    readonly: false,
+    disabled: false,
+  },
+};
+
+const Template = ({
+  modeVariant,
+  state,
+  min,
+  max,
+  size,
+  label,
+  labelPosition,
+  placeholderText,
+  helper,
+  prefix,
+  prefixType,
+  suffix,
+  suffixType,
+  maxLength,
+  noMinWidth,
+  readonly,
+  disabled,
+}) => {
+  const maxlength = maxLength > 0 ? `max-length="${maxLength}"` : '';
+  const stateValue = state.toLowerCase();
+  const sizeLookUp = {
+    Large: 'lg',
+    Medium: 'md',
+    Small: 'sm',
+  };
+  return formatHtmlPreview(
+    `
+    <style>
+    /* demo-wrapper is for demonstration purposes only*/
+  .demo-wrapper {
+    width: 200px;
+    height: 150px;
+  }
+    </style>
+
+  <div class="demo-wrapper">
+    <tds-number-field
+       size="${sizeLookUp[size]}"
+      ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}
+      state="${stateValue}"
+      label="${label}"
+      label-position="${labelPosition.toLowerCase()}"
+      ${helper ? `helper="${helper}"` : ''}
+      ${maxlength}
+      ${min ? `min="${min}"` : ''}
+      ${max ? `max="${max}"` : ''}
+      ${disabled ? 'disabled' : ''}
+      ${readonly ? 'read-only' : ''}
+      ${noMinWidth ? 'no-min-width' : ''}
+      placeholder="${placeholderText}" >
+        ${
+          prefix || suffix
+            ? `
+          ${
+            prefixType || suffixType === 'Text'
+              ? `<span slot="${prefix ? 'prefix' : 'suffix'}">$</span>`
+              : `<tds-icon slot="${
+                  prefix ? 'prefix' : 'suffix'
+                }" name="truck" size="20px"></tds-icon>`
+          }
+        `
+            : ''
+        }
+
+        </tds-number-field>
+  </div>
+  <!-- Script tag for demo purposes -->
+  <script>
+    textElement = document.querySelector('tds-number-field')
+    textElement.addEventListener('tdsFocus',(event) => {
+      console.log(event)
+    })
+    textElement.addEventListener('tdsBlur',(event) => {
+      console.log(event)
+    })
+    textElement.addEventListener('tdsInput',(event) => {
+      console.log(event)
+    })
+    textElement.addEventListener('tdsChange',(event) => {
+      console.log(event)
+    })
+  </script>
+  `,
+  );
+};
+
+export const Default = Template.bind({});

--- a/packages/core/src/components/number-field/number-field.tsx
+++ b/packages/core/src/components/number-field/number-field.tsx
@@ -1,0 +1,227 @@
+import { Component, h, State, Prop, Event, EventEmitter, Element } from '@stencil/core';
+import hasSlot from '../../utils/hasSlot';
+
+/**
+ * @slot prefix - Slot for the prefix in the Number Field
+ * @slot suffix - Slot for the suffix in the Number Field
+ */
+@Component({
+  tag: 'tds-number-field',
+  styleUrl: 'number-field.scss',
+  shadow: false,
+  scoped: true,
+})
+export class TdsNumberField {
+  @Element() host: HTMLElement;
+
+  /** Number input for focus state */
+  numberInput?: HTMLInputElement;
+
+  /** Position of the label for the Number Field. */
+  @Prop() labelPosition: 'inside' | 'outside' | 'no-label' = 'no-label';
+
+  /** Label text */
+  @Prop() label: string = '';
+
+  /** Min allowed value for input type number */
+  @Prop() min?: string | number;
+
+  /** Max allowed value for input type number */
+  @Prop() max?: string | number;
+
+  /** Helper text */
+  @Prop() helper: string;
+
+  /** Placeholder text */
+  @Prop() placeholder: string = '';
+
+  /** Value of the input */
+  @Prop({ reflect: true }) value?: number;
+
+  /** Set input in disabled state */
+  @Prop() disabled: boolean = false;
+
+  /** Set input in readonly state */
+  @Prop() readOnly: boolean = false;
+
+  /** Size of the input */
+  @Prop() size: 'sm' | 'md' | 'lg' = 'lg';
+
+  /** Mode variant of the Number Field */
+  @Prop() modeVariant: 'primary' | 'secondary' = null;
+
+  /** Unset minimum width of 208px. */
+  @Prop() noMinWidth: boolean = false;
+
+  /** Name property */
+  @Prop() name = '';
+
+  /** Error state of input */
+  @Prop() state: 'error' | 'success' | 'default' = 'default';
+
+  /** Autofocus for input */
+  @Prop() autofocus: boolean = false;
+
+  /** Listen to the focus state of the input */
+  @State() focusInput;
+
+  /** Change event for the Number Field */
+  @Event({
+    eventName: 'tdsChange',
+    composed: true,
+    bubbles: true,
+    cancelable: false,
+  })
+  tdsChange: EventEmitter;
+
+  handleChange(event): void {
+    this.tdsChange.emit(event);
+  }
+
+  /** Input event for the Number Field */
+  @Event({
+    eventName: 'tdsInput',
+    composed: true,
+    bubbles: true,
+    cancelable: false,
+  })
+  tdsInput: EventEmitter<InputEvent>;
+
+  // Data input event in value prop
+  handleInput(event): void {
+    this.tdsInput.emit(event);
+    this.value = event.target.value;
+  }
+
+  /** Focus event for the Number Field */
+  @Event({
+    eventName: 'tdsFocus',
+    composed: true,
+    bubbles: true,
+    cancelable: false,
+  })
+  tdsFocus: EventEmitter<FocusEvent>;
+
+  /** Set the input as focus when clicking the whole Number Field with suffix/prefix */
+  handleFocus(event): void {
+    this.numberInput.focus();
+    this.focusInput = true;
+    this.tdsFocus.emit(event);
+  }
+
+  /** Blur event for the Number Field */
+  @Event({
+    eventName: 'tdsBlur',
+    composed: true,
+    bubbles: true,
+    cancelable: false,
+  })
+  tdsBlur: EventEmitter<FocusEvent>;
+
+  /** Set the input as focus when clicking the whole Number Field with suffix/prefix */
+  handleBlur(event): void {
+    this.focusInput = false;
+    this.tdsBlur.emit(event);
+  }
+
+  render() {
+    const usesPrefixSlot = hasSlot('prefix', this.host);
+    const usesSuffixSlot = hasSlot('suffix', this.host);
+    return (
+      <div
+        class={`
+        ${this.noMinWidth ? 'form-number-field-nomin' : ''}
+        ${
+          this.focusInput && !this.disabled
+            ? 'form-number-field number-field-focus'
+            : ' form-number-field'
+        }
+        ${this.value ? 'number-field-data' : ''}
+        ${
+          this.labelPosition === 'inside' && this.size !== 'sm'
+            ? 'number-field-container-label-inside'
+            : ''
+        }
+        ${this.disabled ? 'form-number-field-disabled' : ''}
+        ${this.readOnly ? 'form-number-field-readonly' : ''}
+        ${this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''}
+        ${this.size === 'md' ? 'form-number-field-md' : ''}
+        ${this.size === 'sm' ? 'form-number-field-sm' : ''}
+        ${
+          this.state === 'error' || this.state === 'success'
+            ? `form-number-field-${this.state}`
+            : ''
+        }
+        `}
+      >
+        {this.labelPosition === 'outside' && (
+          <div class="number-field-label-outside">
+            <div>{this.label}</div>
+          </div>
+        )}
+        <div onClick={() => this.numberInput.focus()} class="number-field-container">
+          {usesPrefixSlot && (
+            <div class={`number-field-slot-wrap-prefix number-field-${this.state}`}>
+              <slot name="prefix" />
+            </div>
+          )}
+
+          <div class="number-field-input-container">
+            <input
+              ref={(inputEl) => (this.numberInput = inputEl as HTMLInputElement)}
+              class={`number-field-input number-field-input-${this.size}`}
+              type="number"
+              disabled={this.disabled}
+              readonly={this.readOnly}
+              placeholder={this.placeholder}
+              value={this.value}
+              autofocus={this.autofocus}
+              name={this.name}
+              min={this.min}
+              max={this.max}
+              onInput={(event) => this.handleInput(event)}
+              onChange={(event) => this.handleChange(event)}
+              onFocus={(event) => {
+                if (!this.readOnly) {
+                  this.handleFocus(event);
+                }
+              }}
+              onBlur={(event) => {
+                if (!this.readOnly) {
+                  this.handleBlur(event);
+                }
+              }}
+            />
+
+            {this.labelPosition === 'inside' && this.size !== 'sm' && (
+              <label class="number-field-label-inside">{this.label}</label>
+            )}
+          </div>
+          <div class="number-field-bar"></div>
+
+          {usesSuffixSlot && (
+            <div class={`number-field-slot-wrap-suffix number-field-${this.state}`}>
+              <slot name="suffix" />
+            </div>
+          )}
+          <span class="number-field-icon__readonly">
+            <tds-icon name="edit_inactive" size="20px"></tds-icon>
+          </span>
+          <span class="number-field-icon__readonly-label">This field is non-editable</span>
+        </div>
+
+        {this.helper && (
+          <div class="number-field-helper">
+            {this.state === 'error' && (
+              <div class="number-field-helper-error-state">
+                <tds-icon name="error" size="16px"></tds-icon>
+                {this.helper}
+              </div>
+            )}
+            {this.state !== 'error' && this.helper}
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/packages/core/src/components/number-field/readme.md
+++ b/packages/core/src/components/number-field/readme.md
@@ -1,0 +1,62 @@
+# tds-number-field
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property        | Attribute        | Description                                 | Type                                  | Default      |
+| --------------- | ---------------- | ------------------------------------------- | ------------------------------------- | ------------ |
+| `autofocus`     | `autofocus`      | Autofocus for input                         | `boolean`                             | `false`      |
+| `disabled`      | `disabled`       | Set input in disabled state                 | `boolean`                             | `false`      |
+| `helper`        | `helper`         | Helper text                                 | `string`                              | `undefined`  |
+| `label`         | `label`          | Label text                                  | `string`                              | `''`         |
+| `labelPosition` | `label-position` | Position of the label for the Number Field. | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
+| `max`           | `max`            | Max allowed value for input type number     | `number \| string`                    | `undefined`  |
+| `min`           | `min`            | Min allowed value for input type number     | `number \| string`                    | `undefined`  |
+| `modeVariant`   | `mode-variant`   | Mode variant of the Number Field            | `"primary" \| "secondary"`            | `null`       |
+| `name`          | `name`           | Name property                               | `string`                              | `''`         |
+| `noMinWidth`    | `no-min-width`   | Unset minimum width of 208px.               | `boolean`                             | `false`      |
+| `placeholder`   | `placeholder`    | Placeholder text                            | `string`                              | `''`         |
+| `readOnly`      | `read-only`      | Set input in readonly state                 | `boolean`                             | `false`      |
+| `size`          | `size`           | Size of the input                           | `"lg" \| "md" \| "sm"`                | `'lg'`       |
+| `state`         | `state`          | Error state of input                        | `"default" \| "error" \| "success"`   | `'default'`  |
+| `value`         | `value`          | Value of the input                          | `number`                              | `undefined`  |
+
+
+## Events
+
+| Event       | Description                       | Type                      |
+| ----------- | --------------------------------- | ------------------------- |
+| `tdsBlur`   | Blur event for the Number Field   | `CustomEvent<FocusEvent>` |
+| `tdsChange` | Change event for the Number Field | `CustomEvent<any>`        |
+| `tdsFocus`  | Focus event for the Number Field  | `CustomEvent<FocusEvent>` |
+| `tdsInput`  | Input event for the Number Field  | `CustomEvent<InputEvent>` |
+
+
+## Slots
+
+| Slot       | Description                             |
+| ---------- | --------------------------------------- |
+| `"prefix"` | Slot for the prefix in the Number Field |
+| `"suffix"` | Slot for the suffix in the Number Field |
+
+
+## Dependencies
+
+### Depends on
+
+- [tds-icon](../icon)
+
+### Graph
+```mermaid
+graph TD;
+  tds-number-field --> tds-icon
+  style tds-number-field fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -20,7 +20,7 @@
 
 | Event     | Description                                                                                                                                              | Type                                                                                      |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "desc" \| "asc"; }>` |
+| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
 
 
 ## Slots

--- a/packages/core/src/components/text-field/readme.md
+++ b/packages/core/src/components/text-field/readme.md
@@ -14,7 +14,9 @@
 | `helper`        | `helper`         | Helper text                                 | `string`                              | `undefined`  |
 | `label`         | `label`          | Label text                                  | `string`                              | `''`         |
 | `labelPosition` | `label-position` | Position of the label for the Text Field.   | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
+| `max`           | `max`            | Max allowed value for input type number     | `number \| string`                    | `undefined`  |
 | `maxLength`     | `max-length`     | Max length of input                         | `number`                              | `undefined`  |
+| `min`           | `min`            | Min allowed value for input type number     | `number \| string`                    | `undefined`  |
 | `modeVariant`   | `mode-variant`   | Mode variant of the Text Field              | `"primary" \| "secondary"`            | `null`       |
 | `name`          | `name`           | Name property                               | `string`                              | `''`         |
 | `noMinWidth`    | `no-min-width`   | Unset minimum width of 208px.               | `boolean`                             | `false`      |
@@ -22,7 +24,7 @@
 | `readOnly`      | `read-only`      | Set input in readonly state                 | `boolean`                             | `false`      |
 | `size`          | `size`           | Size of the input                           | `"lg" \| "md" \| "sm"`                | `'lg'`       |
 | `state`         | `state`          | Error state of input                        | `"default" \| "error" \| "success"`   | `'default'`  |
-| `type`          | `type`           | Which input type, text, password or similar | `"password" \| "text"`                | `'text'`     |
+| `type`          | `type`           | Which input type, text, password or similar | `"number" \| "password" \| "text"`    | `'text'`     |
 | `value`         | `value`          | Value of the input text                     | `string`                              | `''`         |
 
 

--- a/packages/core/src/components/text-field/text-field.stories.tsx
+++ b/packages/core/src/components/text-field/text-field.stories.tsx
@@ -50,9 +50,31 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Text', 'Password'],
+      options: ['Text', 'Password', 'Number'],
       table: {
         defaultValue: { summary: 'text' },
+      },
+    },
+    min: {
+      name: 'Min',
+      description: 'Minumum acceptable value when input type is number',
+      control: {
+        type: 'number',
+      },
+      if: {
+        arg: 'type',
+        eq: 'Number',
+      },
+    },
+    max: {
+      name: 'Max',
+      description: 'Maximum acceptable value when input type is number',
+      control: {
+        type: 'number',
+      },
+      if: {
+        arg: 'type',
+        eq: 'Number', 
       },
     },
     size: {
@@ -181,6 +203,8 @@ export default {
     prefixType: 'Icon',
     suffix: false,
     suffixType: 'Icon',
+    min: "0",
+    max: "10",
     maxLength: 0,
     noMinWidth: 'Default',
     readonly: false,
@@ -192,6 +216,8 @@ const Template = ({
   modeVariant,
   state,
   type,
+  min,
+  max,
   size,
   label,
   labelPosition,
@@ -207,6 +233,8 @@ const Template = ({
   disabled,
 }) => {
   const maxlength = maxLength > 0 ? `max-length="${maxLength}"` : '';
+  min = min  ? `min="${min}"` : '';
+  max = max  ? `max="${max}"` : '';
   const stateValue = state.toLowerCase();
   const sizeLookUp = {
     Large: 'lg',
@@ -233,6 +261,8 @@ const Template = ({
       label-position="${labelPosition.toLowerCase()}"
       ${helper ? `helper="${helper}"` : ''}
       ${maxlength}
+      ${min}
+      ${max}
       ${disabled ? 'disabled' : ''}
       ${readonly ? 'read-only' : ''}
       ${noMinWidth ? 'no-min-width' : ''}

--- a/packages/core/src/components/text-field/text-field.stories.tsx
+++ b/packages/core/src/components/text-field/text-field.stories.tsx
@@ -57,7 +57,7 @@ export default {
     },
     min: {
       name: 'Min',
-      description: 'Minumum acceptable value when input type is number',
+      description: 'Minimum acceptable value when input type is number',
       control: {
         type: 'number',
       },

--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -18,13 +18,19 @@ export class TdsTextField {
   textInput?: HTMLInputElement;
 
   /** Which input type, text, password or similar */
-  @Prop({ reflect: true }) type: 'text' | 'password' = 'text';
+  @Prop({ reflect: true }) type: 'text' | 'password' | 'number' = 'text';
 
   /** Position of the label for the Text Field. */
   @Prop() labelPosition: 'inside' | 'outside' | 'no-label' = 'no-label';
 
   /** Label text */
   @Prop() label: string = '';
+
+   /** Min allowed value for input type number */
+  @Prop() min: string | number;
+
+   /** Max allowed value for input type number */
+  @Prop() max: string | number;
 
   /** Helper text */
   @Prop() helper: string;
@@ -174,6 +180,8 @@ export class TdsTextField {
               autofocus={this.autofocus}
               maxlength={this.maxLength}
               name={this.name}
+              min={this.min}
+              max={this.max}
               onInput={(event) => this.handleInput(event)}
               onChange={(event) => this.handleChange(event)}
               onFocus={(event) => {

--- a/packages/core/src/global/global.scss
+++ b/packages/core/src/global/global.scss
@@ -54,6 +54,7 @@
 @import '../components/tabs/navigation-tabs/navigation-tabs-vars';
 @import '../components/textarea/textarea-vars';
 @import '../components/text-field/text-field-vars';
+@import '../components/number-field/number-field-vars';
 @import '../components/toast/toast-vars';
 @import '../components/toggle/toggle-vars';
 @import '../components/tooltip/tooltip-vars';


### PR DESCRIPTION
Example of number-field over text-field type number.

This is just a suuuuper quick (mostly copy-pasted from text-field) variant of a `tds-number-field` component. I personally think this is a better approach than using the `tds-text-field` with `type="number"`. Easier to understand the API, better type safety, separation of concerns and so on.


Improvement area: 
- [ ] Remove all unnecessary props in number-field.
- [ ] Remove unnecessary CSS.
- [ ] Couple the CSS vars of the text-field and number-field by agnostic name
- [ ] Remove number type from `text-field`
For example: 
```
  --tds-number-field-background-primary: var(--tds-grey-50);
```
and 
```
  --tds-text-field-background-primary: var(--tds-grey-50);
```
are the same, so should probably only need one: 
```
  --tds-input-field-background-primary: var(--tds-grey-50);
```