### PR TITLE
fix(textarea): scroll in readonly mode

### DIFF
--- a/packages/core/src/components/textarea/textarea.scss
+++ b/packages/core/src/components/textarea/textarea.scss
@@ -297,8 +297,6 @@
 }
 
 .textarea-readonly {
-  pointer-events: none;
-
   .textarea-icon__readonly {
     display: block;
 

--- a/packages/core/src/components/textarea/textarea.stories.tsx
+++ b/packages/core/src/components/textarea/textarea.stories.tsx
@@ -69,6 +69,13 @@ export default {
         type: 'text',
       },
     },
+    textValue: {
+      name: 'Text value',
+      description: 'Sets the text value.',
+      control: {
+        type: 'text',
+      },
+    },
     helper: {
       name: 'Helper text',
       description: 'Sets the helper text.',
@@ -127,6 +134,7 @@ export default {
     label: 'Label',
     labelPosition: 'No label',
     placeholder: 'Placeholder',
+    textValue: '',
     helper: '',
     rows: 5,
     maxLength: 0,
@@ -143,6 +151,7 @@ const Template = ({
   labelPosition,
   placeholder,
   helper,
+  textValue,
   rows,
   maxLength,
   noMinWidth,
@@ -180,7 +189,8 @@ const Template = ({
           ${readonly ? 'read-only' : ''}
           ${noMinWidth ? 'no-min-width' : ''}
           placeholder="${placeholder}"
-          ${maxlength}>
+          ${maxlength}
+          value="${textValue}">
         </tds-textarea>
   </div>
   <!-- Script tag for demo purposes -->


### PR DESCRIPTION
## **Describe pull-request**  
Enable scrolling when in read-only mode.

## **Issue Linking:**  
- **Jira:** Add ticket number after `CDEP-`: [CDEP-1183](https://tegel.atlassian.net/browse/CDEP-1183)    

## **How to test**  
1. Go to the preview link
2. Open textarea component
3. Set some long text using the "Text value" control
4. Try to scroll, it should work as expected and editing text should be possible
5. Set the component to read-only mode
6. Try to scroll, it should be possible but text editing should not be possible.

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


## **Additional context**  
Additional control for value control is added.


[CDEP-1183]: https://tegel.atlassian.net/browse/CDEP-1183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ