### PR TITLE
fix(stepper): items not aligned

### DIFF
--- a/packages/core/src/components/stepper/step/step.scss
+++ b/packages/core/src/components/stepper/step/step.scss
@@ -9,10 +9,6 @@
   position: relative;
   display: table-cell;
 
-  tds-icon {
-    line-height: 1;
-  }
-
   [role='listitem'] {
     display: flex;
     justify-content: start;
@@ -32,6 +28,14 @@
       .content-container {
         height: 30px;
         min-width: 30px;
+
+        tds-icon {
+          vertical-align: bottom;
+        }
+
+        .index-container {
+          vertical-align: sub;
+        }
       }
 
       &.vertical {
@@ -168,9 +172,7 @@
     .content-container {
       border-radius: 100px;
       border: 1px solid var(--tds-stepper-icon-background);
-      display: flex;
-      justify-content: center;
-      align-items: center;
+      text-align: center;
       position: relative;
 
       &.error {

--- a/packages/core/src/components/stepper/step/step.scss
+++ b/packages/core/src/components/stepper/step/step.scss
@@ -99,9 +99,20 @@
       font: var(--tds-detail-05);
       letter-spacing: var(--tds-detail-05-ls);
 
+      .index-container {
+        vertical-align: -webkit-baseline-middle;
+        vertical-align: -moz-middle-with-baseline;
+      }
+
       .content-container {
         height: 24px;
         min-width: 24px;
+      }
+
+      .tds-step-icon {
+        vertical-align: -webkit-baseline-middle;
+        vertical-align: -moz-middle-with-baseline;
+        margin-top: -2px;
       }
 
       &.vertical {

--- a/packages/core/src/components/stepper/step/step.tsx
+++ b/packages/core/src/components/stepper/step/step.tsx
@@ -69,16 +69,16 @@ export class TdsStep {
             this.hideLabels ? 'hide-labels' : ''
           }`}
         >
-          <div class={`${this.state} content-container`}>
+          <span class={`${this.state} content-container`}>
             {this.state === 'success' || this.state === 'error' ? (
               <tds-icon
                 name={this.state === 'success' ? 'tick' : 'warning'}
                 size={this.size === 'lg' ? '20px' : '16px'}
               ></tds-icon>
             ) : (
-              this.index
+              <span class="index-container">{this.index}</span>
             )}
-          </div>
+          </span>
           {!this.hideLabels && (
             <div class={`label ${this.size} ${this.state}`}>
               <slot name="label"></slot>

--- a/packages/core/src/components/stepper/step/step.tsx
+++ b/packages/core/src/components/stepper/step/step.tsx
@@ -72,6 +72,7 @@ export class TdsStep {
           <span class={`${this.state} content-container`}>
             {this.state === 'success' || this.state === 'error' ? (
               <tds-icon
+                class={'tds-step-icon'}
                 name={this.state === 'success' ? 'tick' : 'warning'}
                 size={this.size === 'lg' ? '20px' : '16px'}
               ></tds-icon>


### PR DESCRIPTION
## **Describe pull-request**  
UI Improvements of stepper component

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-3348`: [items not aligned](https://tegel.atlassian.net/browse/CDEP-CDEP-3348)    

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to stepper in storybook
2. Check that steps are aligned
3. Toggle small/large labels and so on...
4. Repeat in a non-webkit browser(e.g. Firefox)

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [x] Storybook controls

## **Additional context**  
Using -webkit becuase it was the only alignment property that did the trick, is not a standard, so it could be unreliable in the future? However looks good in both Chrome and Firefox.
