### PR TITLE
fix(icon): a11y

### DIFF
--- a/packages/core/src/components/icon/icon.stories.tsx
+++ b/packages/core/src/components/icon/icon.stories.tsx
@@ -39,13 +39,9 @@ export default {
     },
     svgTitle: {
       name: 'SVG title',
-      description:
-        'Text that displays while hovering on icon. If not specified it goes to default icon name.',
+      description: 'Text that displays while hovering on icon.',
       control: {
         type: 'text',
-      },
-      table: {
-        defaultValue: { summary: 'icon-name' },
       },
     },
     svgDescription: {

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -47,14 +47,15 @@ export class Icon {
           <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 32 32"
-            aria-labelledby={this.svgTitle ?? `${element.name} icon`}
+            aria-labelledby={this.svgTitle ? `title-${this.name}` : undefined}
+            aria-describedby={this.svgDescription ? `desc-${this.name}` : undefined}
             role="img"
             style={{ fontSize: this.size }}
             height={this.size}
             width={this.size}
           >
-            <title>{this.svgTitle ?? `${element.name} icon`}</title>
-            {this.svgDescription && <desc>{this.svgDescription}</desc>}
+            {this.svgTitle && <title id={`title-${this.name}`}>{this.svgTitle}</title>}
+            {this.svgDescription && <desc id={`desc-${this.name}`}>{this.svgDescription}</desc>}
             <path fill="currentColor" d={element.definition} />
           </svg>
         );

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -17,7 +17,7 @@ export class Icon {
   /** Pass a size of icon as a string, for example, 32px, 1rem, 4em... */
   @Prop({ reflect: true }) size: string = '16px';
 
-  /** Override the default title for the svg. Text used for aria-labelledby too. */
+  /** Override the default title for the svg. Also used by aria-labelledby. */
   @Prop() svgTitle?: string;
 
   /** Set description for the svg. Text used for aria-describedby too. */

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -17,10 +17,10 @@ export class Icon {
   /** Pass a size of icon as a string, for example, 32px, 1rem, 4em... */
   @Prop({ reflect: true }) size: string = '16px';
 
-  /** Override the default title for the svg. */
+  /** Override the default title for the svg. Text used for aria-labelledby too. */
   @Prop() svgTitle?: string;
 
-  /** Set description for the svg. */
+  /** Set description for the svg. Text used for aria-describedby too. */
   @Prop() svgDescription?: string;
 
   @State() icons_object: string = iconsCollection;

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -20,7 +20,7 @@ export class Icon {
   /** Override the default title for the svg. Also used by aria-labelledby. */
   @Prop() svgTitle?: string;
 
-  /** Set description for the svg. Text used for aria-describedby too. */
+  /** Set description for the svg. Also used by aria-describedby. */
   @Prop() svgDescription?: string;
 
   @State() icons_object: string = iconsCollection;


### PR DESCRIPTION
**Describe pull-request**  

1. Removing setting the icon name as the default value for <title> tag as it creates more issues than help for users.
2. Adding more a11y fields for icons that are dependent on svgTitle and svgDescription props.

**Solving issue**  
Fixes: [CDEP-3113](https://tegel.atlassian.net/browse/CDEP-3113)

**How to test**  
1. title and description elements should not be there if you inspect preview branch
3. Adding svgTitle and svgDescription will enable title and description fields as well as aria attributes too.
4. Run ...

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events




[CDEP-3113]: https://tegel.atlassian.net/browse/CDEP-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ