### PR TITLE
fix(angular-17): dependency on version 17 or higher

### DIFF
--- a/packages/angular-17/projects/components/package-lock.json
+++ b/packages/angular-17/projects/components/package-lock.json
@@ -11,8 +11,8 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/common": "^17.0.0",
-        "@angular/core": "^17.0.0",
+        "@angular/common": ">=17.0.0",
+        "@angular/core": ">=17.0.0",
         "@scania/tegel": "1.9.1"
       }
     },

--- a/packages/angular-17/projects/components/package.json
+++ b/packages/angular-17/projects/components/package.json
@@ -3,8 +3,8 @@
   "version": "1.12.0",
   "description": "Angular wrappers for Tegel package using Angular 17 and above",
   "peerDependencies": {
-    "@angular/common": "^17.0.0",
-    "@angular/core": "^17.0.0",
+    "@angular/common": ">=17.0.0",
+    "@angular/core": ">=17.0.0",
     "@scania/tegel": "1.9.1"
   },
   "dependencies": {


### PR DESCRIPTION
## **Describe pull-request**  
Fix for an issue on peer dependencies. Using @scania/tegel-angular-17 should not require `--force` when installing.

## **Issue Linking:**  
- **No issue:** Being reported in [support channel.](https://teams.microsoft.com/l/message/19:5e33f67fe502441f914fbcdc6e2548f5@thread.skype/1716804816292?tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac&groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&parentMessageId=1716804816292&teamName=Tegel%20Design%20System&channelName=Development%20support%20-%20Tegel&createdTime=1716804816292)

## **How to test**  
1. Pack the angular-17 code and test it on angular-17-demo page.
2. Installation of package should be smooth, without any additional flags like `--force` or `--peerDependencies`

