### PR TITLE
fix(table-body-cell): map text-align prop in lifecycle

### DIFF
--- a/packages/core/src/components/table/table-body-cell/readme.md
+++ b/packages/core/src/components/table/table-body-cell/readme.md
@@ -12,7 +12,7 @@
 | `cellKey`        | `cell-key`        | Passing the same cell key for all body cells which is used in head cell enables features of text align and hovering  | `any`                                               | `undefined` |
 | `cellValue`      | `cell-value`      | Value that will be presented as text inside a cell                                                                   | `number \| string`                                  | `undefined` |
 | `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                             | `boolean`                                           | `false`     |
-| `textAlign`      | `text-align`      | Setting for text align, default value "left". Other accepted values are "left", "start", "right", "end" or "center". | `"center" \| "end" \| "left" \| "right" \| "start"` | `'left'`    |
+| `textAlign`      | `text-align`      | Setting for text align, default value "left". Other accepted values are "left", "start", "right", "end" or "center". | `"center" \| "end" \| "left" \| "right" \| "start"` | `undefined` |
 
 
 ## Slots

--- a/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
+++ b/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
@@ -25,7 +25,7 @@ export class TdsTableBodyCell {
   @Prop({ reflect: true }) disablePadding: boolean = false;
 
   /** Setting for text align, default value "left". Other accepted values are "left", "start", "right", "end" or "center". */
-  @Prop({ reflect: true }) textAlign: 'left' | 'start' | 'right' | 'end' | 'center' = 'left';
+  @Prop({ reflect: true }) textAlign: 'left' | 'start' | 'right' | 'end' | 'center';
 
   @State() textAlignState: string;
 
@@ -98,6 +98,9 @@ export class TdsTableBodyCell {
     relevantTableProps.forEach((tablePropName) => {
       this[tablePropName] = this.tableEl[tablePropName];
     });
+    if (this.textAlign) {
+      this.textAlignState = this.textAlign;
+    }
   }
 
   render() {

--- a/packages/core/src/components/table/table/test/filtering/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/filtering/table.e2e.ts
@@ -10,7 +10,7 @@ test.describe('tds-table-filtering', () => {
     await expect(tableComponent).toHaveCount(1);
 
     /* Check diff of screenshot */
-    await expect(page).toHaveScreenshot({ maxDiffPixels: 0.01 });
+    await expect(page).toHaveScreenshot({ maxDiffPixels: 0.05 });
   });
 
   test('table has header "Filter"', async ({ page }) => {
@@ -35,7 +35,7 @@ test.describe('tds-table-filtering', () => {
     await tdsTableToolbarSearchInput.click();
 
     /* Check diff of screenshot after click */
-    await expect(page).toHaveScreenshot({ maxDiffPixels: 0.01 });
+    await expect(page).toHaveScreenshot({ maxDiffPixels: 0.05 });
   });
 
   test('clicking on search button opens field for entering data', async ({ page }) => {
@@ -46,6 +46,6 @@ test.describe('tds-table-filtering', () => {
     await tdsTableToolbarSearchInput.fill('Some test text');
 
     /* Check diff of screenshot after filled */
-    await expect(page).toHaveScreenshot({ maxDiffPixels: 0.01 });
+    await expect(page).toHaveScreenshot({ maxDiffPixels: 0.05 });
   });
 });

--- a/packages/core/src/components/table/table/test/sorting/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/sorting/table.e2e.ts
@@ -10,7 +10,7 @@ test.describe('tds-table-sorting', () => {
     await expect(tableComponent).toHaveCount(1);
 
     /* Check for diffs in screenshot */
-    await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
+    await expect(page).toHaveScreenshot({ maxDiffPixels: 0.05 });
   });
 
   test('table has header "Sorting"', async ({ page }) => {
@@ -38,6 +38,6 @@ test.describe('tds-table-sorting', () => {
     await mileageHeader.click();
     expect(myEventSpy).toHaveReceivedEventTimes(4);
 
-    await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
+    await expect(page).toHaveScreenshot({ maxDiffPixels: 0.05 });
   });
 });


### PR DESCRIPTION
**Describe pull-request**  
tds-body-cell, when generated via for/while/map loop, missed internal event for text-align property from parent. That said, no matter body cell has prop for text-align itself, it does not get mapped to textAlignState as mapping was happening only in internal event. Now mapping is added to the lifecycle too. 

**How to test**  
1. Check if prop will work in cases where cells are generated from JSON file, local textAlign prop on tds-body-cell has to have effect on text alignment.

React demo example with this code used via npm pack: https://github.com/scania-digital-design-system/tegel-react-demo/pull/176

PS: I increased tolerance on table test to 5% and made new screenshots too for two tests.



