### PR TITLE
fix(table): disable-padding with compact design

### DIFF
--- a/packages/core/src/components/table/table-body-cell/table-body-cell.scss
+++ b/packages/core/src/components/table/table-body-cell/table-body-cell.scss
@@ -16,7 +16,7 @@
 }
 
 :host(.tds-table__body-cell--no-padding) {
-  padding: 0;
+  padding: 0 !important;
 }
 
 :host(.tds-table__body-cell--hover) {

--- a/packages/core/src/components/table/table-body-cell/table-body-cell.scss
+++ b/packages/core/src/components/table/table-body-cell/table-body-cell.scss
@@ -15,10 +15,6 @@
   transition: background-color 200ms ease;
 }
 
-:host(.tds-table__body-cell--no-padding) {
-  padding: 0 !important;
-}
-
 :host(.tds-table__body-cell--hover) {
   background-color: var(--tds-table-body-cell-background-hover);
 }

--- a/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
+++ b/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
@@ -104,6 +104,19 @@ export class TdsTableBodyCell {
   }
 
   render() {
+    let paddingStyle = 'var(--tds-spacing-element-16)'; // Default padding
+
+    if (this.disablePadding) {
+      paddingStyle = '0';
+    } else if (this.compactDesign) {
+      paddingStyle = 'var(--tds-spacing-element-8) var(--tds-spacing-element-16)';
+    }
+
+    const dynamicStyles = {
+      textAlign: this.textAlignState,
+      // Conditionally set padding style
+      padding: paddingStyle,
+    };
     return (
       <Host
         class={{
@@ -112,9 +125,8 @@ export class TdsTableBodyCell {
           'tds-table__compact': this.compactDesign,
           'tds-table--divider': this.verticalDividers,
           'tds-table--no-min-width': this.noMinWidth,
-          'tds-table__body-cell--no-padding': this.disablePadding,
         }}
-        style={{ textAlign: this.textAlignState }}
+        style={dynamicStyles}
       >
         {this.cellValue}
         <slot />

--- a/packages/core/src/components/table/table-header-cell/table-header-cell.scss
+++ b/packages/core/src/components/table/table-header-cell/table-header-cell.scss
@@ -19,7 +19,7 @@
   transition: background-color 200ms ease;
 
   .tds-table__header-text {
-    padding: 0 16px;
+    padding: 8px 16px;
     margin: 0;
   }
 }


### PR DESCRIPTION
**Describe pull-request**  
This PR enables disable-padding to work with compact design instead of the latter overwriting the former. It also sets a top and bottom padding on the Table header text to ensure padding even if the text is very long and breaks into multiple rows.

**Solving issue** 
Fixes: [CDEP-3194](https://tegel.atlassian.net/browse/CDEP-3194) and [CDEP-3215](https://tegel.atlassian.net/browse/CDEP-3215)
https://github.com/scania-digital-design-system/tegel/issues/469
https://github.com/scania-digital-design-system/tegel/issues/557

**How to test**  
1. Go to Storybook link below.
2. Check in Table -> Basic.
3. Enable "Compact design" and "Disable cell padding".
4. Ensure the Table cell padding is disabled _and_ the Table header padding is reduced at the same time.
5. Manipulate the Table header text to be long enough to break into multiple rows.
6. Ensure there is still 8px top and bottom padding on the text.

**Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


[CDEP-3194]: https://tegel.atlassian.net/browse/CDEP-3194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDEP-3215]: https://tegel.atlassian.net/browse/CDEP-3215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ