### PR TITLE
fix(dropdown): scrollbar background color

### DIFF
--- a/packages/core/src/mixins/_scrollbar.scss
+++ b/packages/core/src/mixins/_scrollbar.scss
@@ -16,7 +16,7 @@
   }
 
   &::-webkit-scrollbar-track {
-    background: transparent;
+    background: var(--tds-scrollbar-track-color);
   }
 
   &::-webkit-scrollbar-thumb {


### PR DESCRIPTION
## **Describe pull-request**  
After changes in dropdown scroll we lost background color in track. 


## **Issue Linking:**  
- **No issue:** 2 users have already complained about this in support channel. I have added variable to scrollbar track instead of transparent value. It has been checked in Chrome, Firefox and Safari - works in all three.

## **How to test**  
1. Go to the preview link and check if the scrollbar in the dropdown has a background color. Use a different background in Storybook to check it.


## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [x] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
![Screenshot 2024-08-02 at 10 20 09-tile](https://github.com/user-attachments/assets/17b51c17-1336-46fc-ab8b-d0631d0649df)

