### PR TITLE
feat(datetime): setValue method

### DIFF
--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -1,4 +1,4 @@
-import { Component, State, h, Prop, Listen, Event, EventEmitter } from '@stencil/core';
+import { Component, State, h, Prop, Listen, Event, EventEmitter, Method } from '@stencil/core';
 
 @Component({
   tag: 'tds-datetime',
@@ -10,11 +10,11 @@ export class TdsDatetime {
   /** Text-input for focus state */
   textInput?: HTMLInputElement;
 
-  /** Sets input type */
+  /** Sets an input type */
   @Prop({ reflect: true }) type: 'datetime-local' | 'date' | 'time' = 'datetime-local';
 
   /** Value of the input text */
-  @Prop({ reflect: true }) value = '';
+  @Prop({ reflect: true, mutable: true }) value = '';
 
   /** Sets min value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00" */
   @Prop() min: string;
@@ -81,6 +81,12 @@ export class TdsDatetime {
     cancelable: false,
   })
   tdsFocus: EventEmitter<FocusEvent>;
+
+  /** Setting a new value of the datetime element */
+  @Method()
+  async setValue(newValue: string) {
+    this.value = newValue;
+  }
 
   getDefaultValue = () => {
     const dateTimeObj = {

--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -82,7 +82,7 @@ export class TdsDatetime {
   })
   tdsFocus: EventEmitter<FocusEvent>;
 
-  /** Setting a new value of the datetime element */
+  /** Method that sets the value of the datetime element */
   @Method()
   async setValue(newValue: string) {
     this.value = newValue;

--- a/packages/core/src/components/datetime/readme.md
+++ b/packages/core/src/components/datetime/readme.md
@@ -21,7 +21,7 @@
 | `noMinWidth`   | `no-min-width`  | Resets min width rule                                                                                                   | `boolean`                              | `false`            |
 | `size`         | `size`          | Size of the input                                                                                                       | `"lg" \| "md" \| "sm"`                 | `'lg'`             |
 | `state`        | `state`         | Error state of input                                                                                                    | `string`                               | `undefined`        |
-| `type`         | `type`          | Sets input type                                                                                                         | `"date" \| "datetime-local" \| "time"` | `'datetime-local'` |
+| `type`         | `type`          | Sets an input type                                                                                                      | `"date" \| "datetime-local" \| "time"` | `'datetime-local'` |
 | `value`        | `value`         | Value of the input text                                                                                                 | `string`                               | `''`               |
 
 
@@ -32,6 +32,25 @@
 | `tdsBlur`   | Blur event for the Datetime   | `CustomEvent<FocusEvent>` |
 | `tdsChange` | Change event for the Datetime | `CustomEvent<any>`        |
 | `tdsFocus`  | Focus event for the Datetime  | `CustomEvent<FocusEvent>` |
+
+
+## Methods
+
+### `setValue(newValue: string) => Promise<void>`
+
+Setting a new value of the datetime element
+
+#### Parameters
+
+| Name       | Type     | Description |
+| ---------- | -------- | ----------- |
+| `newValue` | `string` |             |
+
+#### Returns
+
+Type: `Promise<void>`
+
+
 
 
 ## Dependencies


### PR DESCRIPTION
**Describe pull-request**  
Enabling setting "value" to another value during the runtime.

**Solving issue**  
Fixes: [CDEP-3110](https://tegel.atlassian.net/browse/CDEP-3110)

**How to test**  
1. Open the preview link
2. Navigate to Datetime component
3. From the console, try to use setValue method on input by setting new value like: component.setValue('2000-01-13T14:15') 



**Additional context**  
Sometimes you need to find element in "Element" tab in Chrome before using console as sometimes targeting element ends in "null". At least that happened to me. 


[CDEP-3110]: https://tegel.atlassian.net/browse/CDEP-3110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ