### PR TITLE
feat(modal): re-initilize selector and clean-up method

### DIFF
--- a/packages/core/src/components/modal/modal.stories.tsx
+++ b/packages/core/src/components/modal/modal.stories.tsx
@@ -91,38 +91,36 @@ const sizeLookUp = {
   'Extra small': 'xs',
 };
 
-const ModalTemplate = ({ actionsPosition, size, headerText, bodyContent, showModal, prevent }) =>
-  formatHtmlPreview(
-    `
- <!-- The button below is just for demo purposes -->
-  <tds-button id="my-modal-button" text="Open Modal"></tds-button>
-  
-  
-  <tds-modal 
-    header="${headerText}"
-    selector="#my-modal-button"   
-    ${showModal ? 'show' : ''} 
-    id="my-modal" size="${sizeLookUp[size]}" 
-    actions-position="${actionsPosition.toLowerCase()}"
-    prevent="${prevent}"
-  >          
+const ModalTemplate = ({ actionsPosition, size, headerText, bodyContent, showModal, prevent }) => {
+  return formatHtmlPreview(`
+    <!-- The button below is just for demo purposes -->
+    <tds-button id="my-modal-button" text="Open Modal"></tds-button>
+    
+    <tds-modal 
+      header="${headerText}"
+      selector="#my-modal-button"
+      ${showModal ? 'show' : ''} 
+      id="my-modal" size="${sizeLookUp[size]}" 
+      actions-position="${actionsPosition.toLowerCase()}"
+      prevent="${prevent}"
+    >
       <span slot="body">
-          ${bodyContent}
-      </span>      
+        ${bodyContent}
+      </span>
       <span slot='actions' class='tds-u-flex tds-u-gap2'>
         <tds-button data-dismiss-modal size="md" text="Delete" variant="danger"></tds-button>
         <tds-button data-dismiss-modal size="md" text="Cancel" variant="secondary"></tds-button>
-      </span>      
-  </tds-modal>
-  
-  <!-- The script below is just for demo purposes -->
-  <script>
-    modal = document.querySelector('tds-modal')
-    modal.addEventListener('tdsClose', (event) => {
-      console.log(event)
-    })
-  </script>
-  `,
-  );
+      </span>
+    </tds-modal>
+    
+    <!-- The script below is for demo purposes -->
+    <script>
+      modal = document.querySelector('tds-modal')
+      modal.addEventListener('tdsClose', (event) => {
+        console.log(event)
+      })
+    </script>
+  `);
+};
 
 export const Default = ModalTemplate.bind({});

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -74,14 +74,43 @@ export class TdsModal {
     if (this.show !== undefined) {
       this.isShown = this.show;
     }
-    this.setDismissButtons();
-    this.setShowButton();
+    this.initializeModal();
 
     if (this.header && hasSlot('header', this.host)) {
       console.warn(
         "Tegel Modal component: Using both header prop and header slot might break modal's design. Please use just one of them. ",
       );
     }
+  }
+
+  componentWillLoad() {
+    this.initializeModal();
+  }
+
+  disconnectedCallback() {
+    this.cleanupModal();
+  }
+
+  /** Initializes or re-initializes the modal, setting up event listeners. */
+  @Method()
+  async initializeModal() {
+    this.setDismissButtons();
+    this.setShowButton();
+  }
+
+  /** Cleans up event listeners and other resources. */
+  @Method()
+  async cleanupModal() {
+    if (this.selector || this.referenceEl) {
+      const referenceEl = this.referenceEl ?? document.querySelector(this.selector);
+      if (referenceEl) {
+        referenceEl.removeEventListener('click', this.handleReferenceElementClick);
+      }
+    }
+
+    this.host.querySelectorAll('[data-dismiss-modal]').forEach((dismissButton) => {
+      dismissButton.removeEventListener('click', this.handleClose);
+    });
   }
 
   handleClose = (event) => {
@@ -107,16 +136,11 @@ export class TdsModal {
     }
   };
 
-  /** Adds an event listener to the reference element that shows/closes the Modal. */
-  initializeReferenceElement = (referenceEl: HTMLElement) => {
-    if (referenceEl) {
-      referenceEl.addEventListener('click', (event) => {
-        if (this.isShown) {
-          this.handleClose(event);
-        } else {
-          this.handleShow();
-        }
-      });
+  handleReferenceElementClick = (event) => {
+    if (this.isShown) {
+      this.handleClose(event);
+    } else {
+      this.handleShow();
     }
   };
 
@@ -130,12 +154,17 @@ export class TdsModal {
     }
   };
 
+  /** Adds an event listener to the reference element that shows/closes the Modal. */
+  initializeReferenceElement = (referenceEl: HTMLElement) => {
+    if (referenceEl) {
+      referenceEl.addEventListener('click', this.handleReferenceElementClick);
+    }
+  };
+
   /** Adds an event listener to the dismiss buttons that closes the Modal. */
   setDismissButtons() {
     this.host.querySelectorAll('[data-dismiss-modal]').forEach((dismissButton) => {
-      dismissButton.addEventListener('click', (event) => {
-        this.handleClose(event);
-      });
+      dismissButton.addEventListener('click', this.handleClose);
     });
   }
 

--- a/packages/core/src/components/modal/readme.md
+++ b/packages/core/src/components/modal/readme.md
@@ -54,9 +54,29 @@ use the `referenceEl` prop rather than the `selector` the referenced element can
 
 ## Methods
 
+### `cleanupModal() => Promise<void>`
+
+Cleans up event listeners and other resources.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `closeModal() => Promise<void>`
 
 Closes the Modal.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `initializeModal() => Promise<void>`
+
+Initializes or re-initializes the modal, setting up event listeners.
 
 #### Returns
 


### PR DESCRIPTION
**Describe pull-request**  
Modal component, when rendered dynamically and simultaneously using selector/reference has an issue. It looks like the reference is lost after the initial render. That can be observed if the user navigates to other pages and returns to one where the component is. On the initial visit of the page, Modal opens, on revisit - it does not. 

What I did is to have the initialization of selector/reference in a later and more repetitive lifecycle method. The user can call the same method in case the lifecycle fails, just as a fallback solution. An additional thing was adding the removal of listeners once the component is destroyed - just to be neat and prevent performance and memory issues. 

**Solving issue**  
Fixes: [CDEP-3063](https://tegel.atlassian.net/browse/CDEP-3063)

**How to test**  
1. Go check the code and see if it makes sense.
2. Current version fo code in develop is available [here](https://github.com/scania-digital-design-system/tegel-angular-demo/pull/87) to test. 
3. Version of code with this PR fixes is available [here](https://github.com/scania-digital-design-system/tegel-angular-demo/pull/85).
4. So try to visit the page, go to "Test page", open/close different modals. Navigate to another page and then come back to "Test page".
5. New code should make sure that Modla always open while in current one it open only on inital load, refresh is needed to make it work again after navigating to another pages.

**Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)




[CDEP-3063]: https://tegel.atlassian.net/browse/CDEP-3063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ