### PR TITLE
fix(stepper): correct first and last item padding

### DIFF
--- a/packages/core/src/components/stepper/step/step.scss
+++ b/packages/core/src/components/stepper/step/step.scss
@@ -213,7 +213,7 @@
   }
 }
 
-:host(.last) {
+:host(:last-of-type) {
   [role='listitem'] {
     &.sm,
     &.lg {
@@ -234,7 +234,7 @@
   }
 }
 
-:host(.first) {
+:host(:first-of-type) {
   [role='listitem'] {
     &.sm,
     &.lg {

--- a/packages/core/src/components/stepper/step/step.scss
+++ b/packages/core/src/components/stepper/step/step.scss
@@ -214,6 +214,10 @@
 }
 
 :host(:last-of-type) {
+  [role='listitem'].horizontal {
+    padding-right: 0;
+  }
+
   [role='listitem'] {
     &.sm,
     &.lg {
@@ -236,6 +240,10 @@
 
 :host(:first-of-type) {
   [role='listitem'] {
+    &.horizontal {
+      padding-left: 0;
+    }
+
     &.sm,
     &.lg {
       &::before {

--- a/packages/core/src/components/stepper/stepper.tsx
+++ b/packages/core/src/components/stepper/stepper.tsx
@@ -44,8 +44,6 @@ export class TdsStepper {
   @Prop() stepperId: string = generateUniqueId();
 
   componentWillLoad() {
-    this.host.children[0].classList.add('first');
-    this.host.children[this.host.children.length - 1].classList.add('last');
     if (this.orientation === 'vertical') {
       this.labelPosition = 'aside';
     }


### PR DESCRIPTION
## **Describe pull-request**  

Fixes an issue where the first and last styling was not applied to tds-step after the initial render of tds-stepper. The issue was that the styling was applied inside the `componentWillLoad` method of the tds-stepper. Now it's applied using pure CSS and no longer depends on the component lifecycle.

Fixes an issue where padding-left was applied to the first tds-step element and padding-right was applied to the last tds-step element in horizontal mode.


## **Issue Linking:**  
_Choose one of the following options_
- **GitHub:** https://github.com/scania-digital-design-system/tegel/issues/630
- **GitHub:** https://github.com/scania-digital-design-system/tegel/issues/631


## **How to test**  
1. Run storybook
2. Navigate to the stepper story
3. Check the first element has no padding left in horizontal mode
4. Check that the last element has no padding-right in the horizontal mode
5. Check that the first element has no line before itself in both horizontal and vertical mode
6. Check that the last element has no line after itself in both horizontal and vertical mode

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [x] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
