### PR TITLE
fix(package): restore prettier as a dev dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -387,10 +387,10 @@
   "dependencies": {
     "@popperjs/core": "2.11.8",
     "@stencil/core": "4.19.2",
-    "date-fns": "2.30.0",
-    "prettier": "2.7.1"
+    "date-fns": "2.30.0"
   },
   "devDependencies": {
+    "prettier": "2.7.1",
     "@babel/core": "7.19.1",
     "@mdx-js/react": "3.0.1",
     "@playwright/test": "1.46.1",


### PR DESCRIPTION
## **Describe pull-request**  
Updating the package.json file so that we store prettier in dev-dependancies instead of dependancies.

## **Issue Linking:**  
[CDEP-3453](https://tegel.atlassian.net/browse/CDEP-3453?atlOrigin=eyJpIjoiNTY4MDY2YzMxZTZlNDgyN2JjYTA3OTg0M2JhOTk5NDMiLCJwIjoiaiJ9)

## **How to test**  
Checkout to this branch and try to spin up the project.

## **Checklist before submission**
- [x] All existing tests pass
- [x] Not breaking production behavior
- [x] `npm run build-all` without errors

[CDEP-3453]: https://tegel.atlassian.net/browse/CDEP-3453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ