### PR TITLE
feat: enable click on track in slider to update value

### DIFF
--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -186,7 +186,7 @@ export class TdsSlider {
     const numTicks = parseInt(this.ticks);
     const trackRect = this.trackElement.getBoundingClientRect();
     let localLeft = 0;
-    if (event.type === 'mousemove') {
+    if (event.type === 'mousemove' || event.type === 'click') {
       localLeft = event.clientX - trackRect.left;
     } else if (event.type === 'touchmove') {
       localLeft = event.touches[0].clientX - trackRect.left;
@@ -491,6 +491,7 @@ export class TdsSlider {
                 this.trackElement = el as HTMLElement;
               }}
               tabindex={this.disabled ? '-1' : '0'}
+              onClick={(event) => this.thumbCore(event)}
             >
               <div
                 class="tds-slider__track-fill"


### PR DESCRIPTION
## **Describe pull-request**  
Enables ability to click on the track in tds-slider to update its value

## **Issue Linking:**  
- **Jira:** [CDEP-3599](https://tegel.atlassian.net/browse/CDEP-3599) 

## **How to test**  
1. Go to http://localhost:6006/?path=/story/components-slider--default
2. Test clicking anywhere on the track and the value of the slider should update 

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [ ] `npm run build-all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
Not applicable

## **Additional context**  
- Not sure if it's possible or necessary to add unit tests for this feature
- Not sure if documentation should be updated for this
- The height of the track is quite small, so it's not super easy to manage to click on it, unless you're really paying attention. For this reason I think it's appropriate to increase the "clickable height" of the track, but I would like someone else to comment on this first.