### PR TITLE
fix(breadbrumbs): update CSS selector to .current since .current is always last.

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
+++ b/packages/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
@@ -47,7 +47,7 @@
   }
 }
 
-:host(.last) [role='listitem'] {
+.current {
   &::after {
     display: none;
   }


### PR DESCRIPTION
#556

## **Describe pull-request**  
Update CSS selector to hide the arrow on a breadcrumb to `.current` since .current is always last.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://tegel.atlassian.net/browse/CDEP-)    
- **GitHub:** #556
- **No issue:** Describe the problem being solved.  

## **How to test**  
1. Go to Breadcrumbs
2. Make sure the last breadcrumb has no arrow
3. Try it in the demo pages
4. Make sure to try it by navigating between pages

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [ ] `npm run build-all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
