### PR TITLE
fix(banner): padding left in no icon variation

### DIFF
--- a/packages/core/src/components/banner/banner.scss
+++ b/packages/core/src/components/banner/banner.scss
@@ -19,9 +19,10 @@
   display: flex;
   background-color: var(--tds-banner-background-default);
   z-index: tds-z-index(banner);
+  padding-left: 16px;
 
   .banner-icon {
-    padding-left: 20px;
+    padding-left: 4px;
     padding-top: 14px;
     padding-right: 12px;
     color: var(--tds-banner-prefix-default-color);


### PR DESCRIPTION
## **Describe pull-request**  
The icon has a padding of 20px on the left. When no icon is used, text comes to the left side of the component. 
I have added padding of 16px left when no icon is there and an additional 4px in the icon component to keep it per design.
No test needed to be updated as there is no visual change. 

## **Issue Linking:**  
- **Jira:** Add ticket number after `CDEP-`: [CDEP-2899](https://tegel.atlassian.net/browse/CDEP-2899)    

## **How to test**  
1. Go to the preview link.
2. Check the Banner component
3. Check the option with any random icon, check with "none".
4. There should be padding on 16px the the left when just text is there and 20px (16px + 4px) when icon is used.

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)




[CDEP-2899]: https://tegel.atlassian.net/browse/CDEP-2899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ