### PR TITLE
fix(tds-slider): removed preventDefault for touchMove

### DIFF
--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -148,10 +148,6 @@ export class TdsSlider {
   @Listen('mousemove', { target: 'window' })
   @Listen('touchmove', { target: 'window' })
   handleMove(event: MouseEvent | TouchEvent) {
-    if (event.type === 'touchmove') {
-      event.preventDefault();
-    }
-
     if (!this.thumbGrabbed) {
       return;
     }


### PR DESCRIPTION
## **Describe pull-request**  
Removed preventDefault for touchmove.
**Tested on:**
- Chrome device: Galaxy S8+, Surface Pro 7, iPhone SE, iPad Air
- Physical devices: iPhone 14 Pro Max, iPad Pro

Issue was confirmed on Chrome emulated android devices.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-3566](https://tegel.atlassian.net/browse/CDEP-3566)
- **GitHub:** [812](https://github.com/scania-digital-design-system/tegel/issues/812)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to amplify link in chrome.
2. Open any android device through inspector device emulator, slider should now work.

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [x] `npm run build-all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


[CDEP-3566]: https://tegel.atlassian.net/browse/CDEP-3566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ