### PR TITLE
docs: update incorrect link

### DIFF
--- a/packages/core/src/stories/tegel.stories.ts
+++ b/packages/core/src/stories/tegel.stories.ts
@@ -61,7 +61,7 @@ export const TegelDesignSystem = {
                             you
                             want to try out the package today you can! It's available via <tds-link><a href="https://www.npmjs.com/package/@scania/tegel">NPM</a></tds-link> and can be installed using the
                             installation
-                            guide which you can find <tds-link><a target="_self" href="?path=/story/intro-installation--page">here.</a></tds-link>
+                            guide which you can find <tds-link><a target="_self" href="?path=/story/intro-installation--javascript">here.</a></tds-link>
                         </p>
 
                     </section>


### PR DESCRIPTION
## **Describe pull-request**  
The link to installation guide is incorrect.

## **How to test**  
Check out intro section in Storybook and verify that the "find here" link leads to correct installation part.

![Skärmavbild 2024-11-22 kl  08 40 15](https://github.com/user-attachments/assets/24235654-1af7-40b5-9214-8941d75b5042)

