### PR TITLE
fix(dropdown): async data source handling

### DIFF
--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -317,33 +317,36 @@ export class TdsDropdown {
     if (this.defaultValue) {
       const children = Array.from(this.host.children).filter(
         (element) => element.tagName === 'TDS-DROPDOWN-OPTION',
-      );
-      let matched = false;
+      ) as HTMLTdsDropdownOptionElement[];
+
+      if (children.length === 0) {
+        console.warn('TDS DROPDOWN: No options found. Disregard if loading data asynchronously.');
+        return;
+      }
 
       const defaultValues = this.multiselect
         ? new Set(this.defaultValue.split(','))
         : [this.defaultValue];
 
-      defaultValues.forEach((value) => {
-        children.forEach((element: HTMLTdsDropdownOptionElement) => {
-          if (value === element.value) {
-            element.setSelected(true);
-            this.value = this.value
-              ? [...new Set([...this.value, element.value])]
-              : [element.value];
+      const childrenMap = new Map(children.map((element) => [element.value, element]));
 
-            matched = true;
-          }
-        });
+      const matchedValues = Array.from(defaultValues).filter((value) => {
+        const element = childrenMap.get(value);
+        if (element) {
+          element.setSelected(true);
+          return true;
+        }
+        return false;
       });
 
-      if (!matched) {
+      if (matchedValues.length > 0) {
+        this.value = [...new Set(this.value ? [...this.value, ...matchedValues] : matchedValues)];
+        this.setValueAttribute();
+      } else {
         console.warn(
           `TDS DROPDOWN: No matching option found for defaultValue "${this.defaultValue}"`,
         );
       }
-
-      this.setValueAttribute();
     }
   };
 


### PR DESCRIPTION
## **Describe pull-request**  
If the dropdown does not have children, but the default option is set, it would throw a lot of errors in the console.
Some users have an async way of adding data later to the component so they end up in errors even if their state is "normal".
Now we stop processing in the early stage. Also lopping over dropdown items is improved.  

## **Issue Linking:**  
- **Jira:** Add ticket number after `CDEP-`: [CDEP-3116](https://tegel.atlassian.net/browse/CDEP-3116)    

## **How to test** 
1. Open the preview link
2. Check if adding a default value works as expected in the component
3. Try to add more items to the dropdown during the lifetime (fun times in the console ahead :D )

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)

## **Additional context**  
I might try to set up an example on one of the demo pages if needed.


[CDEP-3116]: https://tegel.atlassian.net/browse/CDEP-3116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ