### PR TITLE
fix(text-field): read-only hides suffix icon

### DIFF
--- a/packages/core/src/components/text-field/readme.md
+++ b/packages/core/src/components/text-field/readme.md
@@ -7,25 +7,25 @@
 
 ## Properties
 
-| Property        | Attribute        | Description                                 | Type                                  | Default      |
-| --------------- | ---------------- | ------------------------------------------- | ------------------------------------- | ------------ |
-| `autofocus`     | `autofocus`      | Autofocus for input                         | `boolean`                             | `false`      |
-| `disabled`      | `disabled`       | Set input in disabled state                 | `boolean`                             | `false`      |
-| `helper`        | `helper`         | Helper text                                 | `string`                              | `undefined`  |
-| `label`         | `label`          | Label text                                  | `string`                              | `''`         |
-| `labelPosition` | `label-position` | Position of the label for the Text Field.   | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
-| `max`           | `max`            | Max allowed value for input type number     | `number \| string`                    | `undefined`  |
-| `maxLength`     | `max-length`     | Max length of input                         | `number`                              | `undefined`  |
-| `min`           | `min`            | Min allowed value for input type number     | `number \| string`                    | `undefined`  |
-| `modeVariant`   | `mode-variant`   | Mode variant of the Text Field              | `"primary" \| "secondary"`            | `null`       |
-| `name`          | `name`           | Name property                               | `string`                              | `''`         |
-| `noMinWidth`    | `no-min-width`   | Unset minimum width of 208px.               | `boolean`                             | `false`      |
-| `placeholder`   | `placeholder`    | Placeholder text                            | `string`                              | `''`         |
-| `readOnly`      | `read-only`      | Set input in readonly state                 | `boolean`                             | `false`      |
-| `size`          | `size`           | Size of the input                           | `"lg" \| "md" \| "sm"`                | `'lg'`       |
-| `state`         | `state`          | Error state of input                        | `"default" \| "error" \| "success"`   | `'default'`  |
-| `type`          | `type`           | Which input type, text, password or similar | `"number" \| "password" \| "text"`    | `'text'`     |
-| `value`         | `value`          | Value of the input text                     | `string`                              | `''`         |
+| Property        | Attribute        | Description                                                 | Type                                  | Default      |
+| --------------- | ---------------- | ----------------------------------------------------------- | ------------------------------------- | ------------ |
+| `autofocus`     | `autofocus`      | Autofocus for input                                         | `boolean`                             | `false`      |
+| `disabled`      | `disabled`       | Set input in disabled state                                 | `boolean`                             | `false`      |
+| `helper`        | `helper`         | Helper text                                                 | `string`                              | `undefined`  |
+| `label`         | `label`          | Label text                                                  | `string`                              | `''`         |
+| `labelPosition` | `label-position` | Position of the label for the Text Field.                   | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
+| `max`           | `max`            | Max allowed value for input type number                     | `number \| string`                    | `undefined`  |
+| `maxLength`     | `max-length`     | Max length of input                                         | `number`                              | `undefined`  |
+| `min`           | `min`            | Min allowed value for input type number                     | `number \| string`                    | `undefined`  |
+| `modeVariant`   | `mode-variant`   | Mode variant of the Text Field                              | `"primary" \| "secondary"`            | `null`       |
+| `name`          | `name`           | Name property                                               | `string`                              | `''`         |
+| `noMinWidth`    | `no-min-width`   | Unset minimum width of 208px.                               | `boolean`                             | `false`      |
+| `placeholder`   | `placeholder`    | Placeholder text                                            | `string`                              | `''`         |
+| `readOnly`      | `read-only`      | Set input in readonly state. Hides the suffix slot if true. | `boolean`                             | `false`      |
+| `size`          | `size`           | Size of the input                                           | `"lg" \| "md" \| "sm"`                | `'lg'`       |
+| `state`         | `state`          | Error state of input                                        | `"default" \| "error" \| "success"`   | `'default'`  |
+| `type`          | `type`           | Which input type, text, password or similar                 | `"number" \| "password" \| "text"`    | `'text'`     |
+| `value`         | `value`          | Value of the input text                                     | `string`                              | `''`         |
 
 
 ## Events
@@ -40,10 +40,10 @@
 
 ## Slots
 
-| Slot       | Description                           |
-| ---------- | ------------------------------------- |
-| `"prefix"` | Slot for the prefix in the Text Field |
-| `"suffix"` | Slot for the suffix in the Text Field |
+| Slot       | Description                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------- |
+| `"prefix"` | Slot for the prefix in the component.                                                       |
+| `"suffix"` | Slot for the suffix in the component. Suffix is hidden when the input is in readonly state. |
 
 
 ## Dependencies

--- a/packages/core/src/components/text-field/test/read-only-with-suffix/index.html
+++ b/packages/core/src/components/text-field/test/read-only-with-suffix/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+
+<head>
+    <meta charset="UTF-8" />
+    <title>Text Field - Read Only with Suffix</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
+    <link rel="stylesheet" href="../../../../../dist/tegel/tegel.css" />
+    <script type="module">
+        import { defineCustomElements } from '../../../../../loader/index.es2017.js';
+        defineCustomElements();
+    </script>
+</head>
+
+<body>
+    <tds-text-field label="Readonly with suffix" label-position="no label" read-only placeholder="Readonly with suffix">
+        <tds-icon slot="suffix" name="truck" size="20px"></tds-icon>
+    </tds-text-field>
+</body>
+
+</html>

--- a/packages/core/src/components/text-field/test/read-only-with-suffix/text-field.e2e.ts
+++ b/packages/core/src/components/text-field/test/read-only-with-suffix/text-field.e2e.ts
@@ -1,0 +1,12 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+
+const componentTestPath = 'src/components/text-field/test/read-only-with-suffix/index.html';
+
+test.describe('TdsTextField - readOnly prop effect', () => {
+  test('should hide the suffix icon when readOnly is true', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const suffixIcon = await page.locator('.text-field-slot-wrap-suffix');
+    await expect(suffixIcon).toBeHidden();
+  });
+});

--- a/packages/core/src/components/text-field/text-field.scss
+++ b/packages/core/src/components/text-field/text-field.scss
@@ -289,7 +289,8 @@
   display: none;
   position: absolute;
   right: 18px;
-  top: 18px;
+  top: 50%;
+  transform: translateY(-50%);
   color: var(--tds-text-field-icon-read-only-label-color);
 
   &-label {

--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -26,10 +26,10 @@ export class TdsTextField {
   /** Label text */
   @Prop() label: string = '';
 
-   /** Min allowed value for input type number */
+  /** Min allowed value for input type number */
   @Prop() min: string | number;
 
-   /** Max allowed value for input type number */
+  /** Max allowed value for input type number */
   @Prop() max: string | number;
 
   /** Helper text */
@@ -135,26 +135,22 @@ export class TdsTextField {
     const usesSuffixSlot = hasSlot('suffix', this.host);
     return (
       <div
-        class={`
-        ${this.noMinWidth ? 'form-text-field-nomin' : ''}
-        ${
-          this.focusInput && !this.disabled
-            ? 'form-text-field text-field-focus'
-            : ' form-text-field'
-        }
-        ${this.value ? 'text-field-data' : ''}
-        ${
-          this.labelPosition === 'inside' && this.size !== 'sm'
-            ? 'text-field-container-label-inside'
-            : ''
-        }
-        ${this.disabled ? 'form-text-field-disabled' : ''}
-        ${this.readOnly ? 'form-text-field-readonly' : ''}
-        ${this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''}
-        ${this.size === 'md' ? 'form-text-field-md' : ''}
-        ${this.size === 'sm' ? 'form-text-field-sm' : ''}
-        ${this.state === 'error' || this.state === 'success' ? `form-text-field-${this.state}` : ''}
-        `}
+        class={{
+          'form-text-field-nomin': this.noMinWidth,
+          'form-text-field': !this.focusInput || this.disabled,
+          'text-field-focus': this.focusInput && !this.disabled,
+          'text-field-data': this.value !== '' && this.value !== null,
+          'text-field-container-label-inside':
+            this.labelPosition === 'inside' && this.size !== 'sm',
+          'form-text-field-disabled': this.disabled,
+          'form-text-field-readonly': this.readOnly,
+          'tds-mode-variant-primary': this.modeVariant === 'primary',
+          'tds-mode-variant-secondary': this.modeVariant === 'secondary',
+          'form-text-field-md': this.size === 'md',
+          'form-text-field-sm': this.size === 'sm',
+          'form-text-field-error': this.state === 'error',
+          'form-text-field-success': this.state === 'success',
+        }}
       >
         {this.labelPosition === 'outside' && (
           <div class="text-field-label-outside">
@@ -163,7 +159,14 @@ export class TdsTextField {
         )}
         <div onClick={() => this.textInput.focus()} class="text-field-container">
           {usesPrefixSlot && (
-            <div class={`text-field-slot-wrap-prefix text-field-${this.state}`}>
+            <div
+              class={{
+                'text-field-slot-wrap-prefix': true,
+                'text-field-error': this.state === 'error',
+                'text-field-success': this.state === 'success',
+                'text-field-default': this.state === 'default',
+              }}
+            >
               <slot name="prefix" />
             </div>
           )}
@@ -171,7 +174,12 @@ export class TdsTextField {
           <div class="text-field-input-container">
             <input
               ref={(inputEl) => (this.textInput = inputEl as HTMLInputElement)}
-              class={`text-field-input text-field-input-${this.size}`}
+              class={{
+                'text-field-input': true,
+                'text-field-input-sm': this.size === 'sm',
+                'text-field-input-md': this.size === 'md',
+                'text-field-input-lg': this.size === 'lg',
+              }}
               type={this.type}
               disabled={this.disabled}
               readonly={this.readOnly}
@@ -203,7 +211,15 @@ export class TdsTextField {
           <div class="text-field-bar"></div>
 
           {usesSuffixSlot && (
-            <div class={`text-field-slot-wrap-suffix text-field-${this.state}`}>
+            <div
+              class={{
+                'text-field-slot-wrap-suffix': true,
+                'text-field-error': this.state === 'error',
+                'text-field-success': this.state === 'success',
+                'text-field-default': this.state === 'default',
+                'tds-u-display-none': this.readOnly,
+              }}
+            >
               <slot name="suffix" />
             </div>
           )}

--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -2,8 +2,8 @@ import { Component, h, State, Prop, Event, EventEmitter, Element } from '@stenci
 import hasSlot from '../../utils/hasSlot';
 
 /**
- * @slot prefix - Slot for the prefix in the Text Field
- * @slot suffix - Slot for the suffix in the Text Field
+ * @slot prefix - Slot for the prefix in the component.
+ * @slot suffix - Slot for the suffix in the component. Suffix is hidden when the input is in readonly state.
  */
 @Component({
   tag: 'tds-text-field',
@@ -44,7 +44,7 @@ export class TdsTextField {
   /** Set input in disabled state */
   @Prop() disabled: boolean = false;
 
-  /** Set input in readonly state */
+  /** Set input in readonly state. Hides the suffix slot if true. */
   @Prop() readOnly: boolean = false;
 
   /** Size of the input */


### PR DESCRIPTION
**Describe pull-request**  
When using the suffix icon and read-only, the read-only icon takes priority, and the suffix icon remains hidden. 

**Solving issue**  
Fixes: [CDEP-3182](https://tegel.atlassian.net/browse/CDEP-3182)
https://github.com/scania-digital-design-system/tegel/issues/522

**How to test**  
1. Add suffix icon
2. Turn on "read-only"
3. Suffx icon should be hidden
4. PS. Please check that other controls like size, mode-variant, and state are working too. I had to change from using string literals to using an object way of writing CSS as string literals had some hiccups when changing values in runtime. 

**Checklist before submission**
- [x] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [x] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events




[CDEP-3182]: https://tegel.atlassian.net/browse/CDEP-3182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ