### PR TITLE
refactor(header-title): code clean-up and improvement

### DIFF
--- a/packages/core/src/components/header/header-title/header-title.scss
+++ b/packages/core/src/components/header/header-title/header-title.scss
@@ -1,8 +1,4 @@
-@import '../../../mixins/flex-center';
-
-:host {
-  display: block;
-  flex-shrink: 1;
+h4 {
   box-sizing: border-box;
   color: var(--tds-header-nav-item-color);
   font-weight: normal;
@@ -15,7 +11,6 @@
 
   slot {
     display: block;
-    align-items: center;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;

--- a/packages/core/src/components/header/header-title/header-title.tsx
+++ b/packages/core/src/components/header/header-title/header-title.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host } from '@stencil/core';
+import { Component, h } from '@stencil/core';
 
 /**
  * @slot <default> - <b>Unnamed slot.</b> For the header title text.
@@ -11,11 +11,9 @@ import { Component, h, Host } from '@stencil/core';
 export class TdsHeaderTitle {
   render() {
     return (
-      <Host>
-        <div class="component">
-          <slot></slot>
-        </div>
-      </Host>
+      <h4>
+        <slot></slot>
+      </h4>
     );
   }
 }

--- a/packages/core/src/components/header/header.scss
+++ b/packages/core/src/components/header/header.scss
@@ -30,9 +30,7 @@ nav {
   .tds-header-component-list {
     height: var(--tds-header-height);
     all: unset;
-    display: flex;
-    justify-content: start;
-    align-items: center;
+    @include tds-flex-center;
   }
 
   tds-header-dropdown,


### PR DESCRIPTION
## **Describe pull-request**  
The header was not using any of the heading elements (h1-h6 for the title )which led to accessibility warnings in the console. While improving it, I found some of the lines of code that were not used so I cleaned it a bit. 

## **Issue Linking:**  
- **No issue:** User reported in the support channel.

## **How to test**  
1. Check preview link
2. Make sure Header title looks like one in [prod](https://tds-storybook.tegel.scania.com/?path=/story/components-header--default)

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)


