### PR TITLE
feat(table-header-cell): added disable padding prop

### DIFF
--- a/packages/core/src/components/table/table-component-basic.stories.tsx
+++ b/packages/core/src/components/table/table-component-basic.stories.tsx
@@ -92,6 +92,17 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    disableHeaderPadding: {
+      name: 'Disable header cell padding',
+      description:
+        'By default each header cell comes with padding. Disabling padding rule can be useful when a users want to insert another HTML element in a header cell, eg. input.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
     verticalDivider: {
       name: 'Vertical dividers',
       description: 'Enables vertical dividers between Table columns.',
@@ -167,6 +178,7 @@ export default {
     compactDesign: false,
     responsiveDesign: false,
     disablePadding: false,
+    disableHeaderPadding: false,
     verticalDivider: false,
     horizontalScrollWidth: '',
     noMinWidth: false,
@@ -184,6 +196,7 @@ const BasicTemplate = ({
   compactDesign,
   responsiveDesign,
   disablePadding,
+  disableHeaderPadding,
   verticalDivider,
   horizontalScrollWidth,
   noMinWidth,
@@ -201,19 +214,19 @@ const BasicTemplate = ({
       ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}
       ${horizontalScrollWidth ? `horizontal-scroll-width="${horizontalScrollWidth}"` : ''}
     >
-      <tds-table-header>
-          <tds-header-cell cell-key='truck' cell-value='Truck type' ${
-            column1Width ? `custom-width="${column1Width}"` : ''
-          } text-align="${headerTextAlignment}"></tds-header-cell>
-          <tds-header-cell cell-key='driver' cell-value='Driver name' ${
-            column2Width ? `custom-width="${column2Width}"` : ''
-          } text-align="${headerTextAlignment}"></tds-header-cell>
-          <tds-header-cell cell-key='country' cell-value='Country' ${
-            column3Width ? `custom-width="${column3Width}"` : ''
-          } text-align="${headerTextAlignment}"></tds-header-cell>
-          <tds-header-cell cell-key='mileage' cell-value='Mileage' ${
-            column4Width ? `custom-width="${column4Width}"` : ''
-          } text-align="${headerTextAlignment}"></tds-header-cell>
+      <tds-table-header >
+          <tds-header-cell cell-key='truck' cell-value='Truck type' disable-padding="${disableHeaderPadding}" ${
+    column1Width ? `custom-width="${column1Width}"` : ''
+  } text-align="${headerTextAlignment}"></tds-header-cell>
+          <tds-header-cell cell-key='driver' cell-value='Driver name' disable-padding="${disableHeaderPadding}" ${
+    column2Width ? `custom-width="${column2Width}"` : ''
+  } text-align="${headerTextAlignment}"></tds-header-cell>
+          <tds-header-cell cell-key='country' cell-value='Country' disable-padding="${disableHeaderPadding}" ${
+    column3Width ? `custom-width="${column3Width}"` : ''
+  } text-align="${headerTextAlignment}"></tds-header-cell>
+          <tds-header-cell cell-key='mileage' cell-value='Mileage' disable-padding="${disableHeaderPadding}" ${
+    column4Width ? `custom-width="${column4Width}"` : ''
+  } text-align="${headerTextAlignment}"></tds-header-cell>
       </tds-table-header>
       <tds-table-body>
           <tds-table-body-row>

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -7,13 +7,14 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                                                                             | Type                                                | Default     |
-| ------------- | -------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------- |
-| `cellKey`     | `cell-key`     | The value of column key, usually comes from JSON, needed for sorting                                    | `string`                                            | `undefined` |
-| `cellValue`   | `cell-value`   | Text that displays in column cell                                                                       | `string`                                            | `undefined` |
-| `customWidth` | `custom-width` | In case noMinWidth is set, the user has to specify the width value for each column.                     | `string`                                            | `undefined` |
-| `sortable`    | `sortable`     | Enables sorting on that column                                                                          | `boolean`                                           | `false`     |
-| `textAlign`   | `text-align`   | Setting for text align, default is "left". Other accepted values are "left", "start", "right" or "end". | `"center" \| "end" \| "left" \| "right" \| "start"` | `'left'`    |
+| Property         | Attribute         | Description                                                                                             | Type                                                | Default     |
+| ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------- |
+| `cellKey`        | `cell-key`        | The value of column key, usually comes from JSON, needed for sorting                                    | `string`                                            | `undefined` |
+| `cellValue`      | `cell-value`      | Text that displays in column cell                                                                       | `string`                                            | `undefined` |
+| `customWidth`    | `custom-width`    | In case noMinWidth is set, the user has to specify the width value for each column.                     | `string`                                            | `undefined` |
+| `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                | `boolean`                                           | `false`     |
+| `sortable`       | `sortable`        | Enables sorting on that column                                                                          | `boolean`                                           | `false`     |
+| `textAlign`      | `text-align`      | Setting for text align, default is "left". Other accepted values are "left", "start", "right" or "end". | `"center" \| "end" \| "left" \| "right" \| "start"` | `'left'`    |
 
 
 ## Events

--- a/packages/core/src/components/table/table-header-cell/table-header-cell.scss
+++ b/packages/core/src/components/table/table-header-cell/table-header-cell.scss
@@ -22,6 +22,10 @@
     padding: 8px 16px;
     margin: 0;
   }
+
+  .tds-table__header-text-no-padding {
+    padding: 0;
+  }
 }
 
 :host(.tds-table__header-cell--sortable) {
@@ -106,6 +110,10 @@
 
 :host(.tds-table--no-min-width) {
   min-width: unset;
+}
+
+:host(.tds-table--no-padding) {
+  height: unset;
 }
 
 // border-radius style control

--- a/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
+++ b/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
@@ -44,6 +44,9 @@ export class TdsTableHeaderCell {
   /** Setting for text align, default is "left". Other accepted values are "left", "start", "right" or "end". */
   @Prop({ reflect: true }) textAlign: 'left' | 'start' | 'right' | 'end' | 'center' = 'left';
 
+  /** Disables internal padding. Useful when passing other components to cell. */
+  @Prop({ reflect: true }) disablePadding: boolean = false;
+
   @State() textAlignState: string;
 
   @State() sortingDirection: 'asc' | 'desc' | undefined;
@@ -223,7 +226,13 @@ export class TdsTableHeaderCell {
       );
     }
     return (
-      <p class="tds-table__header-text" style={{ textAlign: this.textAlignState }}>
+      <p
+        class={{
+          'tds-table__header-text': true,
+          'tds-table__header-text-no-padding': this.disablePadding,
+        }}
+        style={{ textAlign: this.textAlignState }}
+      >
         {this.cellValue}
         <slot />
       </p>
@@ -250,6 +259,7 @@ export class TdsTableHeaderCell {
           'tds-table--no-min-width': this.noMinWidth,
           'tds-table--extra-column': this.multiselect || this.expandableRows,
           'tds-table--toolbar-available': this.enableToolbarDesign,
+          'tds-table--no-padding': this.disablePadding,
         }}
         style={{ minWidth: this.customWidth }}
         onMouseOver={() => this.onHeadCellHover(this.cellKey)}


### PR DESCRIPTION
## **Describe pull-request**  
Simular to `table-body-cell` we add a prop to `table-header-cell` that removes all padding. Intended to be used when adding custom components like a `input` field in a header.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** https://tegel.atlassian.net/browse/CDEP-3429
- **GitHub:** Include issue link  
- **No issue:** Describe the problem being solved.  

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to...
2. Check in...
3. Run ...

## **Checklist before submission**
- [x] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
