### PR TITLE
fix(toast): update default header, subheader and link text

### DIFF
--- a/packages/core/src/components/toast/toast.stories.tsx
+++ b/packages/core/src/components/toast/toast.stories.tsx
@@ -72,10 +72,10 @@ export default {
   },
   args: {
     variant: 'Information',
-    header: 'Header',
-    subheader: 'Subheader',
+    header: 'Message header',
+    subheader: 'Short subheader',
     actions: `<tds-link slot="actions">
-          <a href="https://tegel.scania.com/home" target="_blank">Tegel</a>
+          <a href="https://tegel.scania.com/home" target="_blank">Link example</a>
       </tds-link>`,
     hidden: false,
     closable: true,


### PR DESCRIPTION
**Describe pull-request**  
Update default header, subheader and link text in Storybook example to align with design in Figma.

**Solving issue**  
Fixes: [CDEP-3253](https://tegel.atlassian.net/browse/CDEP-3253)

**How to test**  
1. Go to Storybook link below
2. Check in Toast component
3. Compare with design in [Figma](https://www.figma.com/file/d8bTgEx7h694MSesi2CTLF/Tegel-UI-Library?type=design&node-id=26756-59845&mode=design&t=DJl6JHpAQibOE9Xw-0)

**Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  
_Include before/after screenshots for UI changes._

**Additional context**  
_Add any other context or feedback requests about the pull-request here._


[CDEP-3253]: https://tegel.atlassian.net/browse/CDEP-3253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ