### PR TITLE
docs(storybook-table): controls for overflow

### DIFF
--- a/packages/core/src/components/table/table-component-expandable-rows.stories.tsx
+++ b/packages/core/src/components/table/table-component-expandable-rows.stories.tsx
@@ -130,20 +130,23 @@ export default {
       control: {
         type: 'radio',
       },
-
-      options: ['auto', 'hidden'],
-      autoCollapse: {
-        name: 'Auto Collapse',
-        description: 'Automatically collapses other rows when one is expanded.',
-        control: {
-          type: 'boolean',
-        },
-        table: {
-          defaultValue: { summary: false },
-        },
+      options: ['auto', 'hidden', 'visible'],
+      table: {
+        defaultValue: { summary: 'auto' },
+      },
+    },
+    autoCollapse: {
+      name: 'Auto Collapse',
+      description: 'Automatically collapses other rows when one is expanded.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
   },
+
   args: {
     modeVariant: 'Inherit from parent',
     compactDesign: false,
@@ -155,7 +158,7 @@ export default {
     column2Width: '',
     column3Width: '',
     column4Width: '',
-    overflow: 'scroll',
+    overflow: 'auto',
     autoCollapse: false,
   },
 };


### PR DESCRIPTION
## **Describe pull-request**  
Adding missing config for storybook controls on expandable story

## **Issue Linking:**  
- **No issue:** Issue spotted "on-fly"

## **How to test**  
1. Go to preview link
2. Check Table Expandable rows story
3. Check that overflow control has default "auto" and possibility to switch to "hidden" and "visible"

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [x] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [x] Behavior available in storybook with documented descriptions (if applicable)
- [x] `npm run build-all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


