### PR TITLE
fix(button): host in disabled state

### DIFF
--- a/packages/core/src/components/button/button.scss
+++ b/packages/core/src/components/button/button.scss
@@ -181,8 +181,12 @@ button {
   }
 }
 
-:host([disabled]) {
+:host([disabled]:active) {
   pointer-events: none;
+}
+
+:host([disabled]) button {
+  cursor: not-allowed;
 }
 
 :host(tds-button[fullbleed]) {

--- a/packages/core/src/components/button/button.scss
+++ b/packages/core/src/components/button/button.scss
@@ -37,19 +37,12 @@ button {
   padding: var(--tds-spacing-element-20);
   border: 1px solid;
 
-  &:disabled,
-  &.disabled {
-    cursor: unset;
-  }
-
   &:focus {
     outline: none;
   }
 
   &:focus-visible {
-    // TODO: decide on what tod o with these @include tds-focus-state;
-    outline: 2px solid var(--tds-blue-400);
-    outline-offset: -2px;
+    @include tds-focus-state;
   }
 
   &.xs {
@@ -57,12 +50,6 @@ button {
     height: $btn-xs-height;
     font-size: 12px;
     border-radius: 2px;
-
-    &:focus-visible {
-      // TODO: decide on what tod o with these @include tds-focus-state;
-      outline: 2px solid var(--tds-blue-400);
-      outline-offset: -2px;
-    }
   }
 
   &.sm {
@@ -75,12 +62,6 @@ button {
 
     &.only-icon {
       padding: $btn-sm-only-icon-padding;
-    }
-
-    &:focus-visible {
-      // TODO: decide on what tod o with these @include tds-focus-state;
-      outline: 2px solid var(--tds-blue-400);
-      outline-offset: -2px;
     }
   }
 
@@ -95,10 +76,6 @@ button {
     &.only-icon {
       padding: $btn-md-only-icon-padding;
     }
-
-    &:focus-visible {
-      @include tds-focus-state;
-    }
   }
 
   &.lg {
@@ -111,10 +88,6 @@ button {
 
     &.only-icon {
       padding: $btn-lg-only-icon-padding;
-    }
-
-    &:focus-visible {
-      @include tds-focus-state;
     }
   }
 
@@ -184,7 +157,6 @@ button {
       &.disabled,
       &:disabled {
         @each $prop in $props {
-          cursor: not-allowed;
           #{$prop}: var(--tds-btn-#{$type}-#{$prop}-disabled);
         }
       }
@@ -209,12 +181,8 @@ button {
   }
 }
 
-:host(tds-button[disabled='true']) {
+:host([disabled]) {
   pointer-events: none;
-
-  ::slotted([slot='icon']) {
-    pointer-events: none;
-  }
 }
 
 :host(tds-button[fullbleed]) {

--- a/packages/core/src/components/button/button.tsx
+++ b/packages/core/src/components/button/button.tsx
@@ -44,7 +44,10 @@ export class TdsButton {
       this.onlyIcon = true;
     }
     return (
-      <Host class={`${this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''}`}>
+      <Host
+        class={`${this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''} `}
+        disabled={this.disabled}
+      >
         <button
           type={this.type}
           disabled={this.disabled}

--- a/packages/core/src/components/button/test/disabled/button.e2e.ts
+++ b/packages/core/src/components/button/test/disabled/button.e2e.ts
@@ -21,12 +21,10 @@ test.describe.parallel('tds-button-disabled', () => {
     await expect(button).toBeDisabled();
   });
 
-  test('the pointer-events should be none', async ({ page }) => {
+  test('the cursor should be not-allowed', async ({ page }) => {
     await page.goto(componentTestPath);
     const button = page.getByTestId('tds-button-testid').getByRole('button');
-    const buttonCursorState = await button.evaluate(
-      (style) => getComputedStyle(style).pointerEvents,
-    );
-    expect(buttonCursorState).toBe('none');
+    const buttonCursorState = await button.evaluate((style) => getComputedStyle(style).cursor);
+    expect(buttonCursorState).toBe('not-allowed');
   });
 });

--- a/packages/core/src/components/button/test/disabled/button.e2e.ts
+++ b/packages/core/src/components/button/test/disabled/button.e2e.ts
@@ -21,10 +21,12 @@ test.describe.parallel('tds-button-disabled', () => {
     await expect(button).toBeDisabled();
   });
 
-  test('the cursor should be not-allowed', async ({ page }) => {
+  test('the pointer-events should be none', async ({ page }) => {
     await page.goto(componentTestPath);
     const button = page.getByTestId('tds-button-testid').getByRole('button');
-    const buttonCursorState = await button.evaluate((style) => getComputedStyle(style).cursor);
-    expect(buttonCursorState).toBe('not-allowed');
+    const buttonCursorState = await button.evaluate(
+      (style) => getComputedStyle(style).pointerEvents,
+    );
+    expect(buttonCursorState).toBe('none');
   });
 });


### PR DESCRIPTION
## **Describe pull-request**  
Added `disabled` attribute on host level and `pointer-events: none` once component is in disabled state so no event fires when the component is in that state. 
Additionally, I cleaned up the focus state so it uses mixin and only in one place, other places seemed to be repetitive without any value. 

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-3600](https://tegel.atlassian.net/browse/CDEP-3600)    
- **GitHub:** https://github.com/scania-digital-design-system/tegel/issues/833


## **How to test**  
1. Read the GitHub issue and how to recreate it.
2. Go to preview link.
3. Try to recreate the issue.
4. Try the same in production Storybook.
5. Preview link should behave as expected.

## **Checklist before submission**
- [x] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [x] `npm run build-all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [x] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [x] Events


## **Additional context**  
As `pointed-events: none* rule are used, not-allowed cursor style is not possible to be used anymore. So test is updated to reflect it. 

[CDEP-3600]: https://tegel.atlassian.net/browse/CDEP-3600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ