### PR TITLE
fix(text-field): label inside

### DIFF
--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -136,8 +136,8 @@ export class TdsTextField {
     return (
       <div
         class={{
+          'form-text-field': true,
           'form-text-field-nomin': this.noMinWidth,
-          'form-text-field': !this.focusInput || this.disabled,
           'text-field-focus': this.focusInput && !this.disabled,
           'text-field-data': this.value !== '' && this.value !== null,
           'text-field-container-label-inside':


### PR DESCRIPTION
## **Describe pull-request**  
The label inside in text field component has an issue. On focus it appears larger then it should be, it jumps in size.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-3598](https://tegel.atlassian.net/browse/CDEP-3598)    

## **How to test**  
1. Open the preview link
2. Check the Text Field component
3. Set a label inside, type some text and click outside and then back inside
4. Label should not change size or position
5. Do the same in prod or develop branch and observe the issue

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [x] `npm run build-all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


## **Additional context**  
Video of issue:


https://github.com/user-attachments/assets/133a328b-e56d-487c-911b-9b99e3b96979




[CDEP-3598]: https://tegel.atlassian.net/browse/CDEP-3598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ