### PR TITLE
test(table:sorting): added waitFor to improve screenshot stability

### DIFF
--- a/packages/core/src/components/table/table/test/sorting/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/sorting/table.e2e.ts
@@ -4,9 +4,15 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/sorting/index.html';
 
 test.describe.parallel('tds-table-sorting', () => {
-  test('renders sorting table correctly', async ({ page }) => {
+  let tableComponent;
+
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
-    const tableComponent = page.getByRole('table');
+    tableComponent = page.getByRole('table');
+    await tableComponent.waitFor({ state: 'visible' });
+  });
+
+  test('renders sorting table correctly', async ({ page }) => {
     await expect(tableComponent).toHaveCount(1);
 
     /* Check for diffs in screenshot */
@@ -14,8 +20,6 @@ test.describe.parallel('tds-table-sorting', () => {
   });
 
   test('table has header "Sorting"', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     /* Search for header by text and see if it exists */
     const tdsTableToolbarCaption = page.getByText('Sorting');
     await expect(tdsTableToolbarCaption).toHaveCount(1);
@@ -23,7 +27,6 @@ test.describe.parallel('tds-table-sorting', () => {
   });
 
   test('column headers are clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const myEventSpy = await page.spyOnEvent('tdsSort');
     const truckTypeHeader = page.getByText('Truck type');
     await truckTypeHeader.click();


### PR DESCRIPTION
## **Describe pull-request**  
Failing test in screenshots part.

## **Issue Linking:**  
- **No issue:** Sometimes the sorting test fails in screenshot taking. This is an attempt to improve its stability.

## **How to test**  
1. Have a branch in your local
2. Run `npm run test` a couple of times
3. The test for sorting feature of the table should pass
4. If any other test fails, please ping me so I can improve those too.

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)



