### PR TITLE
fix: popover test accepting a pixel diff ratio

### DIFF
--- a/packages/core/src/components/popover-canvas/test/show-true/popover-canvas.e2e.ts
+++ b/packages/core/src/components/popover-canvas/test/show-true/popover-canvas.e2e.ts
@@ -13,7 +13,7 @@ test.describe.parallel('tds-popover-canvas-show-true', () => {
     const popover = page.locator('tds-popover-core');
 
     // wait for it to be visible
-    await popover.waitFor();
+    await popover.waitFor({ state: 'visible' });
 
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixelRatio: 0.05 });

--- a/packages/core/src/components/popover-canvas/test/show-true/popover-canvas.e2e.ts
+++ b/packages/core/src/components/popover-canvas/test/show-true/popover-canvas.e2e.ts
@@ -9,8 +9,14 @@ test.describe.parallel('tds-popover-canvas-show-true', () => {
     const triggerButton = page.getByRole('button');
     await triggerButton.click();
 
+    // get popover element
+    const popover = page.locator('tds-popover-core');
+
+    // wait for it to be visible
+    await popover.waitFor();
+
     /* Check diff on screenshot */
-    await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
+    await expect(page).toHaveScreenshot({ maxDiffPixelRatio: 0.05 });
   });
 
   test('make sure the popover canvas content is displayed both before and after the trigger button is pressed', async ({

--- a/packages/core/src/components/popover-menu/test/show/popover-menu.e2e.ts
+++ b/packages/core/src/components/popover-menu/test/show/popover-menu.e2e.ts
@@ -8,7 +8,7 @@ test.describe.parallel('tds-popover-menu-show', () => {
     await page.goto(componentTestPath);
 
     /* Check diff on screenshot */
-    await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
+    await expect(page).toHaveScreenshot({ maxDiffPixelRatio: 0.05 });
   });
 
   test('clicking the trigger button should keep the popover menu dialog open when it is open by default', async ({


### PR DESCRIPTION
## **Describe pull-request**  
Popover test should accept a 5% pixel diff.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-3548](https://tegel.atlassian.net/browse/CDEP-3548)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. All popover test should pass, consistently.

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [x] `npm run build-all` without errors


[CDEP-3548]: https://tegel.atlassian.net/browse/CDEP-3548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ