### PR TITLE
fix(dropdown): monitor slot changes to assigning defaultValue on dropdown menu update

### DIFF
--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -292,6 +292,13 @@ export class TdsDropdown {
     }
   }
 
+  /** Method to handle slot changes */
+  private handleSlotChange() {
+    if (this.defaultValue) {
+      this.setDefaultOption();
+    }
+  }
+
   /** Method to check if we should normalize text */
   private normalizeString(text: string): string {
     return this.normalizeText ? text.normalize('NFD').replace(/\p{Diacritic}/gu, '') : text;
@@ -613,7 +620,7 @@ export class TdsDropdown {
             ${this.getOpenDirection()}
             ${this.label && this.labelPosition === 'outside' ? 'label-outside' : ''}`}
         >
-          <slot></slot>
+          <slot onSlotchange={() => this.handleSlotChange()}></slot>
           {this.filterResult === 0 && this.noResultText !== '' && (
             <div class={`no-result ${this.size}`}>{this.noResultText}</div>
           )}

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -315,6 +315,12 @@ export class TdsDropdown {
   }
 
   private setDefaultOption = () => {
+    // Ensure this.host.children is not empty
+    if (this.host.children.length === 0) {
+      console.warn('TDS DROPDOWN: Data missing. Disregard if loading data asynchronously.');
+      return;
+    }
+
     Array.from(this.host.children)
       .filter((element) => element.tagName === 'TDS-DROPDOWN-OPTION')
       .forEach((element: HTMLTdsDropdownOptionElement) => {

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -287,16 +287,12 @@ export class TdsDropdown {
   }
 
   componentWillLoad() {
-    if (this.defaultValue) {
-      this.setDefaultOption();
-    }
+    this.setDefaultOption();
   }
 
   /** Method to handle slot changes */
   private handleSlotChange() {
-    if (this.defaultValue) {
-      this.setDefaultOption();
-    }
+    this.setDefaultOption();
   }
 
   /** Method to check if we should normalize text */
@@ -321,20 +317,26 @@ export class TdsDropdown {
       return;
     }
 
-    Array.from(this.host.children)
-      .filter((element) => element.tagName === 'TDS-DROPDOWN-OPTION')
-      .forEach((element: HTMLTdsDropdownOptionElement) => {
+    if (this.defaultValue) {
+      const children = Array.from(this.host.children).filter(
+        (element) => element.tagName === 'TDS-DROPDOWN-OPTION',
+      );
+      let matched = false;
+
+      children.forEach((element: HTMLTdsDropdownOptionElement) => {
         if (this.multiselect) {
           this.defaultValue.split(',').forEach((value) => {
             if (value === element.value) {
               element.setSelected(true);
               this.value = this.value ? [...this.value, element.value] : [element.value];
+              matched = true;
             }
           });
         } else {
           if (this.defaultValue === element.value) {
             element.setSelected(true);
             this.value = [element.value];
+            matched = true;
           } else {
             element.setSelected(false);
           }
@@ -342,6 +344,13 @@ export class TdsDropdown {
         this.setValueAttribute();
         return element;
       });
+
+      if (!matched) {
+        console.warn(
+          `TDS DROPDOWN: No matching option found for defaultValue "${this.defaultValue}"`,
+        );
+      }
+    }
   };
 
   private selectChildrenAsSelectedBasedOnSelectionProp() {


### PR DESCRIPTION
**Describe pull-request**  
Setting default value does not work properly when used in environment where slotted content is loading slow. 

**Solving issue**  
Fixes: 
- [CDEP-3192](https://tegel.atlassian.net/browse/CDEP-3192)
- https://github.com/scania-digital-design-system/tegel/issues/524

**How to test**  
1. Check if setting default value still works as intended.
2. Try to set defaultValue to the element that does not exists yet in the dropdown menu. It should return warning message.
3. Try to add option that is matching defaultValue in run time, observe if it sets it correctly. 




[CDEP-3192]: https://tegel.atlassian.net/browse/CDEP-3192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ