### PR TITLE
fix(text-field): counter label color in disabled state

### DIFF
--- a/packages/core/src/components/text-field/text-field-vars.scss
+++ b/packages/core/src/components/text-field/text-field-vars.scss
@@ -98,6 +98,9 @@
 
   //Textcounter
   --tds-text-field-textcounter: var(--tds-grey-600);
+
+  //when disabled
+  --tds-text-field-textcounter-disabled: var(--tds-grey-700);
   --tds-text-field-textcounter-divider: var(--tds-grey-700);
 
   //Prefix and Suffix

--- a/packages/core/src/components/text-field/text-field-vars.scss
+++ b/packages/core/src/components/text-field/text-field-vars.scss
@@ -34,6 +34,7 @@
 
   //Textcounter
   --tds-text-field-textcounter: var(--tds-grey-700);
+  --tds-text-field-textcounter-disabled: var(--tds-grey-400);
   --tds-text-field-textcounter-divider: var(--tds-grey-500);
 
   //Prefix and Suffix

--- a/packages/core/src/components/text-field/text-field.scss
+++ b/packages/core/src/components/text-field/text-field.scss
@@ -354,15 +354,27 @@
   flex-wrap: nowrap;
 }
 
+.text-field-textcounter-disabled {
+  color: var(--tds-text-field-textcounter-disabled);
+}
+
 .text-field-textcounter {
   font: var(--tds-detail-05);
   letter-spacing: var(--tds-detail-05-ls);
   color: var(--tds-text-field-textcounter);
   float: right;
 
-  & .text-field-textcounter-divider {
+  &.text-field-textcounter-disabled {
+    color: var(--tds-text-field-textcounter-disabled);
+  }
+
+  &.text-field-textcounter-divider {
     // @include type-style('detail-05');
     color: var(--tds-text-field-textcounter-divider);
+  }
+
+  &.text-field-textcounter-divider-disabled {
+    color: var(--tds-text-field-textcounter-divider-disabled);
   }
 }
 

--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -240,9 +240,22 @@ export class TdsTextField {
             {this.state !== 'error' && this.helper}
 
             {this.maxLength > 0 && (
-              <div class="text-field-textcounter">
+              <div
+                class={{
+                  'text-field-textcounter': true,
+                  'text-field-textcounter-disabled': this.disabled,
+                }}
+              >
                 {this.value === null ? 0 : this.value?.length}
-                <span class="text-field-textcounter-divider"> / </span>
+                <span
+                  class={{
+                    'text-field-textcounter-divider': true,
+                    'text-field-textcounter-disabled': this.disabled,
+                  }}
+                >
+                  {' '}
+                  /{' '}
+                </span>
                 {this.maxLength}
               </div>
             )}


### PR DESCRIPTION
## **Describe pull-request**  
This PR address the color on the text field counter label when its disabled. Adding a more toned down grey color to it when its disabled.

## **Issue Linking:**  
[CDEP-2669](https://tegel.atlassian.net/browse/CDEP-2669?atlOrigin=eyJpIjoiOGIxZWM0NGQyZWUxNGJiMWIwNmQ1NGRmZTc2MjI1ODMiLCJwIjoiaiJ9)

## **How to test**  
1. Go to aws storybook link
2. Navigate to the textfield component 
3. Add an limit to the textfield text and toggle disabled controller to true. 
4. Make sure it works as intended.
5. Also change to dark mode to make sure it looks good here as well.

## **Checklist before submission**
- [x] All existing tests pass
- [x] Not breaking production behavior
- [x] `npm run build-all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [x] Storybook controls
- [x] Dark/light mode and variants 


[CDEP-2669]: https://tegel.atlassian.net/browse/CDEP-2669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ