### PR TITLE
fix(table-body-cell): Behavior and additional `text-align` values in `tds-header-cell` and `tds-body-cell`

### DIFF
--- a/packages/core/src/components/table/table-body-cell/readme.md
+++ b/packages/core/src/components/table/table-body-cell/readme.md
@@ -7,12 +7,13 @@
 
 ## Properties
 
-| Property         | Attribute         | Description                                                                                                         | Type               | Default     |
-| ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------ | ----------- |
-| `cellKey`        | `cell-key`        | Passing the same cell key for all body cells which is used in head cell enables features of text align and hovering | `any`             | `undefined` |
-| `cellValue`      | `cell-value`      | Value that will be presented as text inside a cell                                                                  | `number \| string` | `undefined` |
-| `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                            | `boolean`          | `false`     |
-| `textAlign`      | `text-align`      | Setting for text align, default is "left". Other accepted values are "start", "right", "end" or "center". | `string`         | `undefined`       |
+| Property         | Attribute         | Description                                                                                                         | Type                                                | Default     |
+| ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------- |
+| `cellKey`        | `cell-key`        | Passing the same cell key for all body cells which is used in head cell enables features of text align and hovering | `any`                                               | `undefined` |
+| `cellValue`      | `cell-value`      | Value that will be presented as text inside a cell                                                                  | `number \| string`                                  | `undefined` |
+| `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                            | `boolean`                                           | `false`     |
+| `textAlign`      | `text-align`      | Setting for text align, no default value. Other accepted values are "left", "start", "right", "end" or "center".    | `"center" \| "end" \| "left" \| "right" \| "start"` | `undefined` |
+
 
 ## Slots
 

--- a/packages/core/src/components/table/table-body-cell/readme.md
+++ b/packages/core/src/components/table/table-body-cell/readme.md
@@ -12,7 +12,7 @@
 | `cellKey`        | `cell-key`        | Passing the same cell key for all body cells which is used in head cell enables features of text align and hovering | `any`             | `undefined` |
 | `cellValue`      | `cell-value`      | Value that will be presented as text inside a cell                                                                  | `number \| string` | `undefined` |
 | `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                            | `boolean`          | `false`     |
-| `textAlign`      | `text-align`      | Setting for text align, default is "left". Other accepted values are "start", "right" or "end". | `string`         | `undefined`       |
+| `textAlign`      | `text-align`      | Setting for text align, default is "left". Other accepted values are "start", "right", "end" or "center". | `string`         | `undefined`       |
 
 ## Slots
 

--- a/packages/core/src/components/table/table-body-cell/readme.md
+++ b/packages/core/src/components/table/table-body-cell/readme.md
@@ -12,7 +12,7 @@
 | `cellKey`        | `cell-key`        | Passing the same cell key for all body cells which is used in head cell enables features of text align and hovering | `any`                                               | `undefined` |
 | `cellValue`      | `cell-value`      | Value that will be presented as text inside a cell                                                                  | `number \| string`                                  | `undefined` |
 | `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                            | `boolean`                                           | `false`     |
-| `textAlign`      | `text-align`      | Setting for text align, no default value. Other accepted values are "left", "start", "right", "end" or "center".    | `"center" \| "end" \| "left" \| "right" \| "start"` | `undefined` |
+| `textAlign`      | `text-align`      | Setting for text align, default value "left". Other accepted values are "left", "start", "right", "end" or "center".    | `"center" \| "end" \| "left" \| "right" \| "start"` | `left` |
 
 
 ## Slots

--- a/packages/core/src/components/table/table-body-cell/readme.md
+++ b/packages/core/src/components/table/table-body-cell/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property         | Attribute         | Description                                                                                                         | Type                                                | Default     |
-| ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------- |
-| `cellKey`        | `cell-key`        | Passing the same cell key for all body cells which is used in head cell enables features of text align and hovering | `any`                                               | `undefined` |
-| `cellValue`      | `cell-value`      | Value that will be presented as text inside a cell                                                                  | `number \| string`                                  | `undefined` |
-| `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                            | `boolean`                                           | `false`     |
-| `textAlign`      | `text-align`      | Setting for text align, default value "left". Other accepted values are "left", "start", "right", "end" or "center".    | `"center" \| "end" \| "left" \| "right" \| "start"` | `left` |
+| Property         | Attribute         | Description                                                                                                          | Type                                                | Default     |
+| ---------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------- |
+| `cellKey`        | `cell-key`        | Passing the same cell key for all body cells which is used in head cell enables features of text align and hovering  | `any`                                               | `undefined` |
+| `cellValue`      | `cell-value`      | Value that will be presented as text inside a cell                                                                   | `number \| string`                                  | `undefined` |
+| `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                             | `boolean`                                           | `false`     |
+| `textAlign`      | `text-align`      | Setting for text align, default value "left". Other accepted values are "left", "start", "right", "end" or "center". | `"center" \| "end" \| "left" \| "right" \| "start"` | `'left'`    |
 
 
 ## Slots

--- a/packages/core/src/components/table/table-body-cell/readme.md
+++ b/packages/core/src/components/table/table-body-cell/readme.md
@@ -9,10 +9,10 @@
 
 | Property         | Attribute         | Description                                                                                                         | Type               | Default     |
 | ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------ | ----------- |
-| `cellKey`        | `cell-key`        | Passing the same cell key for all body cells which is used in head cell enables features of text align and hovering | `any`              | `undefined` |
+| `cellKey`        | `cell-key`        | Passing the same cell key for all body cells which is used in head cell enables features of text align and hovering | `any`             | `undefined` |
 | `cellValue`      | `cell-value`      | Value that will be presented as text inside a cell                                                                  | `number \| string` | `undefined` |
 | `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                            | `boolean`          | `false`     |
-
+| `textAlign`      | `text-align`      | Setting for text align, default is "left". Other accepted values are "start", "right" or "end". | `string`         | `undefined`       |
 
 ## Slots
 

--- a/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
+++ b/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
@@ -24,8 +24,8 @@ export class TdsTableBodyCell {
   /** Disables internal padding. Useful when passing other components to cell. */
   @Prop({ reflect: true }) disablePadding: boolean = false;
 
-  /** Setting for text align, no default value. Other accepted values are "left", "start", "right", "end" or "center". */
-  @Prop({ reflect: true }) textAlign?: 'left' | 'start' | 'right' | 'end' | 'center';
+  /** Setting for text align, default value "left". Other accepted values are "left", "start", "right", "end" or "center". */
+  @Prop({ reflect: true }) textAlign: 'left' | 'start' | 'right' | 'end' | 'center' = 'left';
 
   @State() textAlignState: string;
 

--- a/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
+++ b/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
@@ -79,7 +79,9 @@ export class TdsTableBodyCell {
         if (this.textAlign) {
           this.textAlignState = this.textAlign;
         } else {
-          this.textAlignState = ['left', 'start', 'right', 'end'].includes(receivedTextAlign)
+          this.textAlignState = ['left', 'start', 'center', 'right', 'end'].includes(
+            receivedTextAlign,
+          )
             ? receivedTextAlign
             : 'left';
         }

--- a/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
+++ b/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
@@ -24,8 +24,8 @@ export class TdsTableBodyCell {
   /** Disables internal padding. Useful when passing other components to cell. */
   @Prop({ reflect: true }) disablePadding: boolean = false;
 
-  /** Setting for text align, default is "left". Other accepted values are "start", "right" or "end". */
-  @Prop({ reflect: true }) textAlign: 'left' | 'start' | 'right' | 'end' | 'center' = 'left';
+  /** Setting for text align, no default value. Other accepted values are "left", "start", "right", "end" or "center". */
+  @Prop({ reflect: true }) textAlign?: 'left' | 'start' | 'right' | 'end' | 'center';
 
   @State() textAlignState: string;
 
@@ -76,9 +76,13 @@ export class TdsTableBodyCell {
 
     if (this.tableId === receivedID) {
       if (this.cellKey === receivedKey) {
-        this.textAlignState = ['left', 'start', 'right', 'end'].includes(receivedTextAlign)
-          ? receivedTextAlign
-          : 'left';
+        if (this.textAlign) {
+          this.textAlignState = this.textAlign;
+        } else {
+          this.textAlignState = ['left', 'start', 'right', 'end'].includes(receivedTextAlign)
+            ? receivedTextAlign
+            : 'left';
+        }
       }
     }
   }

--- a/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
+++ b/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
@@ -25,7 +25,7 @@ export class TdsTableBodyCell {
   @Prop({ reflect: true }) disablePadding: boolean = false;
 
   /** Setting for text align, default is "left". Other accepted values are "start", "right" or "end". */
-  @Prop({ reflect: true }) textAlign: 'left' | 'start' | 'right' | 'end' = 'left';
+  @Prop({ reflect: true }) textAlign: 'left' | 'start' | 'right' | 'end' | 'center' = 'left';
 
   @State() textAlignState: string;
 

--- a/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
+++ b/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
@@ -24,6 +24,9 @@ export class TdsTableBodyCell {
   /** Disables internal padding. Useful when passing other components to cell. */
   @Prop({ reflect: true }) disablePadding: boolean = false;
 
+  /** Setting for text align, default is "left". Other accepted values are "start", "right" or "end". */
+  @Prop({ reflect: true }) textAlign: 'left' | 'start' | 'right' | 'end' = 'left';
+
   @State() textAlignState: string;
 
   @State() activeSorting: boolean = false;
@@ -73,7 +76,9 @@ export class TdsTableBodyCell {
 
     if (this.tableId === receivedID) {
       if (this.cellKey === receivedKey) {
-        this.textAlignState = receivedTextAlign;
+        this.textAlignState = ['left', 'start', 'right', 'end'].includes(receivedTextAlign)
+          ? receivedTextAlign
+          : 'left';
       }
     }
   }

--- a/packages/core/src/components/table/table-component-basic.stories.tsx
+++ b/packages/core/src/components/table/table-component-basic.stories.tsx
@@ -44,7 +44,10 @@ export default {
       control: {
         type: 'radio',
       },
-      options: [null, 'left', 'start', 'right', 'end', 'center'],
+      options: ['left', 'start', 'right', 'end', 'center'],
+      table: {
+        defaultValue: { summary: 'center' },
+      },
     },
     cellTextAlignment: {
       name: 'Text alignment in cells',
@@ -52,7 +55,10 @@ export default {
       control: {
         type: 'radio',
       },
-      options: [null, 'left', 'start', 'right', 'end', 'center'],
+      options: ['left', 'start', 'right', 'end', 'center'],
+      table: {
+        defaultValue: { summary: 'left' },
+      },
     },
     compactDesign: {
       name: 'Compact design',
@@ -143,8 +149,8 @@ export default {
   },
   args: {
     modeVariant: 'Inherit from parent',
-    headerTextAlignment: null,
-    cellTextAlignment: null,
+    headerTextAlignment: 'center',
+    cellTextAlignment: 'left',
     compactDesign: false,
     responsiveDesign: false,
     disablePadding: false,

--- a/packages/core/src/components/table/table-component-basic.stories.tsx
+++ b/packages/core/src/components/table/table-component-basic.stories.tsx
@@ -196,86 +196,86 @@ const BasicTemplate = ({
           <tds-table-body-row>
               <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
               <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
               <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
               <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
               <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
               <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
               <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" ${
     cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-  }"></tds-body-cell>
+  }></tds-body-cell>
           </tds-table-body-row>
       </tds-table-body>
   </tds-table>`);

--- a/packages/core/src/components/table/table-component-basic.stories.tsx
+++ b/packages/core/src/components/table/table-component-basic.stories.tsx
@@ -38,6 +38,22 @@ export default {
         defaultValue: { summary: 'Inherit from parent' },
       },
     },
+    headerTextAlignment: {
+      name: 'Text alignment in headers',
+      description: 'Content alignment inside headers',
+      control: {
+        type: 'radio',
+      },
+      options: [null, 'left', 'start', 'right', 'end', 'center'],
+    },
+    cellTextAlignment: {
+      name: 'Text alignment in cells',
+      description: 'Content alignment inside body cells',
+      control: {
+        type: 'radio',
+      },
+      options: [null, 'left', 'start', 'right', 'end', 'center'],
+    },
     compactDesign: {
       name: 'Compact design',
       description: 'Enables compact design of the Table, rows with less height.',
@@ -127,6 +143,8 @@ export default {
   },
   args: {
     modeVariant: 'Inherit from parent',
+    headerTextAlignment: null,
+    cellTextAlignment: null,
     compactDesign: false,
     responsiveDesign: false,
     disablePadding: false,
@@ -141,6 +159,8 @@ export default {
 
 const BasicTemplate = ({
   modeVariant,
+  headerTextAlignment,
+  cellTextAlignment,
   compactDesign,
   responsiveDesign,
   disablePadding,
@@ -161,53 +181,101 @@ const BasicTemplate = ({
       <tds-table-header>
           <tds-header-cell cell-key='truck' cell-value='Truck type' ${
             column1Width ? `custom-width="${column1Width}"` : ''
-          }></tds-header-cell>
+          } text-align="${headerTextAlignment}"></tds-header-cell>
           <tds-header-cell cell-key='driver' cell-value='Driver name' ${
             column2Width ? `custom-width="${column2Width}"` : ''
-          }></tds-header-cell>
-          <tds-header-cell cell-key='country' cell-value='Country' text-align='center' ${
+          } text-align="${headerTextAlignment}"></tds-header-cell>
+          <tds-header-cell cell-key='country' cell-value='Country' ${
             column3Width ? `custom-width="${column3Width}"` : ''
-          }></tds-header-cell>
-          <tds-header-cell cell-key='mileage' cell-value='Mileage' text-align='right' ${
+          } text-align="${headerTextAlignment}"></tds-header-cell>
+          <tds-header-cell cell-key='mileage' cell-value='Mileage' ${
             column4Width ? `custom-width="${column4Width}"` : ''
-          }></tds-header-cell>
+          } text-align="${headerTextAlignment}"></tds-header-cell>
       </tds-table-header>
       <tds-table-body>
           <tds-table-body-row>
-              <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
-              <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
-              <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" text-align="center"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
-              <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" text-align="left"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
-              <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" text-align="center"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
-              <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" text-align="${
+    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+  }"></tds-body-cell>
           </tds-table-body-row>
       </tds-table-body>
   </tds-table>`);

--- a/packages/core/src/components/table/table-component-basic.stories.tsx
+++ b/packages/core/src/components/table/table-component-basic.stories.tsx
@@ -46,7 +46,7 @@ export default {
       },
       options: ['left', 'start', 'right', 'end', 'center'],
       table: {
-        defaultValue: { summary: 'center' },
+        defaultValue: { summary: 'left' },
       },
     },
     cellTextAlignment: {

--- a/packages/core/src/components/table/table-component-basic.stories.tsx
+++ b/packages/core/src/components/table/table-component-basic.stories.tsx
@@ -194,87 +194,87 @@ const BasicTemplate = ({
       </tds-table-header>
       <tds-table-body>
           <tds-table-body-row>
-              <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
-  }"></tds-body-cell>
-          </tds-table-body-row>
-          <tds-table-body-row>
-              <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
-  }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
-  }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
-  }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
-              <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
-  }"></tds-body-cell>
-          </tds-table-body-row>
-          <tds-table-body-row>
-              <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
-  }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
-  }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
-  }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
-              <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
-              <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" text-align="${
-    cellTextAlignment ? `text-align="${cellTextAlignment}` : ''
+              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+  }"></tds-body-cell>
+          </tds-table-body-row>
+          <tds-table-body-row>
+              <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+  }"></tds-body-cell>
+          </tds-table-body-row>
+          <tds-table-body-row>
+              <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+  }"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" ${
+    cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
   }"></tds-body-cell>
           </tds-table-body-row>
       </tds-table-body>

--- a/packages/core/src/components/table/table-component-basic.stories.tsx
+++ b/packages/core/src/components/table/table-component-basic.stories.tsx
@@ -149,7 +149,7 @@ export default {
   },
   args: {
     modeVariant: 'Inherit from parent',
-    headerTextAlignment: 'center',
+    headerTextAlignment: 'left',
     cellTextAlignment: 'left',
     compactDesign: false,
     responsiveDesign: false,

--- a/packages/core/src/components/table/table-component-basic.stories.tsx
+++ b/packages/core/src/components/table/table-component-basic.stories.tsx
@@ -165,7 +165,7 @@ const BasicTemplate = ({
           <tds-header-cell cell-key='driver' cell-value='Driver name' ${
             column2Width ? `custom-width="${column2Width}"` : ''
           }></tds-header-cell>
-          <tds-header-cell cell-key='country' cell-value='Country' ${
+          <tds-header-cell cell-key='country' cell-value='Country' text-align='center' ${
             column3Width ? `custom-width="${column3Width}"` : ''
           }></tds-header-cell>
           <tds-header-cell cell-key='mileage' cell-value='Mileage' text-align='right' ${

--- a/packages/core/src/components/table/table-component-basic.stories.tsx
+++ b/packages/core/src/components/table/table-component-basic.stories.tsx
@@ -189,19 +189,19 @@ const BasicTemplate = ({
               <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}"></tds-body-cell>
               <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}"></tds-body-cell>
               <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" text-align="center"></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
               <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}"></tds-body-cell>
               <tds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${disablePadding}"></tds-body-cell>
               <tds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${disablePadding}" text-align="left"></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
               <tds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${disablePadding}"></tds-body-cell>
               <tds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${disablePadding}"></tds-body-cell>
               <tds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${disablePadding}"></tds-body-cell>
-              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}"></tds-body-cell>
+              <tds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${disablePadding}" text-align="center"></tds-body-cell>
           </tds-table-body-row>
           <tds-table-body-row>
               <tds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${disablePadding}"></tds-body-cell>

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -13,7 +13,7 @@
 | `cellValue`   | `cell-value`   | Text that displays in column cell                                                    | `string`  | `undefined` |
 | `customWidth` | `custom-width` | In case noMinWidth is set, the user has to specify the width value for each column.  | `string`  | `undefined` |
 | `sortable`    | `sortable`     | Enables sorting on that column                                                       | `boolean` | `false`     |
-| `textAlign`   | `text-align`   | Setting for text align, default is left. Other accepted values are "right" or "end". | `string`  | `undefined` |
+| `textAlign`   | `text-align`   | Setting for text align, default is "left". Other accepted values are "start", "right", "end" or "center". | `string`  | `undefined` |
 
 
 ## Events

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -7,13 +7,13 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                                                                               | Type                                                | Default     |
-| ------------- | -------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------- |
-| `cellKey`     | `cell-key`     | The value of column key, usually comes from JSON, needed for sorting                                      | `string`                                            | `undefined` |
-| `cellValue`   | `cell-value`   | Text that displays in column cell                                                                         | `string`                                            | `undefined` |
-| `customWidth` | `custom-width` | In case noMinWidth is set, the user has to specify the width value for each column.                       | `string`                                            | `undefined` |
-| `sortable`    | `sortable`     | Enables sorting on that column                                                                            | `boolean`                                           | `false`     |
-| `textAlign`   | `text-align`   | Setting for text align, default is "center". Other accepted values are "left", "start", "right" or "end". | `"center" \| "end" \| "left" \| "right" \| "start"` | `'center'`  |
+| Property      | Attribute      | Description                                                                                             | Type                                                | Default     |
+| ------------- | -------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------- |
+| `cellKey`     | `cell-key`     | The value of column key, usually comes from JSON, needed for sorting                                    | `string`                                            | `undefined` |
+| `cellValue`   | `cell-value`   | Text that displays in column cell                                                                       | `string`                                            | `undefined` |
+| `customWidth` | `custom-width` | In case noMinWidth is set, the user has to specify the width value for each column.                     | `string`                                            | `undefined` |
+| `sortable`    | `sortable`     | Enables sorting on that column                                                                          | `boolean`                                           | `false`     |
+| `textAlign`   | `text-align`   | Setting for text align, default is "left". Other accepted values are "left", "start", "right" or "end". | `"center" \| "end" \| "left" \| "right" \| "start"` | `'left'`    |
 
 
 ## Events

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -7,20 +7,20 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                                                          | Type      | Default     |
-| ------------- | -------------- | ------------------------------------------------------------------------------------ | --------- | ----------- |
-| `cellKey`     | `cell-key`     | The value of column key, usually comes from JSON, needed for sorting                 | `string`  | `undefined` |
-| `cellValue`   | `cell-value`   | Text that displays in column cell                                                    | `string`  | `undefined` |
-| `customWidth` | `custom-width` | In case noMinWidth is set, the user has to specify the width value for each column.  | `string`  | `undefined` |
-| `sortable`    | `sortable`     | Enables sorting on that column                                                       | `boolean` | `false`     |
-| `textAlign`   | `text-align`   | Setting for text align, default is "left". Other accepted values are "start", "right", "end" or "center". | `string`  | `undefined` |
+| Property      | Attribute      | Description                                                                                               | Type                                                | Default     |
+| ------------- | -------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------- |
+| `cellKey`     | `cell-key`     | The value of column key, usually comes from JSON, needed for sorting                                      | `string`                                            | `undefined` |
+| `cellValue`   | `cell-value`   | Text that displays in column cell                                                                         | `string`                                            | `undefined` |
+| `customWidth` | `custom-width` | In case noMinWidth is set, the user has to specify the width value for each column.                       | `string`                                            | `undefined` |
+| `sortable`    | `sortable`     | Enables sorting on that column                                                                            | `boolean`                                           | `false`     |
+| `textAlign`   | `text-align`   | Setting for text align, default is "center". Other accepted values are "left", "start", "right" or "end". | `"center" \| "end" \| "left" \| "right" \| "start"` | `'center'`  |
 
 
 ## Events
 
 | Event     | Description                                                                                                                                              | Type                                                                                      |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "desc" \| "asc"; }>` |
+| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
 
 
 ## Slots

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -20,7 +20,7 @@
 
 | Event     | Description                                                                                                                                              | Type                                                                                      |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
+| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to implement custom-sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "desc" \| "asc"; }>` |
 
 
 ## Slots

--- a/packages/core/src/components/table/table-header-cell/table-header-cell.scss
+++ b/packages/core/src/components/table/table-header-cell/table-header-cell.scss
@@ -74,14 +74,6 @@
   }
 }
 
-:host(.tds-table__header-cell--right-align) {
-  .tds-table__header-button {
-    text-align: right;
-    justify-content: end;
-    flex-direction: row-reverse;
-  }
-}
-
 :host(.tds-table__header-cell--is-sorted) {
   .tds-table__header-button {
     background-color: var(--tds-table-header-btn-background);

--- a/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
+++ b/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
@@ -41,7 +41,7 @@ export class TdsTableHeaderCell {
   /** Enables sorting on that column */
   @Prop() sortable: boolean = false;
 
-  /** Setting for text align, default is "center". Other accepted values are "left", "start", "right" or "end". */
+  /** Setting for text align, default is "left". Other accepted values are "left", "start", "right" or "end". */
   @Prop({ reflect: true }) textAlign: 'left' | 'start' | 'right' | 'end' | 'center' = 'left';
 
   @State() textAlignState: string;

--- a/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
+++ b/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
@@ -204,8 +204,12 @@ export class TdsTableHeaderCell {
   headerCellContent = () => {
     if (this.sortable) {
       return (
-        <button class="tds-table__header-button" onClick={() => this.sortButtonClick()}>
-          <span class="tds-table__header-button-text" style={{ textAlign: this.textAlignState }}>
+        <button
+          class="tds-table__header-button"
+          onClick={() => this.sortButtonClick()}
+          style={{ justifyContent: this.textAlignState }}
+        >
+          <span class="tds-table__header-button-text">
             {this.cellValue}
             <slot />
           </span>
@@ -277,7 +281,6 @@ export class TdsTableHeaderCell {
           'tds-table__header-cell--sortable': this.sortable,
           'tds-table__header-cell--is-sorted': this.sortedByMyKey,
           'tds-table__header-cell--custom-width': this.customWidth !== '',
-          'tds-table__header-cell--right-align': this.textAlignState === 'right',
           'tds-table--compact': this.compactDesign,
           'tds-table--divider': this.verticalDividers,
           'tds-table--no-min-width': this.noMinWidth,

--- a/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
+++ b/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
@@ -42,7 +42,7 @@ export class TdsTableHeaderCell {
   @Prop() sortable: boolean = false;
 
   /** Setting for text align, default is "center". Other accepted values are "left", "start", "right" or "end". */
-  @Prop({ reflect: true }) textAlign: 'left' | 'start' | 'right' | 'end' | 'center' = 'center';
+  @Prop({ reflect: true }) textAlign: 'left' | 'start' | 'right' | 'end' | 'center' = 'left';
 
   @State() textAlignState: string;
 

--- a/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
+++ b/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
@@ -41,8 +41,8 @@ export class TdsTableHeaderCell {
   /** Enables sorting on that column */
   @Prop() sortable: boolean = false;
 
-  /** Setting for text align, default is left. Other accepted values are "right" or "end". */
-  @Prop({ reflect: true }) textAlign?: string;
+  /** Setting for text align, default is "center". Other accepted values are "left", "start", "right" or "end". */
+  @Prop({ reflect: true }) textAlign: 'left' | 'start' | 'right' | 'end' | 'center' = 'center';
 
   @State() textAlignState: string;
 
@@ -162,12 +162,11 @@ export class TdsTableHeaderCell {
   }
 
   componentWillRender() {
-    // enable only right or left text align
-    if (this.textAlign === 'right' || this.textAlign === 'end') {
-      this.textAlignState = 'right';
-    } else {
-      this.textAlignState = 'left';
-    }
+    // if text alignment matches any of the acceptable values, use it. Otherwise, set "left" as default
+    this.textAlignState = ['left', 'start', 'right', 'end', 'center'].includes(this.textAlign)
+      ? this.textAlign
+      : 'left';
+
     // To enable body cells text align per rules set in head cell
     this.internalTdsTextAlign.emit([this.tableId, this.cellKey, this.textAlignState]);
 


### PR DESCRIPTION
**Describe pull-request**  
Additional `text-align` value for centering content inside `tds-header-cell` and `tds-body-cell` component.

**Solving issue**
Fixes: [548](https://github.com/scania-digital-design-system/tegel/issues/548)

**How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Open StoryBook
2. Navigate to and open folder "Table"
3. Click on "Basic"
4. Examine the behavior of the table cells and the columns. For deeper explanation, open the "Docs"/code.

**Checklist before submission**
- [X] I have added unit tests for my changes (if applicable)
- [X] All existing tests pass
- [X] I have updated the documentation (if applicable)

**Suggested test steps**
- [X] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [X] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [X] Events

**Screenshots**  
Before:
![image](https://github.com/scania-digital-design-system/tegel/assets/163417029/75e6b6cc-c509-4a29-bc9b-91aebdda3464)

After:
![image](https://github.com/scania-digital-design-system/tegel/assets/163417029/aa1f6458-ebf3-4216-b48a-64f9e9e34410)
