### PR TITLE
build: smoke test webhook

### DIFF
--- a/.github/workflows/smoke-test-all.yml
+++ b/.github/workflows/smoke-test-all.yml
@@ -213,3 +213,6 @@ jobs:
       - name: Check results
         run: |
           echo "All previous jobs have completed successfully!"
+      - name: Notify in Teams on failure
+        if: failure()
+        uses: ./.github/workflows/smoke-test-webhook.yml

--- a/.github/workflows/smoke-test-failure-webhook.yml
+++ b/.github/workflows/smoke-test-failure-webhook.yml
@@ -1,4 +1,4 @@
-name: Smoke test webhook
+name: 'ci: smoke test failure webhook'
 
 on:
   push:
@@ -8,19 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Run your build or tests
-        run: |
-          echo "Running build/test..."
-          # Replace this with your actual build/test command
-          exit 1 # Simulate failure
-
-      - name: Notify Teams on failure
-        if: failure()
+      - name: Post failure in Teams channel
         env:
           TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
           REPO_NAME: ${{ github.repository }}
@@ -64,7 +53,7 @@ jobs:
                   "actions": [
                     {
                       "type": "Action.OpenUrl",
-                      "title": "View failed jobs",
+                      "title": "View failed run",
                       "url": "'"${RUN_URL}"'"
                     }
                   ]

--- a/.github/workflows/smoketest-webhook.yml
+++ b/.github/workflows/smoketest-webhook.yml
@@ -32,29 +32,40 @@ jobs:
             "type": "message",
             "attachments": [
               {
-                "contentType": "application/vnd.microsoft.card.hero",
+                "contentType": "application/vnd.microsoft.card.adaptive",
                 "content": {
-                  "title": "Build Failure Notification",
-                  "text": "The build has failed. Please check the details.",
-                  "facts": [
+                  "type": "AdaptiveCard",
+                  "version": "1.0",
+                  "body": [
                     {
-                      "name": "Repository",
-                      "value": "'"${REPO_NAME}"'"
+                      "type": "TextBlock",
+                      "size": "Medium",
+                      "weight": "Bolder",
+                      "text": "Build Failure Notification"
                     },
                     {
-                      "name": "Branch",
-                      "value": "'"${BRANCH_NAME}"'"
-                    },
-                    {
-                      "name": "Commit",
-                      "value": "'"${COMMIT_SHA}"'"
+                      "type": "FactSet",
+                      "facts": [
+                        {
+                          "title": "Repository",
+                          "value": "'"${REPO_NAME}"'"
+                        },
+                        {
+                          "title": "Branch",
+                          "value": "'"${BRANCH_NAME}"'"
+                        },
+                        {
+                          "title": "Commit",
+                          "value": "'"${COMMIT_SHA}"'"
+                        }
+                      ]
                     }
                   ],
-                  "buttons": [
+                  "actions": [
                     {
-                      "type": "openUrl",
+                      "type": "Action.OpenUrl",
                       "title": "View Logs",
-                      "value": "'"${RUN_URL}"'"
+                      "url": "'"${RUN_URL}"'"
                     }
                   ]
                 }

--- a/.github/workflows/smoketest-webhook.yml
+++ b/.github/workflows/smoketest-webhook.yml
@@ -1,0 +1,63 @@
+name: Smoke test webhook
+
+on:
+  push:
+    branches:
+      - build/smoketest-webhook
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run your build or tests
+        run: |
+          echo "Running build/test..."
+          # Replace this with your actual build/test command
+          exit 1 # Simulate failure
+
+      - name: Notify Teams on failure
+        if: failure()
+        env:
+          TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          REPO_NAME: ${{ github.repository }}
+          BRANCH_NAME: ${{ github.ref }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        run: |
+          curl -H 'Content-Type: application/json' -d '{
+            "type": "message",
+            "attachments": [
+              {
+                "contentType": "application/vnd.microsoft.card.hero",
+                "content": {
+                  "title": "Build Failure Notification",
+                  "text": "The build has failed. Please check the details.",
+                  "facts": [
+                    {
+                      "name": "Repository",
+                      "value": "'"${REPO_NAME}"'"
+                    },
+                    {
+                      "name": "Branch",
+                      "value": "'"${BRANCH_NAME}"'"
+                    },
+                    {
+                      "name": "Commit",
+                      "value": "'"${COMMIT_SHA}"'"
+                    }
+                  ],
+                  "buttons": [
+                    {
+                      "type": "openUrl",
+                      "title": "View Logs",
+                      "value": "'"${RUN_URL}"'"
+                    }
+                  ]
+                }
+              }
+            ]
+          }' "$TEAMS_WEBHOOK_URL"

--- a/.github/workflows/smoketest-webhook.yml
+++ b/.github/workflows/smoketest-webhook.yml
@@ -64,7 +64,7 @@ jobs:
                   "actions": [
                     {
                       "type": "Action.OpenUrl",
-                      "title": "View Logs",
+                      "title": "View failed jobs",
                       "url": "'"${RUN_URL}"'"
                     }
                   ]


### PR DESCRIPTION
## **Describe pull-request**  
Added a Teams channel webhook that triggers a post with information once a failing smoke test occurs.

## **Issue Linking:**  
- **Jira:** [ci: Smoke test webhook in dev channel](https://tegel.atlassian.net/browse/CDEP-3562)

## **How to test**  
1. Go to GitHub Actions
2. Check for failed smoke test
3. If that is the case, check in teams channel under "IXI - Corporate Digital Experience -> Failed Jobs" for more information

## **Additional context**  
More improvements of the smoke test will be done in different PR:s
