### PR TITLE
fix(table): scroll instead of expanding parent

### DIFF
--- a/packages/core/src/components/table/table-body-row-expandable/readme.md
+++ b/packages/core/src/components/table/table-body-row-expandable/readme.md
@@ -31,6 +31,20 @@ tds-table-body-row-expandable::part(expand-row) {
 
 This CSS will apply a background color and border to the expandable row part of the `tds-table-body-row-expandable` component.
 
+### Overflow solution for Expanded Rows (Use with Caution)
+
+If you need to control overflow in a table, you can wrap the table content using a div with the following styles:
+
+```html
+<div style="overflow:auto; width:100%; display:table-caption;">
+    // Your table content here
+</div>
+```
+
+This approach forces the content to scroll within the table. However, it leverages unconventional CSS (display: table-caption) to work across Firefox, Chrome, and Safari. This might lead to unexpected issues in complex layouts or future browser updates. While effective, use this method with caution and consider other layout strategies.
+
+We recommend fitting your content within the table’s natural size whenever possible.
+
 <hr>
 <br>
 

--- a/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.scss
+++ b/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.scss
@@ -64,6 +64,8 @@
     }
 
     .tds-table__cell-expand {
+      max-width: 1px;
+      overflow: scroll;
       padding: 16px 16px 16px 66px;
       color: var(--tds-table-color);
     }

--- a/packages/core/src/components/table/table-component-expandable-rows.stories.tsx
+++ b/packages/core/src/components/table/table-component-expandable-rows.stories.tsx
@@ -180,7 +180,13 @@ const ExpandableRowTemplate = ({
           <tds-body-cell cell-value="Test value 2" cell-key="driver"></tds-body-cell>
           <tds-body-cell cell-value="Test value 3" cell-key="country"></tds-body-cell>
           <tds-body-cell cell-value="Test value 4" cell-key="mileage"></tds-body-cell>
-          <div slot="expand-row">Hello world 1</div>
+          <!-- Demo block: Overflow solution for Expanded Rows (Not Recommended). -->
+          <div slot="expand-row">
+            <div style="overflow:auto; width:100%; display:table-caption;">
+              <div style="background-color: red; width: 900px; height: 100px;">Not Recommended</div>
+            </div>
+          </div>
+          <!-- end of demo block -->
         </tds-table-body-row-expandable>
          <tds-table-body-row-expandable row-id="2">
           <tds-body-cell cell-value="Test value 5" cell-key="truck"></tds-body-cell>

--- a/packages/core/src/components/table/table-component-expandable-rows.stories.tsx
+++ b/packages/core/src/components/table/table-component-expandable-rows.stories.tsx
@@ -180,13 +180,7 @@ const ExpandableRowTemplate = ({
           <tds-body-cell cell-value="Test value 2" cell-key="driver"></tds-body-cell>
           <tds-body-cell cell-value="Test value 3" cell-key="country"></tds-body-cell>
           <tds-body-cell cell-value="Test value 4" cell-key="mileage"></tds-body-cell>
-          <!-- Demo block: Overflow solution for Expanded Rows (Not Recommended). -->
-          <div slot="expand-row">
-            <div style="overflow:auto; width:100%; display:table-caption;">
-              <div style="background-color: red; width: 900px; height: 100px;">Not Recommended</div>
-            </div>
-          </div>
-          <!-- end of demo block -->
+          <div slot="expand-row">Hello world 1</div>
         </tds-table-body-row-expandable>
          <tds-table-body-row-expandable row-id="2">
           <tds-body-cell cell-value="Test value 5" cell-key="truck"></tds-body-cell>
@@ -201,6 +195,21 @@ const ExpandableRowTemplate = ({
           <tds-body-cell cell-value="Test value 11" cell-key="country"></tds-body-cell>
           <tds-body-cell cell-value="Test value 12" cell-key="mileage"></tds-body-cell>
           <div slot="expand-row"><tds-button type="primary" text="Call to action"></tds-button></div>
+        </tds-table-body-row-expandable>
+        <tds-table-body-row-expandable>
+          <tds-body-cell cell-value="Demo overflow 1" cell-key="truck"></tds-body-cell>
+          <tds-body-cell cell-value="Demo overflow 2" cell-key="driver"></tds-body-cell>
+          <tds-body-cell cell-value="Demo overflow 3" cell-key="country"></tds-body-cell>
+          <tds-body-cell cell-value="Demo overflow 4" cell-key="mileage"></tds-body-cell>
+          <div slot="expand-row">
+            <!-- Demo block: Overflow solution for Expanded Rows (Not Recommended). -->
+              <div slot="expand-row">
+                <div style="overflow:auto; width:100%; display:table-caption;">
+                  <div style="background-color: red; width: 900px; height: 100px;">Not Recommended</div>
+                </div>
+              </div>
+            <!-- end of demo block -->
+          </div>
         </tds-table-body-row-expandable>
       </tds-table-body>
   </tds-table>


### PR DESCRIPTION
## **Describe pull-request**  
Any elements, that are wider than the available width inside the expand-row slot, should overflow instead of expanding the entire table.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-3353: The expand-row slot expands the entire table instead of overflowing](https://tegel.atlassian.net/browse/CDEP-3353)     

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to: `table-component-expandable-rows.stories.tsx`
2. Replace `<div slot="expand-row">Hello world 1</div>` with some wider content for example:  
```
<div slot="expand-row">
  <tds-body-cell cell-value="Test value 1" cell-key="truck"></tds-body-cell>
  <tds-body-cell cell-value="Test value 2" cell-key="driver"></tds-body-cell>
  <tds-body-cell cell-value="Test value 3" cell-key="country"></tds-body-cell>
  <tds-body-cell cell-value="Test value 4" cell-key="mileage"></tds-body-cell>
  <tds-body-cell cell-value="Test value 1" cell-key="truck"></tds-body-cell>
</div>
```
3. Go to the storybook Table -> Expandable Rows
4. Expand the row you edited and see that it's now scrollable instead of expanding the whole table.

## **Additional context**  
Does anyone have a suggestion for the same behaviour using other CSS properties? The max-width: 1px is working but it's not super clear what it does for anyone who just looking briefly at the styling.
