### PR TITLE
feat(table): add part for the cell in the expanded row of the table. add visible for overflow.

### DIFF
--- a/packages/core/src/components/table/table-body-row-expandable/readme.md
+++ b/packages/core/src/components/table/table-body-row-expandable/readme.md
@@ -53,12 +53,12 @@ We recommend fitting your content within the table’s natural size whenever pos
 
 ## Properties
 
-| Property   | Attribute  | Description                                                                                                                               | Type                 | Default              |
-| ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------- |
-| `colSpan`  | `col-span` | In case that automatic count of columns does not work, user can manually set this one. Take in mind that expandable control is column too | `number`             | `null`               |
-| `expanded` | `expanded` | Sets isExpanded state to true or false externally                                                                                         | `boolean`            | `undefined`          |
-| `overflow` | `overflow` | Controls the overflow behavior of the expandable row content                                                                              | `"auto" \| "hidden"` | `'auto'`             |
-| `rowId`    | `row-id`   | ID for the table row. Randomly generated if not specified.                                                                                | `string`             | `generateUniqueId()` |
+| Property   | Attribute  | Description                                                                                                                               | Type                              | Default              |
+| ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | -------------------- |
+| `colSpan`  | `col-span` | In case that automatic count of columns does not work, user can manually set this one. Take in mind that expandable control is column too | `number`                          | `null`               |
+| `expanded` | `expanded` | Sets isExpanded state to true or false externally                                                                                         | `boolean`                         | `undefined`          |
+| `overflow` | `overflow` | Controls the overflow behavior of the expandable row content                                                                              | `"auto" \| "hidden" \| "visible"` | `'auto'`             |
+| `rowId`    | `row-id`   | ID for the table row. Randomly generated if not specified.                                                                                | `string`                          | `generateUniqueId()` |
 
 
 ## Events
@@ -101,10 +101,11 @@ Type: `Promise<void>`
 
 ## Shadow Parts
 
-| Part           | Description                                 |
-| -------------- | ------------------------------------------- |
-| `"expand-row"` | Selector for the expanded row of the table. |
-| `"row"`        | Selector for the main row of the table.     |
+| Part                | Description                                             |
+| ------------------- | ------------------------------------------------------- |
+| `"expand-row"`      | Selector for the expanded row of the table.             |
+| `"expand-row-cell"` | Selector for the cell in the expanded row of the table. |
+| `"row"`             | Selector for the main row of the table.                 |
 
 
 ----------------------------------------------

--- a/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.scss
+++ b/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.scss
@@ -69,6 +69,11 @@
       padding: 16px 16px 16px 66px;
       color: var(--tds-table-color);
     }
+
+    .tds-table__cell-expand-visible {
+      color: var(--tds-table-color);
+      padding: 16px 16px 16px 66px;
+    }
   }
 }
 

--- a/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.scss
+++ b/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.scss
@@ -70,9 +70,12 @@
       color: var(--tds-table-color);
     }
 
-    .tds-table__cell-expand-visible {
-      color: var(--tds-table-color);
-      padding: 16px 16px 16px 66px;
+    .tds-table__cell-expand--overflow-visible {
+      overflow: visible;
+    }
+
+    .tds-table__cell-expand--overflow-hidden {
+      overflow: hidden;
     }
   }
 }

--- a/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -27,6 +27,7 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
 
  * @part row - Selector for the main row of the table.
  * @part expand-row - Selector for the expanded row of the table.
+ * @part expand-row-cell - Selector for the cell in the expanded row of the table.
  */
 
 @Component({
@@ -46,7 +47,7 @@ export class TdsTableBodyRowExpandable {
   @Prop({ reflect: true }) expanded: boolean;
 
   /** Controls the overflow behavior of the expandable row content */
-  @Prop({ reflect: true }) overflow: 'auto' | 'hidden' = 'auto';
+  @Prop({ reflect: true }) overflow: 'auto' | 'hidden' | 'visible' = 'auto';
 
   /** Sets isExpanded state to true or false internally */
   @State() isExpanded: boolean = false;
@@ -205,7 +206,7 @@ export class TdsTableBodyRowExpandable {
           }}
           part="expand-row"
         >
-          <td class="tds-table__cell-expand" colSpan={this.columnsNumber}>
+          <td class="tds-table__cell-expand" part="expand-row-cell" colSpan={this.columnsNumber}>
             <div
               style={{
                 overflow: this.overflow,

--- a/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -176,7 +176,12 @@ export class TdsTableBodyRowExpandable {
           }}
           part="row"
         >
-          <td class="tds-table__cell tds-table__cell--expand">
+          <td
+            class={{
+              'tds-table__cell-expand': true,
+              'tds-table__cell-expand-visible': this.overflow === 'visible',
+            }}
+          >
             <label class="tds-table__expand-control-container">
               <input
                 class="tds-table__expand-input"

--- a/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -179,7 +179,6 @@ export class TdsTableBodyRowExpandable {
           <td
             class={{
               'tds-table__cell-expand': true,
-              'tds-table__cell-expand-visible': this.overflow === 'visible',
             }}
           >
             <label class="tds-table__expand-control-container">
@@ -211,7 +210,15 @@ export class TdsTableBodyRowExpandable {
           }}
           part="expand-row"
         >
-          <td class="tds-table__cell-expand" part="expand-row-cell" colSpan={this.columnsNumber}>
+          <td
+            class={{
+              'tds-table__cell-expand': true,
+              'tds-table__cell-expand--overflow-hidden': this.overflow === 'hidden',
+              'tds-table__cell-expand--overflow-visible': this.overflow === 'visible',
+            }}
+            part="expand-row-cell"
+            colSpan={this.columnsNumber}
+          >
             <div
               style={{
                 overflow: this.overflow,

--- a/packages/core/src/components/table/table-component-expandable-rows.stories.tsx
+++ b/packages/core/src/components/table/table-component-expandable-rows.stories.tsx
@@ -130,7 +130,7 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['auto', 'hidden'],
+      options: ['auto', 'hidden', 'visible'],
     },
   },
   args: {
@@ -224,7 +224,7 @@ const ExpandableRowTemplate = ({
   <script>
 
   tableRowElementAll = document.querySelectorAll("tds-table-body-row-expandable");
- 
+
   for (let i = 0; i < tableRowElementAll.length; i++) {
     tableRowElementAll[i].addEventListener("tdsChange", (event) => {
       console.log("Row with id: ", event.detail.rowId, " is ", event.detail.isExpanded);

--- a/packages/core/src/components/table/table-component-expandable-rows.stories.tsx
+++ b/packages/core/src/components/table/table-component-expandable-rows.stories.tsx
@@ -131,6 +131,9 @@ export default {
         type: 'radio',
       },
       options: ['auto', 'hidden', 'visible'],
+      table: {
+        defaultValue: { summary: 'auto' },
+      },
     },
   },
   args: {
@@ -144,7 +147,7 @@ export default {
     column2Width: '',
     column3Width: '',
     column4Width: '',
-    overflow: 'scroll',
+    overflow: 'auto',
   },
 };
 
@@ -213,7 +216,9 @@ const ExpandableRowTemplate = ({
           <tds-body-cell cell-value="Demo overflow 4" cell-key="mileage"></tds-body-cell>
           <div slot="expand-row">
             <!-- Demo block: Overflow solution for Expanded Rows (Not Recommended). -->
-              <div style="background-color: red; width: 900px; height: 100px;">Not Recommended</div>
+              <div style="background: linear-gradient(to right, red, orange, yellow, green, blue, indigo, violet); width: 900px; height: 100px; color: white; text-shadow: 1px 1px 2px black;">
+                This is an example of a long sentence that demonstrates how content can overflow the boundaries of its container, especially when the container has a fixed width and the content is too large to fit within it.
+              </div>
             <!-- end of demo block -->
           </div>
         </tds-table-body-row-expandable>


### PR DESCRIPTION
## **Describe pull-request**  
The purpose of this PR is to provide an option to remove the padding in the expanded area. Additionally, I want to have control over the overflow behavior. Otherwise, it might cause elements like dropdowns to be cut off.

The proposed technical solution is to add a "part" that allows styling of the expanded area in an expanded table row. This would enable adjustments like removing padding, allowing the expanded area to utilize its full width.

More information can be found in the Teams channel "Development support - Tegel".

## **Issue Linking:**  
- **GitHub:** https://github.com/scania-digital-design-system/tegel/issues/785

## **Checklist before submission**
- [x] All existing tests pass
- [x] Not breaking production behavior
- [x] `npm run build-all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 