### PR TITLE
feat: add a method to reset datetime value

### DIFF
--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -91,6 +91,16 @@ export class TdsDatetime {
   })
   tdsInput: EventEmitter<InputEvent>;
 
+  /** Method that resets the value of the Datetime, using defaultValue if is not 'none' */
+  @Method()
+  async reset() {
+    this.internalReset();
+    this.tdsChange.emit({
+      name: this.name,
+      value: this.value,
+    });
+  }
+
   /** Method that sets the value of the datetime element */
   @Method()
   async setValue(newValue: string) {
@@ -156,6 +166,15 @@ export class TdsDatetime {
   handleBlur(e: FocusEvent): void {
     this.textInput.blur();
     this.tdsBlur.emit(e);
+  }
+
+  /** Method that resets the dateteime without emitting an event. */
+  private internalReset() {
+    let value = '';
+    if (this.defaultValue !== 'none') {
+      this.value = this.getDefaultValue();
+    }
+    this.value = value;
   }
 
   render() {

--- a/packages/core/src/components/datetime/readme.md
+++ b/packages/core/src/components/datetime/readme.md
@@ -37,6 +37,16 @@
 
 ## Methods
 
+### `reset() => Promise<void>`
+
+Method that resets the value of the Datetime, using defaultValue if is not 'none'
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `setValue(newValue: string) => Promise<void>`
 
 Method that sets the value of the datetime element


### PR DESCRIPTION
## **Describe pull-request**  
This PR adds a method to reset the value of the datetime back to `''` or `defaultValue` if set.
I based this on the Dropdown `reset()` method. 

This is my first PR for **tegel**, so let me know if everything is ok.

## **Issue Linking:**  
_Choose one of the following options_
- **GitHub:** https://github.com/scania-digital-design-system/tegel/issues/821

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Whether you're using angular, react or web components:
2. Get datetime's element reference.
3. Invoke the `reset()` method.
4. Value should've gone back to default or `''`

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [x] I have updated the documentation (if applicable)
- [ x Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [x] `npm run build-all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls 
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [x] Events

## **Additional context** 

The Contributing file, doesn't really explain how to properly test locally. 
There is a valid observation to add that both tegel, and tegel-{framework} should be built and link in order for local testing to be available.
Would you like me to create a PR to include these instructions?