### PR TITLE
fix(popover-core): close instances of component when another opens

### DIFF
--- a/packages/core/src/components/popover-core/popover-core.tsx
+++ b/packages/core/src/components/popover-core/popover-core.tsx
@@ -12,6 +12,7 @@ import {
 } from '@stencil/core';
 import { createPopper } from '@popperjs/core';
 import type { Placement, Instance } from '@popperjs/core';
+import generateUniqueId from '../../utils/generateUniqueId';
 
 @Component({
   tag: 'tds-popover-core',
@@ -57,14 +58,16 @@ export class TdsPopoverCore {
 
   @State() isShown: boolean = false;
 
+  private uuid: string = generateUniqueId();
+
   /** @internal Show event. */
   @Event({
     eventName: 'internalTdsShow',
     composed: false,
     cancelable: false,
-    bubbles: false,
+    bubbles: true,
   })
-  tdsShow: EventEmitter<{}>;
+  internalTdsShow: EventEmitter<{}>;
 
   /** @internal Close event. */
   @Event({
@@ -73,7 +76,7 @@ export class TdsPopoverCore {
     cancelable: false,
     bubbles: false,
   })
-  tdsClose: EventEmitter<{}>;
+  internalTdsClose: EventEmitter<{}>;
 
   @Listen('click', { target: 'window' })
   onAnyClick(event: MouseEvent) {
@@ -83,6 +86,14 @@ export class TdsPopoverCore {
       if (isClickOutside) {
         this.setIsShown(false);
       }
+    }
+  }
+
+  @Listen('internalTdsShow', { target: 'window' })
+  onTdsShow(event: Event) {
+    const target = event.target as HTMLElement;
+    if (target.id !== `tds-popover-core-${this.uuid}`) {
+      this.setIsShown(false);
     }
   }
 
@@ -117,9 +128,9 @@ export class TdsPopoverCore {
       this.isShown = isShown;
     }
     if (this.isShown) {
-      this.tdsShow.emit();
+      this.internalTdsShow.emit();
     } else {
-      this.tdsClose.emit();
+      this.internalTdsClose.emit();
     }
   }.bind(this);
 
@@ -233,7 +244,7 @@ export class TdsPopoverCore {
     }
 
     return (
-      <Host style={hostStyle}>
+      <Host style={hostStyle} id={`tds-popover-core-${this.uuid}`}>
         <slot></slot>
       </Host>
     );

--- a/packages/core/src/components/popover-menu/popover-menu.stories.tsx
+++ b/packages/core/src/components/popover-menu/popover-menu.stories.tsx
@@ -94,6 +94,7 @@ const Template = ({ menuPosition, icons, fluidWidth }) => {
         display: flex;
         flex-wrap: nowrap;
         align-items: center;
+        gap: 200px;
       }
     </style>
 

--- a/packages/core/src/components/popover-menu/popover-menu.stories.tsx
+++ b/packages/core/src/components/popover-menu/popover-menu.stories.tsx
@@ -137,11 +137,55 @@ const Template = ({ menuPosition, icons, fluidWidth }) => {
         </tds-popover-menu-item>
     </tds-popover-menu>
 
+    <tds-popover-menu
+      id="my-popover-menu2"
+      placement="${menuPosLookup[menuPosition]}"
+      ${fluidWidth ? 'fluid-width' : ''}
+      selector="#my-popover-button2"
+      >
+        <tds-popover-menu-item>
+          <a href="#"> ${icons ? '<tds-icon name="share"></tds-icon>' : ''} Action </a>
+        </tds-popover-menu-item>
+        <tds-divider></tds-divider>
+        <tds-popover-menu-item>
+          <a href="#"> ${icons ? '<tds-icon name="share"></tds-icon>' : ''} ${
+      fluidWidth ? 'The menu width adjusts to the widest word' : 'Action'
+    } </a>
+        </tds-popover-menu-item>
+        <tds-popover-menu-item>
+          <a href="#"> ${icons ? '<tds-icon name="share"></tds-icon>' : ''} Action </a>
+        </tds-popover-menu-item>
+        <tds-popover-menu-item disabled>
+          <button> ${icons ? '<tds-icon name="share"></tds-icon>' : ''} Action </button>
+        </tds-popover-menu-item>
+        <tds-divider></tds-divider>
+        <tds-popover-menu-item>
+          <a href="#"> ${icons ? '<tds-icon name="share"></tds-icon>' : ''} Action </a>
+        </tds-popover-menu-item>
+        <tds-popover-menu-item>
+          <a href="#"> ${icons ? '<tds-icon name="share"></tds-icon>' : ''} Action </a>
+        </tds-popover-menu-item>
+        <tds-popover-menu-item>
+          <a href="#"> ${icons ? '<tds-icon name="share"></tds-icon>' : ''} Action </a>
+        </tds-popover-menu-item>
+        <tds-divider></tds-divider>
+        <tds-popover-menu-item>
+          <a href="#"> ${icons ? '<tds-icon name="share"></tds-icon>' : ''} Action </a>
+        </tds-popover-menu-item>
+        <tds-popover-menu-item>
+          <button> ${icons ? '<tds-icon name="share"></tds-icon>' : ''} Action </button>
+        </tds-popover-menu-item>
+    </tds-popover-menu>
+
     <!-- demo-wrapper code below is for demonstration purposes only -->
     <div class="demo-wrapper">
       <span class="tds-u-mr2">Click icon for Popover Menu</span>
       
       <tds-button aria-label="menu" only-icon id="my-popover-button" type="ghost" size="sm">
+        <tds-icon slot="icon" size="16px" name="kebab"></tds-icon>
+      </tds-button>
+
+         <tds-button aria-label="menu" only-icon id="my-popover-button2" type="ghost" size="sm">
         <tds-icon slot="icon" size="16px" name="kebab"></tds-icon>
       </tds-button>
     </div>


### PR DESCRIPTION
**Describe pull-request**  
Enable automatic closure of other instances of tds-popover-component when new one opens.
Cases like that are in
  - Popover Canvas
  - Popover Menu
  - Tooltip 

**Solving issue**  
Fixes: [CDEP-3105](https://tegel.atlassian.net/browse/CDEP-3105)

**How to test**  
1. Go to the preview link in this PR.
2. Navigate to the Popover Menu story
3. Try to open one and then the second component. The first one should close when a new one opens.

**Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


[CDEP-3105]: https://tegel.atlassian.net/browse/CDEP-3105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ