### PR TITLE
feat(toast): make close button optional

### DIFF
--- a/packages/core/src/components/toast/readme.md
+++ b/packages/core/src/components/toast/readme.md
@@ -9,6 +9,7 @@
 
 | Property    | Attribute    | Description                                            | Type                                                 | Default              |
 | ----------- | ------------ | ------------------------------------------------------ | ---------------------------------------------------- | -------------------- |
+| `closable`  | `closable`   | Enables the close button.                              | `boolean`                                            | `true`               |
 | `header`    | `header`     | Header text for the component.                         | `string`                                             | `undefined`          |
 | `hidden`    | `hidden`     | Hides the Toast.                                       | `boolean`                                            | `false`              |
 | `subheader` | `subheader`  | Subheader text for the component.                      | `string`                                             | `undefined`          |

--- a/packages/core/src/components/toast/toast.scss
+++ b/packages/core/src/components/toast/toast.scss
@@ -82,6 +82,7 @@
     flex-direction: column;
     flex: 1;
     max-width: 250px;
+    word-break: break-all;
 
     .header-subheader {
       display: flex;

--- a/packages/core/src/components/toast/toast.scss
+++ b/packages/core/src/components/toast/toast.scss
@@ -82,7 +82,7 @@
     flex-direction: column;
     flex: 1;
     max-width: 250px;
-    word-break: break-all;
+    word-break: break-word;
 
     .header-subheader {
       display: flex;

--- a/packages/core/src/components/toast/toast.stories.tsx
+++ b/packages/core/src/components/toast/toast.stories.tsx
@@ -62,6 +62,13 @@ export default {
         type: 'boolean',
       },
     },
+    closable: {
+      name: 'Closable',
+      description: 'Controls visibility of the close button.',
+      control: {
+        type: 'boolean',
+      },
+    },
   },
   args: {
     variant: 'Information',
@@ -71,25 +78,26 @@ export default {
           <a href="https://tegel.scania.com/home" target="_blank">Tegel</a>
       </tds-link>`,
     hidden: false,
+    closable: true,
   },
 };
 
-const Template = ({ variant, header, subheader, actions, hidden }) =>
+const Template = ({ variant, header, subheader, actions, hidden, closable }) =>
   formatHtmlPreview(
     `<tds-toast
         variant="${variant.toLowerCase()}"
         header="${header}"
         ${subheader ? `subheader="${subheader}"` : ''}
         ${hidden ? 'hidden' : ''}
+        closable="${closable ? 'true' : 'false'}"
     >
     ${actions || ''}
     </tds-toast>
-    
     <script>
-      document.addEventListener('tdsClose', (event) => {
-          console.log(event)
-      })
+        document.addEventListener('tdsClose', (event) => {
+            console.log(event)
+        })
     </script>
-  `,
+    `,
   );
 export const Default = Template.bind({});

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -30,6 +30,9 @@ export class TdsToast {
   /** Hides the Toast. */
   @Prop({ reflect: true }) hidden: boolean = false;
 
+  /** Enables the close button. */
+  @Prop() closable: boolean = true;
+
   /** ARIA role for the Toast. */
   @Prop() toastRole: 'alert' | 'log' | 'status' = 'alert';
 
@@ -125,14 +128,12 @@ export class TdsToast {
               </div>
             )}
           </div>
-          <button
-            onClick={() => {
-              this.handleClose();
-            }}
-            class={`close`}
-          >
-            <tds-icon name="cross" size="20px"></tds-icon>
-          </button>
+
+          {this.closable && (
+            <button onClick={this.handleClose} class="close">
+              <tds-icon name="cross" size="20px"></tds-icon>
+            </button>
+          )}
         </div>
       </Host>
     );


### PR DESCRIPTION
**Describe pull-request**  
Introduced prop to make close button optional to align with design in Figma.

**How to test**  
1. Go to Storybook link below
2. Check in Toast component
3. Toggle the "Closable" control, make sure the close button toggles accordingly between visibility and hidden

**Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  
_Include before/after screenshots for UI changes._

**Additional context**  
_Add any other context or feedback requests about the pull-request here._
