### PR TITLE
release: tegel 1.9.1

### DIFF
--- a/packages/angular-17/projects/components/package-lock.json
+++ b/packages/angular-17/projects/components/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@scania/tegel-angular-17",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@scania/tegel-angular-17",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": "^17.0.0",
         "@angular/core": "^17.0.0",
-        "@scania/tegel": "1.8.2"
+        "@scania/tegel": "1.9.1"
       }
     },
     "node_modules/@angular/common": {
@@ -71,13 +71,13 @@
       }
     },
     "node_modules/@scania/tegel": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.8.2.tgz",
-      "integrity": "sha512-rZtL0mFxezt7xAQ/kdOPhfuUjrytdRkTXActrZPeA7lF+45vofX/3ysofITgXT+O2MXu4tRoIxqmwRLUADYWYw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.9.1.tgz",
+      "integrity": "sha512-sdYavFETIkddSsq8bTWwas821mgxO5OVNZy1UbVUSbPXY0eSO/ZKOhaEVuoBpglb+7AR+77ICoFkodMPu3Zamg==",
       "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.11.8",
-        "@stencil/core": "^4.12.6",
+        "@stencil/core": "^4.18.1",
         "date-fns": "^2.30.0",
         "prettier": "^2.7.1"
       }

--- a/packages/angular-17/projects/components/package.json
+++ b/packages/angular-17/projects/components/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@scania/tegel-angular-17",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Angular wrappers for Tegel package using Angular 17 and above",
   "peerDependencies": {
     "@angular/common": "^17.0.0",
     "@angular/core": "^17.0.0",
-    "@scania/tegel": "1.8.2"
+    "@scania/tegel": "1.9.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "@scania/tegel-angular",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@scania/tegel-angular",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "dependencies": {
-        "@scania/tegel": "1.3.0",
+        "@scania/tegel": "1.9.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -3152,13 +3152,13 @@
       }
     },
     "node_modules/@scania/tegel": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.3.0.tgz",
-      "integrity": "sha512-3aPjqEWOcU/omQGH2Yhsbfr0SRpaS1PY7dXqzPan2oo4Nh6Jy8DIsE96EeDeSIp7sbKpFyK4xfLwB/yARMpcWQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.9.1.tgz",
+      "integrity": "sha512-sdYavFETIkddSsq8bTWwas821mgxO5OVNZy1UbVUSbPXY0eSO/ZKOhaEVuoBpglb+7AR+77ICoFkodMPu3Zamg==",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
-        "@stencil/core": "^4.4.0",
-        "dotenv": "^16.0.3",
+        "@stencil/core": "^4.18.1",
+        "date-fns": "^2.30.0",
         "prettier": "^2.7.1"
       }
     },
@@ -3185,9 +3185,9 @@
       "dev": true
     },
     "node_modules/@stencil/core": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.4.0.tgz",
-      "integrity": "sha512-YlLyCqGBsMEuZb3XTO/STT0TX9eSwjoVhCJgtjVfQOF+ebIMVlojTh40CmDveWiWbth687cbr6S2heeussV8Sg==",
+      "version": "4.18.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.18.3.tgz",
+      "integrity": "sha512-8yoG5AFQYEPocVtuoc5kvRS0Hku0MoDWDUpADRaXPVHsOFLmxR16LJENj25ucCz5GEfeTGQ/tCE8JAypPmr/fQ==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -5032,6 +5032,37 @@
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true
     },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns/node_modules/@babel/runtime": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.6.tgz",
+      "integrity": "sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/date-fns/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
     "node_modules/date-format": {
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
@@ -5250,17 +5281,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/eastasianwidth": {

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scania/tegel-angular",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Angular wrappers for Tegel package",
   "main": "dist",
   "files": [
@@ -11,7 +11,7 @@
     "build": "npx -p @angular/cli ng build components"
   },
   "dependencies": {
-    "@scania/tegel": "1.3.0",
+    "@scania/tegel": "1.9.1",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scania/tegel",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@scania/tegel",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scania/tegel",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Tegel Design System",
   "type": "module",
   "keywords": [
@@ -22,6 +22,7 @@
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/components/components.esm.js",
   "exports": {
+    "./dist/tegel/tegel.css": "./dist/tegel/tegel.css",
     "./tds-accordion-item": {
       "import": "./dist/components/tds-accordion-item.js",
       "types": "./dist/components/tds-accordion-item.d.ts"

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@scania/tegel-react",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@scania/tegel-react",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
-        "@scania/tegel": "1.3.0"
+        "@scania/tegel": "1.9.1"
       },
       "devDependencies": {
         "@types/node": "^20.8.0",
@@ -17,6 +17,17 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "^5.2.2"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.6.tgz",
+      "integrity": "sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@popperjs/core": {
@@ -29,20 +40,20 @@
       }
     },
     "node_modules/@scania/tegel": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.3.0.tgz",
-      "integrity": "sha512-3aPjqEWOcU/omQGH2Yhsbfr0SRpaS1PY7dXqzPan2oo4Nh6Jy8DIsE96EeDeSIp7sbKpFyK4xfLwB/yARMpcWQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.9.1.tgz",
+      "integrity": "sha512-sdYavFETIkddSsq8bTWwas821mgxO5OVNZy1UbVUSbPXY0eSO/ZKOhaEVuoBpglb+7AR+77ICoFkodMPu3Zamg==",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
-        "@stencil/core": "^4.4.0",
-        "dotenv": "^16.0.3",
+        "@stencil/core": "^4.18.1",
+        "date-fns": "^2.30.0",
         "prettier": "^2.7.1"
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.4.0.tgz",
-      "integrity": "sha512-YlLyCqGBsMEuZb3XTO/STT0TX9eSwjoVhCJgtjVfQOF+ebIMVlojTh40CmDveWiWbth687cbr6S2heeussV8Sg==",
+      "version": "4.18.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.18.3.tgz",
+      "integrity": "sha512-8yoG5AFQYEPocVtuoc5kvRS0Hku0MoDWDUpADRaXPVHsOFLmxR16LJENj25ucCz5GEfeTGQ/tCE8JAypPmr/fQ==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -86,15 +97,19 @@
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
       "dev": true
     },
-    "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=0.11"
       },
       "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/js-tokens": {
@@ -153,6 +168,11 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/scheduler": {
       "version": "0.23.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scania/tegel-react",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "React wrappers for Tegel package",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/scania-digital-design-system/tegel#readme",
   "dependencies": {
-    "@scania/tegel": "1.3.0"
+    "@scania/tegel": "1.9.1"
   },
   "devDependencies": {
     "@types/node": "^20.8.0",


### PR DESCRIPTION
## **Describe pull-request**  
New version of Tegel to fix the issue with export of tegel.css file.

## **Issue Linking:**  
- **No issue:** There was a prod issue with version 1.9.0 and export of main CSS file for tegel. This version fixes it. 
- **GitHub:** https://github.com/scania-digital-design-system/tegel/issues/640

## **How to test**  
1. Check PRs on demo pages