### PR TITLE
fix(header-launcher): null check

### DIFF
--- a/packages/core/src/components/header/header-launcher/header-launcher.tsx
+++ b/packages/core/src/components/header/header-launcher/header-launcher.tsx
@@ -34,20 +34,8 @@ export class TdsHeaderLauncher {
   }
 
   componentDidLoad() {
-    const slotElement = this.host.shadowRoot.querySelector('slot:not([name])') as HTMLSlotElement;
-
-    if (slotElement) {
-      const slottedElements = slotElement.assignedElements();
-      const hasListTypeMenu = slottedElements.some(
-        (element) => element.tagName.toLowerCase() === 'tds-header-launcher-list',
-      );
-
-      if (hasListTypeMenu) {
-        this.hasListTypeMenu = true;
-      }
-    } else {
-      console.warn('Slot element not found or assigned elements.');
-    }
+    const hasListTypeMenu = !!this.host.querySelector('tds-header-launcher-list');
+    this.hasListTypeMenu = hasListTypeMenu;
   }
 
   toggleLauncher() {

--- a/packages/core/src/components/header/header-launcher/header-launcher.tsx
+++ b/packages/core/src/components/header/header-launcher/header-launcher.tsx
@@ -35,13 +35,18 @@ export class TdsHeaderLauncher {
 
   componentDidLoad() {
     const slotElement = this.host.shadowRoot.querySelector('slot:not([name])') as HTMLSlotElement;
-    const slottedElements = slotElement.assignedElements();
-    const hasListTypeMenu = slottedElements.some(
-      (element) => element.tagName.toLowerCase() === 'tds-header-launcher-list',
-    );
 
-    if (hasListTypeMenu) {
-      this.hasListTypeMenu = true;
+    if (slotElement) {
+      const slottedElements = slotElement.assignedElements();
+      const hasListTypeMenu = slottedElements.some(
+        (element) => element.tagName.toLowerCase() === 'tds-header-launcher-list',
+      );
+
+      if (hasListTypeMenu) {
+        this.hasListTypeMenu = true;
+      }
+    } else {
+      console.warn('Slot element not found or assigned elements.');
     }
   }
 


### PR DESCRIPTION
**Describe pull-request**  
Adding a check for tds-header-launcher-list. 
If an element exists, we should add a class to the launcher list enabling it to take all available height on the screen.


**Solving issue**  
We get an console.error that it is null. 
Fixes: [CDEP-3126](https://tegel.atlassian.net/browse/CDEP-3126)

**How to test**  
1. Go to Storybook
2. Check in the Header and see that there is no error in the console.
3. Check this story `/?path=/story/patterns-navigation--few-navigation-items` in preview. It does not have tds-header-launcher-list, so launcher takes as much height is needed to present all items, but not more. In other stories tds-header-launcher-list is present so launcher takes 100% of available height. 


See screenshot for error:
<img width="1605" alt="Skärmavbild 2024-02-19 kl  16 51 46" src="https://github.com/scania-digital-design-system/tegel/assets/201671/55830b07-f6a5-4bf8-8502-6158e48735a4">

**Aditional notes**
It seems we complicated way of looking for element so I tried to simplify it. 





[CDEP-3126]: https://tegel.atlassian.net/browse/CDEP-3126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ