### PR TITLE
fix(slider): emit tdsChange on mouse-up and touch-end events

### DIFF
--- a/packages/core/src/components/datetime/readme.md
+++ b/packages/core/src/components/datetime/readme.md
@@ -7,22 +7,22 @@
 
 ## Properties
 
-| Property       | Attribute       | Description                                                                                                             | Type                                             | Default     |
-| -------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ----------- |
-| `autofocus`    | `autofocus`     | Autofocus for input                                                                                                     | `boolean`                                        | `false`     |
-| `defaultValue` | `default-value` | Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM | `string`                                         | `'none'`    |
-| `disabled`     | `disabled`      | Set input in disabled state                                                                                             | `boolean`                                        | `false`     |
-| `helper`       | `helper`        | Helper text for the component                                                                                           | `string`                                         | `''`        |
-| `label`        | `label`         | Label text for the component                                                                                            | `string`                                         | `''`        |
-| `max`          | `max`           | Sets max value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"                 | `string`                                         | `undefined` |
-| `min`          | `min`           | Sets min value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"                 | `string`                                         | `undefined` |
-| `modeVariant`  | `mode-variant`  | Set the variant of the Datetime component.                                                                              | `"primary" \| "secondary"`                       | `null`      |
-| `name`         | `name`          | Name property                                                                                                           | `string`                                         | `''`        |
-| `noMinWidth`   | `no-min-width`  | Resets min width rule                                                                                                   | `boolean`                                        | `false`     |
-| `size`         | `size`          | Size of the input                                                                                                       | `"lg" \| "md" \| "sm"`                           | `'lg'`      |
-| `state`        | `state`         | Error state of input                                                                                                    | `string`                                         | `undefined` |
-| `type`         | `type`          | Sets an input type                                                                                                      | `"date" \| "datetime-local" \| "text" \| "time"` | `'text'`    |
-| `value`        | `value`         | Value of the input text                                                                                                 | `string`                                         | `''`        |
+| Property       | Attribute       | Description                                                                                                             | Type                                   | Default            |
+| -------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------------------ |
+| `autofocus`    | `autofocus`     | Autofocus for input                                                                                                     | `boolean`                              | `false`            |
+| `defaultValue` | `default-value` | Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM | `string`                               | `'none'`           |
+| `disabled`     | `disabled`      | Set input in disabled state                                                                                             | `boolean`                              | `false`            |
+| `helper`       | `helper`        | Helper text for the component                                                                                           | `string`                               | `''`               |
+| `label`        | `label`         | Label text for the component                                                                                            | `string`                               | `''`               |
+| `max`          | `max`           | Sets max value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"                 | `string`                               | `undefined`        |
+| `min`          | `min`           | Sets min value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"                 | `string`                               | `undefined`        |
+| `modeVariant`  | `mode-variant`  | Set the variant of the Datetime component.                                                                              | `"primary" \| "secondary"`             | `null`             |
+| `name`         | `name`          | Name property                                                                                                           | `string`                               | `''`               |
+| `noMinWidth`   | `no-min-width`  | Resets min width rule                                                                                                   | `boolean`                              | `false`            |
+| `size`         | `size`          | Size of the input                                                                                                       | `"lg" \| "md" \| "sm"`                 | `'lg'`             |
+| `state`        | `state`         | Error state of input                                                                                                    | `string`                               | `undefined`        |
+| `type`         | `type`          | Sets an input type                                                                                                      | `"date" \| "datetime-local" \| "time"` | `'datetime-local'` |
+| `value`        | `value`         | Value of the input text                                                                                                 | `string`                               | `''`               |
 
 
 ## Events

--- a/packages/core/src/components/icon/readme.md
+++ b/packages/core/src/components/icon/readme.md
@@ -19,8 +19,6 @@
 
  - [tds-accordion-item](../accordion/accordion-item)
  - [tds-banner](../banner)
- - [tds-date-picker](../_beta/date-picker/date-picker-single)
- - [tds-date-range-picker](../_beta/date-picker/date-range-picker)
  - [tds-datetime](../datetime)
  - [tds-dropdown](../dropdown)
  - [tds-dropdown-option](../dropdown/dropdown-option)
@@ -48,8 +46,6 @@
 graph TD;
   tds-accordion-item --> tds-icon
   tds-banner --> tds-icon
-  tds-date-picker --> tds-icon
-  tds-date-range-picker --> tds-icon
   tds-datetime --> tds-icon
   tds-dropdown --> tds-icon
   tds-dropdown-option --> tds-icon

--- a/packages/core/src/components/popover-core/readme.md
+++ b/packages/core/src/components/popover-core/readme.md
@@ -24,8 +24,6 @@
 
 ### Used by
 
- - [tds-date-picker](../_beta/date-picker/date-picker-single)
- - [tds-date-range-picker](../_beta/date-picker/date-range-picker)
  - [tds-popover-canvas](../popover-canvas)
  - [tds-popover-menu](../popover-menu)
  - [tds-tooltip](../tooltip)
@@ -33,8 +31,6 @@
 ### Graph
 ```mermaid
 graph TD;
-  tds-date-picker --> tds-popover-core
-  tds-date-range-picker --> tds-popover-core
   tds-popover-canvas --> tds-popover-core
   tds-popover-menu --> tds-popover-core
   tds-tooltip --> tds-popover-core

--- a/packages/core/src/components/slider/readme.md
+++ b/packages/core/src/components/slider/readme.md
@@ -29,9 +29,10 @@
 
 ## Events
 
-| Event       | Description                                 | Type                              |
-| ----------- | ------------------------------------------- | --------------------------------- |
-| `tdsChange` | Sends the value of the slider when changed. | `CustomEvent<{ value: string; }>` |
+| Event       | Description                                                                                      | Type                              |
+| ----------- | ------------------------------------------------------------------------------------------------ | --------------------------------- |
+| `tdsChange` | Sends the value of the slider when changed. Fires after mouse up and touch end events.           | `CustomEvent<{ value: string; }>` |
+| `tdsInput`  | Sends the value of the slider while moving the thumb. Fires on mouse move and touch move events. | `CustomEvent<{ value: string; }>` |
 
 
 ## Methods

--- a/packages/core/src/components/slider/slider.stories.tsx
+++ b/packages/core/src/components/slider/slider.stories.tsx
@@ -254,12 +254,21 @@ const Template = ({
     
      <!-- Script tag for demo purposes -->
     <script>
-      slider = document.querySelector('tds-slider')
+      const slider = document.querySelector('tds-slider');
       
-      slider.removeEventListener('tdsChange', null)
-      slider.addEventListener('tdsChange', (event) => {
-        console.log(event);
-      });
+      function handleTdsChange(event) {
+        console.log('tdsChange event:', event);
+      }
+      
+      slider.removeEventListener('tdsChange', handleTdsChange);
+      slider.addEventListener('tdsChange', handleTdsChange);
+
+      function handleTdsInput(event) {
+        console.log('tdsInput event:', event);
+      }
+
+      slider.removeEventListener('tdsInput', handleTdsInput);
+      slider.addEventListener('tdsInput', handleTdsInput);
     </script>
   `);
 

--- a/packages/core/src/components/slider/slider.stories.tsx
+++ b/packages/core/src/components/slider/slider.stories.tsx
@@ -254,7 +254,7 @@ const Template = ({
     
      <!-- Script tag for demo purposes -->
     <script>
-      const slider = document.querySelector('tds-slider');
+      slider = document.querySelector('tds-slider');
       
       function handleTdsChange(event) {
         console.log('tdsChange event:', event);

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -303,6 +303,11 @@ export class TdsSlider {
     const inputElement = event.target as HTMLInputElement;
     let newValue = parseInt(inputElement.value);
 
+    // Check if the new value is different from the current value
+    if (newValue === parseInt(this.value)) {
+      return; // Exit the function if the new value is the same as the current value
+    }
+
     if (newValue < parseFloat(this.min)) {
       newValue = parseFloat(this.min);
     } else if (newValue > parseFloat(this.max)) {
@@ -558,6 +563,9 @@ export class TdsSlider {
                   readOnly={this.readOnly}
                   onBlur={(event) => this.updateSliderValueOnInputChange(event)}
                   onKeyDown={(event) => this.handleInputFieldEnterPress(event)}
+                  type="number"
+                  min={this.min}
+                  max={this.max}
                 />
               </div>
             </div>

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -83,7 +83,7 @@ export class TdsSlider {
 
   private resizeObserverAdded: boolean = false;
 
-  /** Sends the value of the slider when changed. */
+  /** Sends the value of the slider when changed. Fires after mouse up and touch end events. */
   @Event({
     eventName: 'tdsChange',
     composed: true,
@@ -91,6 +91,17 @@ export class TdsSlider {
     bubbles: true,
   })
   tdsChange: EventEmitter<{
+    value: string;
+  }>;
+
+  /** Sends the value of the slider while moving the thumb. Fires on mouse move and touch move events. */
+  @Event({
+    eventName: 'tdsInput',
+    composed: true,
+    cancelable: false,
+    bubbles: true,
+  })
+  tdsInput: EventEmitter<{
     value: string;
   }>;
 
@@ -237,6 +248,9 @@ export class TdsSlider {
       )}`;
     }
     this.updateTrack();
+
+    this.tdsInput.emit({ value: this.value });
+
     /* Emit event after user has finished dragging the thumb */
     if (event.type === 'touchend' || event.type === 'mouseup') {
       this.tdsChange.emit({ value: this.value });

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -132,20 +132,8 @@ export class TdsSlider {
   }
 
   @Listen('mouseup', { target: 'window' })
-  handleMouseUp(event: MouseEvent) {
-    if (!this.thumbGrabbed) {
-      return;
-    }
-
-    this.thumbGrabbed = false;
-    this.thumbInnerElement.classList.remove('pressed');
-    this.updateValue(event);
-
-    this.trackElement.focus();
-  }
-
   @Listen('touchend', { target: 'window' })
-  handleTouchEnd(event: TouchEvent) {
+  handleRelease(event: MouseEvent | TouchEvent) {
     if (!this.thumbGrabbed) {
       return;
     }
@@ -158,17 +146,11 @@ export class TdsSlider {
   }
 
   @Listen('mousemove', { target: 'window' })
-  handleMouseMove(event: MouseEvent) {
-    if (!this.thumbGrabbed) {
-      return;
-    }
-
-    this.thumbCore(event);
-  }
-
   @Listen('touchmove', { target: 'window' })
-  handleTouchMove(event: TouchEvent) {
-    event.preventDefault();
+  handleMove(event: MouseEvent | TouchEvent) {
+    if (event.type === 'touchmove') {
+      event.preventDefault();
+    }
 
     if (!this.thumbGrabbed) {
       return;

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -106,13 +106,13 @@ export class TdsSlider {
       case 'ArrowLeft':
       case 'ArrowDown':
       case '-':
-        this.stepLeft();
+        this.stepLeft(event);
         break;
 
       case 'ArrowRight':
       case 'ArrowUp':
       case '+':
-        this.stepRight();
+        this.stepRight(event);
         break;
 
       default:
@@ -121,33 +121,33 @@ export class TdsSlider {
   }
 
   @Listen('mouseup', { target: 'window' })
-  handleMouseUp() {
+  handleMouseUp(event: MouseEvent) {
     if (!this.thumbGrabbed) {
       return;
     }
 
     this.thumbGrabbed = false;
     this.thumbInnerElement.classList.remove('pressed');
-    this.updateValue();
+    this.updateValue(event);
 
     this.trackElement.focus();
   }
 
   @Listen('touchend', { target: 'window' })
-  handleTouchEnd() {
+  handleTouchEnd(event: TouchEvent) {
     if (!this.thumbGrabbed) {
       return;
     }
 
     this.thumbGrabbed = false;
     this.thumbInnerElement.classList.remove('pressed');
-    this.updateValue();
+    this.updateValue(event);
 
     this.trackElement.focus();
   }
 
   @Listen('mousemove', { target: 'window' })
-  handleMouseMove(event) {
+  handleMouseMove(event: MouseEvent) {
     if (!this.thumbGrabbed) {
       return;
     }
@@ -156,7 +156,7 @@ export class TdsSlider {
   }
 
   @Listen('touchmove', { target: 'window' })
-  handleTouchMove(event) {
+  handleTouchMove(event: TouchEvent) {
     event.preventDefault();
 
     if (!this.thumbGrabbed) {
@@ -212,7 +212,7 @@ export class TdsSlider {
     this.thumbLeft = this.constrainThumb(localLeft);
     this.thumbElement.style.left = `${this.thumbLeft}px`;
 
-    this.updateValue();
+    this.updateValue(event);
   }
 
   private updateTrack() {
@@ -221,7 +221,7 @@ export class TdsSlider {
     this.trackFillElement.style.width = `${percentageFilled}%`;
   }
 
-  private updateValue() {
+  private updateValue(event) {
     const trackWidth = this.getTrackWidth();
     const numTicks = parseInt(this.ticks);
 
@@ -237,7 +237,10 @@ export class TdsSlider {
       )}`;
     }
     this.updateTrack();
-    this.tdsChange.emit({ value: this.value });
+    /* Emit event after user has finished dragging the thumb */
+    if (event.type === 'touchend' || event.type === 'mouseup') {
+      this.tdsChange.emit({ value: this.value });
+    }
   }
 
   private forceValueUpdate(newValue: string) {
@@ -317,7 +320,7 @@ export class TdsSlider {
     return this.max.length;
   }
 
-  private controlsStep(delta) {
+  private controlsStep(delta: number, event: KeyboardEvent) {
     if (this.readOnly || this.disabled) {
       return;
     }
@@ -334,7 +337,7 @@ export class TdsSlider {
       } else if (this.supposedValueSlot > numTicks + 1) {
         this.supposedValueSlot = numTicks + 1;
       }
-      this.updateValue();
+      this.updateValue(event);
     } else {
       const trackWidth = this.getTrackWidth();
       const percentage = this.thumbLeft / trackWidth;
@@ -356,12 +359,12 @@ export class TdsSlider {
     }
   }
 
-  private stepLeft() {
-    this.controlsStep(-parseInt(this.step));
+  private stepLeft(event) {
+    this.controlsStep(-parseInt(this.step), event);
   }
 
-  private stepRight() {
-    this.controlsStep(parseInt(this.step));
+  private stepRight(event) {
+    this.controlsStep(parseInt(this.step), event);
   }
 
   componentWillLoad() {
@@ -458,7 +461,7 @@ export class TdsSlider {
             <div class="tds-slider__controls">
               <div
                 class="tds-slider__control tds-slider__control-minus"
-                onClick={() => this.stepLeft()}
+                onClick={(event) => this.stepLeft(event)}
               >
                 <tds-icon name="minus" size="16px"></tds-icon>
               </div>
@@ -530,7 +533,7 @@ export class TdsSlider {
 
           {this.useInput && (
             <div class="tds-slider__input-values">
-              <div class="tds-slider__input-value" onClick={() => this.stepLeft()}>
+              <div class="tds-slider__input-value" onClick={(event) => this.stepLeft(event)}>
                 {this.max}
               </div>
               <div class="tds-slider__input-field-wrapper">
@@ -550,7 +553,7 @@ export class TdsSlider {
             <div class="tds-slider__controls">
               <div
                 class="tds-slider__control tds-slider__control-plus"
-                onClick={() => this.stepRight()}
+                onClick={(event) => this.stepRight(event)}
               >
                 <tds-icon name="plus" size="16px"></tds-icon>
               </div>

--- a/packages/core/src/components/text-field/readme.md
+++ b/packages/core/src/components/text-field/readme.md
@@ -48,11 +48,6 @@
 
 ## Dependencies
 
-### Used by
-
- - [tds-date-picker](../_beta/date-picker/date-picker-single)
- - [tds-date-range-picker](../_beta/date-picker/date-range-picker)
-
 ### Depends on
 
 - [tds-icon](../icon)
@@ -61,8 +56,6 @@
 ```mermaid
 graph TD;
   tds-text-field --> tds-icon
-  tds-date-picker --> tds-text-field
-  tds-date-range-picker --> tds-text-field
   style tds-text-field fill:#f9f,stroke:#333,stroke-width:4px
 ```
 


### PR DESCRIPTION
**Describe pull-request**  
Slider component spam users as we emit tdsChange on every move of the thumb. That made users use timeout functions to prevent it. The solution is to emit tdsChange once the user lifts the finger from the mouse or there is an end of touch (for touch devices).

**Solving issue**  
Fixes: [CDEP-3199](https://tegel.atlassian.net/browse/CDEP-3199)

**How to test**  
1. Open the preview Storybook of this branch and the production version of Storybook.
2. Open inspector and observe Console.
3. Move the thumbs of the slider left and right. Production one emits events all the time, while in this PR it happens only once the user releases the mouse button or stops touch.
4. Also, check behavior for snapping points, increase via +/- buttons as well as input. 

**Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Additional context**  
There is noticed flickering of the Thumb once going slowly towards the left (decreasing). Behavior is observed in both prod and development. There is another ticket for it. It is not noticeable when using Slider for a range of 0 - 1000 for example. 
