### PR TITLE
fix: use correct font family in headline 01 variable

### DIFF
--- a/packages/core/src/global/scania-fonts-vars.scss
+++ b/packages/core/src/global/scania-fonts-vars.scss
@@ -7,7 +7,8 @@
   /* FUNCTIONAL TYPOGRAPHY */
 
   //HEADLINE
-  --tds-headline-01: normal normal bold 40px/40px 'Scania Sans', arial, helvetica, sans-serif;
+  --tds-headline-01: normal normal bold 40px/40px 'Scania Sans Headline', arial, helvetica,
+    sans-serif;
   --tds-headline-01-ls: 0;
   --tds-headline-02: normal normal bold 32px/32px 'Scania Sans', arial, helvetica, sans-serif;
   --tds-headline-02-ls: -0.04em;

--- a/typography/scania-fonts-vars.scss
+++ b/typography/scania-fonts-vars.scss
@@ -7,7 +7,8 @@
   /* FUNCTIONAL TYPOGRAPHY */
 
   //HEADLINE
-  --tds-headline-01: normal normal bold 40px/40px 'Scania Sans', arial, helvetica, sans-serif;
+  --tds-headline-01: normal normal bold 40px/40px 'Scania Sans Headline', arial, helvetica,
+    sans-serif;
   --tds-headline-01-ls: 0;
   --tds-headline-02: normal normal bold 32px/32px 'Scania Sans', arial, helvetica, sans-serif;
   --tds-headline-02-ls: -0.04em;


### PR DESCRIPTION
## **Describe pull-request**  
Fixing wrong font family usage in css variable for tds-headline-01

## **Issue Linking:**  
**No issue:** When using the headline-01 variable instead of the class you don't get the same header. Variable is using Scania Sans instead of Scania Sans Headline


## **How to test**  
This variable is not used in any component so have to test it in a separate project or use it temporarily in a component while verifying. Encountered this when using variable inside another stencil project with shadow dom enabled.

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
