### PR TITLE
ci(release-scripts): run on develop and release all

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: develop
 
       # Reference for this pattern: https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#keep-a-branch-up-to-date-with-another
       - name: Reset promotion branch

--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -1,0 +1,87 @@
+name: Release All Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      nodeVersion:
+        description: 'Node version'
+        required: true
+        default: '20.9.0'
+        type: string
+      tags:
+        description: 'Tag'
+        required: true
+        default: 'latest'
+        type: choice
+        options:
+          - latest
+          - beta
+          - dev
+      dryRun:
+        description: 'Dry run'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  release-core:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.core-release.outputs.version }}
+    steps:
+      - name: Trigger Core Release
+        id: core-release
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: release-core.yml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          inputs: '{"nodeVersion": "${{ github.event.inputs.nodeVersion }}", "tags": "${{ github.event.inputs.tags }}", "dryRun": "${{ github.event.inputs.dryRun }}"}'
+
+  release-angular:
+    needs: release-core
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Angular Release
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: release-angular.yml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          inputs: '{"nodeVersion": "${{ github.event.inputs.nodeVersion }}", "tags": "${{ github.event.inputs.tags }}", "dryRun": "${{ github.event.inputs.dryRun }}"}'
+
+  release-react:
+    needs: release-core
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger React Release
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: release-react.yml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          inputs: '{"nodeVersion": "${{ github.event.inputs.nodeVersion }}", "tags": "${{ github.event.inputs.tags }}", "dryRun": "${{ github.event.inputs.dryRun }}"}'
+
+  create-pr:
+    needs: [release-core, release-angular, release-react]
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Core - Read Package.json Version
+        id: version
+        working-directory: packages/core
+        run: echo "PACKAGE_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
+
+      - name: Create Pull Request
+        id: create-pr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: 'release: ${{ env.PACKAGE_VERSION }}'
+          title: 'release: ${{ env.PACKAGE_VERSION }}'
+          body: |
+            This PR is to sync the develop branch with the main branch after the successful release of the core package.
+            Version: ${{ env.PACKAGE_VERSION }}
+          base: main
+          branch: develop

--- a/.github/workflows/release-angular.yml
+++ b/.github/workflows/release-angular.yml
@@ -11,7 +11,7 @@ on:
       tags:
         description: 'Tag'
         required: true
-        default: 'beta'
+        default: 'latest'
         type: choice
         options:
           - latest
@@ -21,7 +21,7 @@ on:
       dryRun:
         description: 'Dry run'
         required: false
-        default: true
+        default: false
         type: boolean
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: develop
 
       - name: Set up node
         # Setup .npmrc file to publish to npm
@@ -43,7 +43,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Set Tegel user
-        run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"r
+        run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"
 
       - name: Angular - Read package.json Version
         id: version
@@ -90,7 +90,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: develop
 
       - name: Remove git tag on failure
         run: |

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -11,7 +11,7 @@ on:
       tags:
         description: 'Tag'
         required: true
-        default: 'beta'
+        default: 'latest'
         type: choice
         options:
           - latest
@@ -21,7 +21,7 @@ on:
       dryRun:
         description: 'Dry run'
         required: false
-        default: true
+        default: false
         type: boolean
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: develop
 
       - name: Set up node
         uses: actions/setup-node@v3
@@ -88,7 +88,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: develop
 
       - name: Remove git tag on failure
         run: |

--- a/.github/workflows/release-react.yml
+++ b/.github/workflows/release-react.yml
@@ -11,7 +11,7 @@ on:
       tags:
         description: 'Tag'
         required: true
-        default: 'beta'
+        default: 'latest'
         type: choice
         options:
           - latest
@@ -21,7 +21,7 @@ on:
       dryRun:
         description: 'Dry run'
         required: false
-        default: true
+        default: false
         type: boolean
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: develop
 
       - name: Set up node
         uses: actions/setup-node@v3
@@ -86,7 +86,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: develop
 
       - name: Remove git tag on failure
         run: |


### PR DESCRIPTION
**Describe pull-request**  

1. We encountered a lot of issues with making a feature release branch out of develop and merging it to develop and main. 
There are issues with merge conflicts and rebasing content back so I propose that all action happens on the develop branch and once a successful release is done we sync the main with develop with merging.
2. Tag creation happens on develop branch so the creation of release notes should work as expected. 
3. All actions are set for release with tag latest and with dry run disabled - user can always choose different settings there.
4. Added a release-all script, which releases all packages. I made sure there is a dependency on successful core release for angular and react wrappers.   

**How to test it**
Check the lines and see if you find anything suspicious.
Proper testing can happen once we have a next release so we can give it a shot.  



