### PR TITLE
test: refactor tests to use beforeEach for setup

### DIFF
--- a/packages/core/src/components/accordion/test/basic/accordion.e2e.ts
+++ b/packages/core/src/components/accordion/test/basic/accordion.e2e.ts
@@ -5,9 +5,12 @@ const componentTestPath = 'src/components/accordion/test/basic/index.html';
 const accordionSelector = 'tds-accordion';
 
 test.describe.parallel('tds-accordion', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(componentTestPath);
+  });
+
   test('renders basic accordion correctly', async ({ page }) => {
     // Define selector for accordion
-    await page.goto(componentTestPath);
     const accordion = page.locator(accordionSelector);
 
     // Check if accordion contains the correct text
@@ -20,7 +23,6 @@ test.describe.parallel('tds-accordion', () => {
 
   test('should handle hover on accordion items', async ({ page }) => {
     // Define selector for first accordion item
-    await page.goto(componentTestPath);
     const accordionFirstItem = page.getByText('First item');
 
     // Hover first accordion item
@@ -42,7 +44,6 @@ test.describe.parallel('tds-accordion', () => {
 
   test('second accordion item opens on click', async ({ page }) => {
     // Define selector for second accordion item
-    await page.goto(componentTestPath);
     const accordionSecondItem = page.getByText('Second item');
 
     // Hover second accordion item
@@ -54,7 +55,6 @@ test.describe.parallel('tds-accordion', () => {
 
   test('fires tdsToggle event on click', async ({ page }) => {
     // Define selector for first accordion item
-    await page.goto(componentTestPath);
     const accordionFirstItem = page.getByText('First item');
 
     // Define selector for second accordion item

--- a/packages/core/src/components/accordion/test/disabled/accordion.e2e.ts
+++ b/packages/core/src/components/accordion/test/disabled/accordion.e2e.ts
@@ -5,9 +5,12 @@ const componentTestPath = 'src/components/accordion/test/disabled/index.html';
 const accordionSelector = 'tds-accordion';
 
 test.describe.parallel('tds-accordion', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(componentTestPath);
+  });
+
   test('renders disabled accordion correctly', async ({ page }) => {
     // Define selector for accordion
-    await page.goto(componentTestPath);
     const accordion = page.locator(accordionSelector);
 
     // Check if accordion contains the correct text
@@ -20,7 +23,6 @@ test.describe.parallel('tds-accordion', () => {
 
   test('disabled accordion items should be displayed', async ({ page }) => {
     // Define selector for first accordion item
-    await page.goto(componentTestPath);
     const accordionFirstItem = page.locator(accordionSelector + '>> text=First item');
 
     // Expect first accordion item to be disabled
@@ -40,7 +42,6 @@ test.describe.parallel('tds-accordion', () => {
 
   test('cursor should be not-allowed on disabled accordion items', async ({ page }) => {
     // Define selector for first accordion item
-    await page.goto(componentTestPath);
     const accordionFirstItem = page.getByTestId('first-item');
     const accordionFirstItemButton = accordionFirstItem.getByRole('button');
 
@@ -68,7 +69,6 @@ test.describe.parallel('tds-accordion', () => {
 
   test('does not fire tdsToggle event on click on disabled accordion', async ({ page }) => {
     // Define selector for first accordion item
-    await page.goto(componentTestPath);
     const accordionFirstItem = page.getByText('First item');
 
     // Click first accordion item

--- a/packages/core/src/components/accordion/test/hide-last-border/accordion.e2e.ts
+++ b/packages/core/src/components/accordion/test/hide-last-border/accordion.e2e.ts
@@ -5,9 +5,12 @@ const componentTestPath = 'src/components/accordion/test/hide-last-border/index.
 const accordionSelector = 'tds-accordion';
 
 test.describe.parallel('tds-accordion', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(componentTestPath);
+  });
+
   test('renders accordion with hidden last border correctly', async ({ page }) => {
     // Define selector for accordion
-    await page.goto(componentTestPath);
     const accordion = page.locator(accordionSelector);
 
     // Check if accordion contains the correct text

--- a/packages/core/src/components/badge/test/basic/badge.e2e.ts
+++ b/packages/core/src/components/badge/test/basic/badge.e2e.ts
@@ -1,9 +1,14 @@
 import { test } from 'stencil-playwright';
 import { expect } from '@playwright/test';
 
+const componentTestPath = 'src/components/badge/test/basic/index.html';
+
 test.describe('tds-badge', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(componentTestPath);
+  });
+
   test('renders basic badge correctly', async ({ page }) => {
-    await page.goto('src/components/badge/test/basic/index.html');
     const accordion = page.locator('tds-badge');
     await expect(accordion).toHaveClass('hydrated');
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });

--- a/packages/core/src/components/badge/test/value/badge.e2e.ts
+++ b/packages/core/src/components/badge/test/value/badge.e2e.ts
@@ -1,10 +1,14 @@
 import { test } from 'stencil-playwright';
 import { expect } from '@playwright/test';
 
-test.describe('tds-badge', () => {
-  test('renders value badge correctly', async ({ page }) => {
-    await page.goto('src/components/badge/test/value/index.html');
+const componentTestPath = 'src/components/badge/test/value/index.html';
 
+test.describe('tds-badge', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(componentTestPath);
+  });
+
+  test('renders value badge correctly', async ({ page }) => {
     (await page.locator('tds-badge').all()).forEach(async (element) => {
       await expect(element).toHaveClass(/hydrated/);
     });

--- a/packages/core/src/components/banner/test/basic/banner.e2e.ts
+++ b/packages/core/src/components/banner/test/basic/banner.e2e.ts
@@ -4,16 +4,16 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/banner/test/basic/index.html';
 
 test.describe.parallel('tds-banner-basic', () => {
-  test('renders basic banner correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders basic banner correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('the close button should be visible', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const closeButton = page.getByRole('button');
     await expect(closeButton).toBeVisible();
   });

--- a/packages/core/src/components/banner/test/default/banner.e2e.ts
+++ b/packages/core/src/components/banner/test/default/banner.e2e.ts
@@ -4,45 +4,37 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/banner/test/default/index.html';
 
 test.describe.parallel('tds-banner-default', () => {
-  test('renders default banner correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders default banner correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('header exists', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const bannerHeader = page.getByText('This is a header text area', { exact: true });
     await expect(bannerHeader).toBeVisible();
   });
 
   test('text exists', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const bannerSubheader = page.getByText('This is the subheader text area', { exact: true });
     await expect(bannerSubheader).toBeVisible();
   });
 
   test('icons exists', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const images = page.getByRole('img');
     await expect(images).toHaveCount(2);
   });
 
   test('link example exists', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const linkExample = page.getByRole('link');
     await expect(linkExample).toHaveCount(1);
     await expect(linkExample).toBeVisible();
   });
 
   test('close button exists', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const closeButton = page.getByRole('button');
     await expect(closeButton).toHaveCount(1);
     await expect(closeButton).toBeVisible();

--- a/packages/core/src/components/banner/test/error/banner.e2e.ts
+++ b/packages/core/src/components/banner/test/error/banner.e2e.ts
@@ -4,16 +4,16 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/banner/test/error/index.html';
 
 test.describe.parallel('tds-banner-error', () => {
-  test('renders error banner correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders error banner correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('icons exists', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const images = page.getByRole('img');
     await expect(images).toHaveCount(2);
   });

--- a/packages/core/src/components/banner/test/information/banner.e2e.ts
+++ b/packages/core/src/components/banner/test/information/banner.e2e.ts
@@ -4,16 +4,16 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/banner/test/information/index.html';
 
 test.describe.parallel('tds-banner-information', () => {
-  test('renders information banner correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders information banner correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('icons exists', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const images = page.getByRole('img');
     await expect(images).toHaveCount(2);
   });

--- a/packages/core/src/components/block/test/2-level-light-mode/block.e2e.ts
+++ b/packages/core/src/components/block/test/2-level-light-mode/block.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/block/test/2-level-light-mode/index.html';
 
 test.describe.parallel('tds-block-2-level-light-mode', () => {
-  test('renders 2 level block correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders 2 level block correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });

--- a/packages/core/src/components/block/test/3-level-dark-mode/block.e2e.ts
+++ b/packages/core/src/components/block/test/3-level-dark-mode/block.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/block/test/3-level-dark-mode/index.html';
 
 test.describe.parallel('tds-block-3-level-dark-mode', () => {
-  test('renders 2 level block correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders 2 level block correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });

--- a/packages/core/src/components/breadcrumbs/test/default/breadcrumbs.e2e.ts
+++ b/packages/core/src/components/breadcrumbs/test/default/breadcrumbs.e2e.ts
@@ -4,15 +4,16 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/breadcrumbs/test/default/index.html';
 
 test.describe.parallel('tds-breadcrumbs-default', () => {
-  test('renders default breadcrumbs correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders default breadcrumbs correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('items Page 1, Page 2, Page 3 exist on the page', async ({ page }) => {
-    await page.goto(componentTestPath);
     const navigation = page.getByRole('navigation');
     await expect(navigation).toHaveCount(1);
     const listItems = page.getByRole('listitem');
@@ -32,8 +33,6 @@ test.describe.parallel('tds-breadcrumbs-default', () => {
   });
 
   test('page 3 item should be able to become focused', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const pageThree = page.getByText(/Page 3/);
     await pageThree.focus();
 

--- a/packages/core/src/components/button/test/basic/button.e2e.ts
+++ b/packages/core/src/components/button/test/basic/button.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/button/test/basic/index.html';
 
 test.describe.parallel('tds-button-basic', () => {
-  test('renders basic button correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders basic button correctly', async ({ page }) => {
     const button = page.getByTestId('tds-button-testid');
     await expect(button).toHaveCount(1);
 
@@ -14,7 +17,6 @@ test.describe.parallel('tds-button-basic', () => {
   });
 
   test('component receives click event', async ({ page }) => {
-    await page.goto(componentTestPath);
     const button = page.getByRole('button');
     const myEventSpy = await page.spyOnEvent('click');
     await button.click();
@@ -22,19 +24,16 @@ test.describe.parallel('tds-button-basic', () => {
   });
 
   test('expect button to be of role button', async ({ page }) => {
-    await page.goto(componentTestPath);
     const button = page.getByRole('button');
     await expect(button).toHaveCount(1);
   });
 
   test('Text is displayed', async ({ page }) => {
-    await page.goto(componentTestPath);
     const button = page.getByText('Button', { exact: true });
     await expect(button).toBeVisible();
   });
 
   test('Check so that height is correct to lg/default measurements', async ({ page }) => {
-    await page.goto(componentTestPath);
     const button = page.getByText('Button', { exact: true });
     const buttonHeight = await button.evaluate((style) => getComputedStyle(style).height);
     expect(buttonHeight).toBe('56px');

--- a/packages/core/src/components/button/test/danger/button.e2e.ts
+++ b/packages/core/src/components/button/test/danger/button.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/button/test/danger/index.html';
 
 test.describe.parallel('tds-button-danger', () => {
-  test('renders danger button correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders danger button correctly', async ({ page }) => {
     const button = page.getByTestId('tds-button-testid');
     await expect(button).toHaveCount(1);
 
@@ -14,7 +17,6 @@ test.describe.parallel('tds-button-danger', () => {
   });
 
   test('Check so that height is correct to sm measurements', async ({ page }) => {
-    await page.goto(componentTestPath);
     const button = page.getByText('Button', { exact: true });
     const buttonHeight = await button.evaluate((style) => getComputedStyle(style).height);
     expect(buttonHeight).toBe('40px');

--- a/packages/core/src/components/button/test/disabled/button.e2e.ts
+++ b/packages/core/src/components/button/test/disabled/button.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/button/test/disabled/index.html';
 
 test.describe.parallel('tds-button-disabled', () => {
-  test('renders disabled button correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders disabled button correctly', async ({ page }) => {
     const button = page.getByTestId('tds-button-testid');
     await expect(button).toHaveCount(1);
 
@@ -14,15 +17,12 @@ test.describe.parallel('tds-button-disabled', () => {
   });
 
   test('disabled button should be disabled', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     /* Check if disabled */
     const button = page.getByRole('button');
     await expect(button).toBeDisabled();
   });
 
   test('the cursor should be not-allowed', async ({ page }) => {
-    await page.goto(componentTestPath);
     const button = page.getByTestId('tds-button-testid').getByRole('button');
     const buttonCursorState = await button.evaluate((style) => getComputedStyle(style).cursor);
     expect(buttonCursorState).toBe('not-allowed');

--- a/packages/core/src/components/button/test/ghost/button.e2e.ts
+++ b/packages/core/src/components/button/test/ghost/button.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/button/test/ghost/index.html';
 
 test.describe.parallel('tds-button-ghost', () => {
-  test('renders ghost button correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders ghost button correctly', async ({ page }) => {
     const button = page.getByTestId('tds-button-testid');
     await expect(button).toHaveCount(1);
 
@@ -14,7 +17,6 @@ test.describe.parallel('tds-button-ghost', () => {
   });
 
   test('Check so that height is correct to md measurements', async ({ page }) => {
-    await page.goto(componentTestPath);
     const button = page.getByText('Button', { exact: true });
     const buttonHeight = await button.evaluate((style) => getComputedStyle(style).height);
     expect(buttonHeight).toBe('24px');

--- a/packages/core/src/components/button/test/icon/button.e2e.ts
+++ b/packages/core/src/components/button/test/icon/button.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/button/test/icon/index.html';
 
 test.describe.parallel('tds-button-icon', () => {
-  test('renders icon button correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders icon button correctly', async ({ page }) => {
     const button = page.getByTestId('tds-button-testid');
     await expect(button).toHaveCount(1);
 
@@ -14,7 +17,6 @@ test.describe.parallel('tds-button-icon', () => {
   });
 
   test('icon should exist', async ({ page }) => {
-    await page.goto(componentTestPath);
     const icon = page.getByRole('img');
     await expect(icon).toBeVisible();
   });
@@ -22,7 +24,6 @@ test.describe.parallel('tds-button-icon', () => {
   test('Check so that height and width is correct to lg/default measurements with a single button', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const button = page.getByRole('button');
     const buttonHeight = await button.evaluate((style) => getComputedStyle(style).height);
     expect(buttonHeight).toBe('56px');
@@ -39,7 +40,6 @@ test.describe.parallel('tds-button-icon', () => {
   test('Check so that height and width is correct to lg/default measurements with a single button for the icon', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const icon = page.getByRole('img');
     const iconHeight = await icon.evaluate((style) => getComputedStyle(style).height);
     expect(iconHeight).toBe('20px');

--- a/packages/core/src/components/button/test/secondary/button.e2e.ts
+++ b/packages/core/src/components/button/test/secondary/button.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/button/test/secondary/index.html';
 
 test.describe.parallel('tds-button-secondary', () => {
-  test('renders secondary button correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders secondary button correctly', async ({ page }) => {
     const button = page.getByTestId('tds-button-testid');
     await expect(button).toHaveCount(1);
 
@@ -14,7 +17,6 @@ test.describe.parallel('tds-button-secondary', () => {
   });
 
   test('Check so that height is correct to md measurements', async ({ page }) => {
-    await page.goto(componentTestPath);
     const button = page.getByText('Button', { exact: true });
     const buttonHeight = await button.evaluate((style) => getComputedStyle(style).height);
     expect(buttonHeight).toBe('48px');

--- a/packages/core/src/components/card/test/basic/card.e2e.ts
+++ b/packages/core/src/components/card/test/basic/card.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/card/test/basic/index.html';
 
 test.describe('tds-card-basic', () => {
-  test('renders basic card correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders basic card correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });

--- a/packages/core/src/components/card/test/clickable/card.e2e.ts
+++ b/packages/core/src/components/card/test/clickable/card.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/card/test/clickable/index.html';
 
 test.describe.parallel('tds-card-clickable', () => {
-  test('renders clickable card correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders clickable card correctly', async ({ page }) => {
     const cardButton = page.getByRole('button');
     await cardButton.hover();
 
@@ -14,7 +17,6 @@ test.describe.parallel('tds-card-clickable', () => {
   });
 
   test('card should contain a button that is clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const cardButton = page.getByRole('button');
     await expect(cardButton).toHaveCount(1);
     await expect(cardButton).toBeVisible();

--- a/packages/core/src/components/card/test/default/card.e2e.ts
+++ b/packages/core/src/components/card/test/default/card.e2e.ts
@@ -4,36 +4,34 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/card/test/default/index.html';
 
 test.describe.parallel('tds-card-default', () => {
-  test('renders default card correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders default card correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('header text exists', async ({ page }) => {
-    await page.goto(componentTestPath);
     const cardHeaderText = page.getByText('Header text', { exact: true });
     await expect(cardHeaderText).toHaveCount(1);
     await expect(cardHeaderText).toBeVisible();
   });
 
   test('subheader text exists', async ({ page }) => {
-    await page.goto(componentTestPath);
     const cardSubheaderText = page.getByText('Subheader text', { exact: true });
     await expect(cardSubheaderText).toHaveCount(1);
     await expect(cardSubheaderText).toBeVisible();
   });
 
   test('arrow icon exists', async ({ page }) => {
-    await page.goto(componentTestPath);
     const cardTdsIcon = page.getByRole('img');
     await expect(cardTdsIcon).toHaveCount(1);
     await expect(cardTdsIcon).toBeVisible();
   });
 
   test('card should not contain a button that is clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const cardButton = page.getByRole('button');
     await expect(cardButton).toHaveCount(0);
   });

--- a/packages/core/src/components/checkbox/test/default/checkbox.e2e.ts
+++ b/packages/core/src/components/checkbox/test/default/checkbox.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/checkbox/test/default/index.html';
 
 test.describe.parallel('tds-checkbox', () => {
-  test('renders basic checkbox correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders basic checkbox correctly', async ({ page }) => {
     const labelElement = page.locator('tds-checkbox label'); // Target label underneath checkbox
 
     expect(labelElement).toHaveText('Label'); // Check label text
@@ -14,7 +17,6 @@ test.describe.parallel('tds-checkbox', () => {
   });
 
   test('Hover and click on checkbox -> should become checked', async ({ page }) => {
-    await page.goto(componentTestPath);
     const checkbox = page.locator('tds-checkbox');
     // Hover over the checkbox
     await checkbox.hover();

--- a/packages/core/src/components/checkbox/test/disabled/checkbox.e2e.ts
+++ b/packages/core/src/components/checkbox/test/disabled/checkbox.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/checkbox/test/disabled/index.html';
 
 test.describe('tds-checkbox', () => {
-  test('Hover over checkbox and label -> cursor should become inactive', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('Hover over checkbox and label -> cursor should become inactive', async ({ page }) => {
     // Find the checkbox and label elements
     const checkbox = page.locator('tds-checkbox');
     const input = page.locator('tds-checkbox input');

--- a/packages/core/src/components/checkbox/test/indeterminate/checkbox.e2e.ts
+++ b/packages/core/src/components/checkbox/test/indeterminate/checkbox.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/checkbox/test/indeterminate/index.html';
 
 test.describe('tds-checkbox', () => {
-  test('Checkbox indeterminate state', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('Checkbox indeterminate state', async ({ page }) => {
     // Find the checkbox and label elements
     const checkbox = page.locator('tds-checkbox');
     const labelElement = page.locator('tds-checkbox label'); // Target label underneath checkbox

--- a/packages/core/src/components/chip/test/checkbox/chip.e2e.ts
+++ b/packages/core/src/components/chip/test/checkbox/chip.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/chip/test/checkbox/index.html';
 
 test.describe.parallel('tds-chip-checkbox', () => {
-  test('renders checkbox chips correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders checkbox chips correctly', async ({ page }) => {
     const chip1 = page.getByText('Label 1', { exact: true });
     await expect(chip1).toHaveCount(1);
 
@@ -20,13 +23,11 @@ test.describe.parallel('tds-chip-checkbox', () => {
   });
 
   test('expect chips to be of the role checkbox', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chipRole = page.getByRole('checkbox');
     await expect(chipRole).toHaveCount(3);
   });
 
   test('Check so that height is correct to lg/default measurements', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chip1 = page.locator('tds-chip label').filter({ hasText: `Label 1` });
     const chipHeight1 = await chip1.evaluate((style) => getComputedStyle(style).height);
     expect(chipHeight1).toBe('32px');
@@ -41,7 +42,6 @@ test.describe.parallel('tds-chip-checkbox', () => {
   });
 
   test('Chip 1 is clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chip = page.locator('tds-chip label').filter({ hasText: `Label 1` });
     chip.hover();
     const chipCursorStyle = await chip.evaluate((style) => getComputedStyle(style).cursor);
@@ -53,7 +53,6 @@ test.describe.parallel('tds-chip-checkbox', () => {
   });
 
   test('Chip 2 is clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chip = page.locator('tds-chip label').filter({ hasText: `Label 2` });
     chip.hover();
     const chipCursorStyle = await chip.evaluate((style) => getComputedStyle(style).cursor);
@@ -65,7 +64,6 @@ test.describe.parallel('tds-chip-checkbox', () => {
   });
 
   test('Chip 3 is clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chip = page.locator('tds-chip label').filter({ hasText: `Label 3` });
     chip.hover();
     const chipCursorStyle = await chip.evaluate((style) => getComputedStyle(style).cursor);
@@ -77,14 +75,12 @@ test.describe.parallel('tds-chip-checkbox', () => {
   });
 
   test('1st chip is checked', async ({ page }) => {
-    await page.goto(componentTestPath);
     const checkedLabel1Chip = page.locator('input[id="option-1"]');
     const isChecked = await checkedLabel1Chip.evaluate((node: HTMLInputElement) => node.checked);
     expect(isChecked).toBeTruthy();
   });
 
   test('Clicking "Label 2" chip changes checked state appropriately', async ({ page }) => {
-    await page.goto(componentTestPath);
     const labelText2 = page.locator('text=Label 2');
     await labelText2.click();
     const chip1 = page.locator('input[id="option-1"]');
@@ -107,7 +103,6 @@ test.describe.parallel('tds-chip-checkbox', () => {
   test('Clicking "Label 2" and "Label 3" chips changes checked state appropriately', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const labelText2 = page.locator('text=Label 2');
     await labelText2.click();
     const labelText3 = page.locator('text=Label 3');
@@ -132,7 +127,6 @@ test.describe.parallel('tds-chip-checkbox', () => {
   test('Clicking "Label 1", "Label 2" and "Label 3" chips changes checked state appropriately', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const labelText1 = page.locator('text=Label 1');
     await labelText1.click();
     const labelText2 = page.locator('text=Label 2');

--- a/packages/core/src/components/chip/test/default/chip.e2e.ts
+++ b/packages/core/src/components/chip/test/default/chip.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/chip/test/default/index.html';
 
 test.describe.parallel('tds-chip-default', () => {
-  test('renders default chip correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default chip correctly', async ({ page }) => {
     const chip = page.locator('tds-chip');
     await expect(chip).toHaveCount(1);
 
@@ -17,20 +20,17 @@ test.describe.parallel('tds-chip-default', () => {
   });
 
   test('expect chip to be of the role button', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chipRole = page.getByRole('button');
     await expect(chipRole).toHaveCount(1);
   });
 
   test('Check so that height is correct to lg/default measurements', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chip = page.locator('tds-chip label');
     const chipHeight = await chip.evaluate((style) => getComputedStyle(style).height);
     expect(chipHeight).toBe('32px');
   });
 
   test('Chip is clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chip = page.locator('tds-chip label');
     chip.hover();
     const chipCursorStyle = await chip.evaluate((style) => getComputedStyle(style).cursor);

--- a/packages/core/src/components/chip/test/disabled/chip.e2e.ts
+++ b/packages/core/src/components/chip/test/disabled/chip.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/chip/test/disabled/index.html';
 
 test.describe.parallel('tds-chip-checkbox', () => {
-  test('renders checkbox chips correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders checkbox chips correctly', async ({ page }) => {
     const chip1 = page.getByText('Label 1', { exact: true });
     await expect(chip1).toHaveCount(1);
 
@@ -20,7 +23,6 @@ test.describe.parallel('tds-chip-checkbox', () => {
   });
 
   test('Chip 1 is disabled and not clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chip1 = page.locator('tds-chip[chip-id="option-1"]');
 
     const isDisabled = await chip1.evaluate((el) => el.hasAttribute('disabled'));
@@ -35,7 +37,6 @@ test.describe.parallel('tds-chip-checkbox', () => {
   });
 
   test('Chip 2 is clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const checkboxLabel2 = page.locator('tds-chip[type="checkbox"] >> text=Label 2');
     checkboxLabel2.hover();
     const chipCursorStyle = await checkboxLabel2.evaluate(
@@ -49,7 +50,6 @@ test.describe.parallel('tds-chip-checkbox', () => {
   });
 
   test('Chip 3 is clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const checkboxLabel3 = page.locator('tds-chip[type="checkbox"] >> text=Label 2');
     checkboxLabel3.hover();
     const chipCursorStyle = await checkboxLabel3.evaluate(
@@ -63,8 +63,11 @@ test.describe.parallel('tds-chip-checkbox', () => {
   });
 });
 test.describe.parallel('tds-chip-radio', () => {
-  test('renders radio chips correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders radio chips correctly', async ({ page }) => {
     const chip1 = page.getByText('Label 1 for radio', { exact: true });
     await expect(chip1).toHaveCount(1);
 
@@ -79,7 +82,6 @@ test.describe.parallel('tds-chip-radio', () => {
   });
 
   test('Radio Chip 1 is disabled and not clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const radioChip1 = page.locator('tds-chip[chip-id="radio-option-1"]');
 
     const isDisabled = await radioChip1.evaluate((el) => el.hasAttribute('disabled'));
@@ -95,8 +97,11 @@ test.describe.parallel('tds-chip-radio', () => {
 });
 
 test.describe.parallel('tds-chip-button', () => {
-  test('renders button chips correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders button chips correctly', async ({ page }) => {
     const chip1 = page.getByText('Label 1 for button', { exact: true });
     await expect(chip1).toHaveCount(1);
 
@@ -111,7 +116,6 @@ test.describe.parallel('tds-chip-button', () => {
   });
 
   test('Button Chip 1 is disabled and not clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const buttonChip1 = page.locator('tds-chip[chip-id="button-option-1"]');
 
     const isDisabled = await buttonChip1.evaluate((el) => el.hasAttribute('disabled'));

--- a/packages/core/src/components/chip/test/icon/chip.e2e.ts
+++ b/packages/core/src/components/chip/test/icon/chip.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/chip/test/icon/index.html';
 
 test.describe.parallel('tds-chip-default', () => {
-  test('renders default chip correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default chip correctly', async ({ page }) => {
     const chip = page.locator('tds-chip');
     await expect(chip).toHaveCount(1);
 
@@ -17,13 +20,11 @@ test.describe.parallel('tds-chip-default', () => {
   });
 
   test('expect chip to be of the role button', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chipRole = page.getByRole('button');
     await expect(chipRole).toHaveCount(1);
   });
 
   test('Check so that the chip contains an icon', async ({ page }) => {
-    await page.goto(componentTestPath);
     const icon = page.locator('tds-icon');
     await expect(icon).toBeVisible();
     await expect(icon).toHaveAttribute('name', 'star');

--- a/packages/core/src/components/chip/test/radio/chip.e2e.ts
+++ b/packages/core/src/components/chip/test/radio/chip.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/chip/test/radio/index.html';
 
 test.describe.parallel('tds-chip-radio', () => {
-  test('renders radio chips correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders radio chips correctly', async ({ page }) => {
     const chip1 = page.getByText('Label 1', { exact: true });
     await expect(chip1).toHaveCount(1);
 
@@ -20,13 +23,11 @@ test.describe.parallel('tds-chip-radio', () => {
   });
 
   test('expect chips to be of the role radio', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chipRole = page.getByRole('radio');
     await expect(chipRole).toHaveCount(3);
   });
 
   test('Check so that height is correct to lg/default measurements', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chip1 = page.locator('tds-chip label').filter({ hasText: `Label 1` });
     const chipHeight1 = await chip1.evaluate((style) => getComputedStyle(style).height);
     expect(chipHeight1).toBe('32px');
@@ -41,7 +42,6 @@ test.describe.parallel('tds-chip-radio', () => {
   });
 
   test('Chip 1 is clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chip = page.locator('tds-chip label').filter({ hasText: `Label 1` });
     chip.hover();
     const chipCursorStyle = await chip.evaluate((style) => getComputedStyle(style).cursor);
@@ -53,7 +53,6 @@ test.describe.parallel('tds-chip-radio', () => {
   });
 
   test('Chip 2 is clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chip = page.locator('tds-chip label').filter({ hasText: `Label 2` });
     chip.hover();
     const chipCursorStyle = await chip.evaluate((style) => getComputedStyle(style).cursor);
@@ -65,7 +64,6 @@ test.describe.parallel('tds-chip-radio', () => {
   });
 
   test('Chip 3 is clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const chip = page.locator('tds-chip label').filter({ hasText: `Label 3` });
     chip.hover();
     const chipCursorStyle = await chip.evaluate((style) => getComputedStyle(style).cursor);
@@ -77,14 +75,12 @@ test.describe.parallel('tds-chip-radio', () => {
   });
 
   test('2nd chip is checked', async ({ page }) => {
-    await page.goto(componentTestPath);
     const checkedLabel2Chip = page.locator('input[id="option-2"]');
     const isChecked = await checkedLabel2Chip.evaluate((node: HTMLInputElement) => node.checked);
     expect(isChecked).toBeTruthy();
   });
 
   test('Clicking "Label 1" chip changes checked state appropriately', async ({ page }) => {
-    await page.goto(componentTestPath);
     const labelText1 = page.locator('text=Label 1');
     await labelText1.click();
     const chip1 = page.locator('input[id="option-1"]');
@@ -105,7 +101,6 @@ test.describe.parallel('tds-chip-radio', () => {
   });
 
   test('Clicking "Label 3" chip changes checked state appropriately', async ({ page }) => {
-    await page.goto(componentTestPath);
     const labelText3 = page.locator('text=Label 3');
     await labelText3.click();
     const chip1 = page.locator('input[id="option-1"]');

--- a/packages/core/src/components/datetime/test/default/datetime.e2e.ts
+++ b/packages/core/src/components/datetime/test/default/datetime.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/datetime/test/default/index.html';
 
 test.describe('tds-datetime-default', () => {
-  test('renders datetime component correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders datetime component correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
@@ -14,8 +16,6 @@ test.describe('tds-datetime-default', () => {
   test('verifies label, helper text, size, and calendar icon for datetime-local component', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
-
     // Check for the label text
     const label = page.locator('.tds-datetime-label');
     const dateTime = page.locator('tds-datetime');
@@ -36,8 +36,6 @@ test.describe('tds-datetime-default', () => {
   });
 
   test('icon click triggers native datetime picker', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     // Assuming the calendar icon can be clicked to open the datetime picker
     await page.click('input[type="datetime-local"]');
 
@@ -52,8 +50,6 @@ test.describe('tds-datetime-default', () => {
   });
 
   test('setting input to current date and time programmatically', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     // Get the current date and time, formatted as 'YYYY-MM-DDThh:mm', which is the expected format for datetime-local inputs
     const currentDate = new Date().toISOString().slice(0, 16);
 

--- a/packages/core/src/components/datetime/test/disabled/datetime.e2e.ts
+++ b/packages/core/src/components/datetime/test/disabled/datetime.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/datetime/test/disabled/index.html';
 
 test.describe('tds-datetime-disabled', () => {
-  test('renders disabled datetime component correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders disabled datetime component correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
@@ -14,8 +16,6 @@ test.describe('tds-datetime-disabled', () => {
   test('when in disabled state all but helper text should have pointer events none', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
-
     // Check for disabled state of the datetime input
     const datetimeInput = page.locator('input[type="datetime-local"]');
     const label = page.locator('label');

--- a/packages/core/src/components/datetime/test/error/datetime.e2e.ts
+++ b/packages/core/src/components/datetime/test/error/datetime.e2e.ts
@@ -4,16 +4,16 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/datetime/test/error/index.html';
 
 test.describe('tds-datetime-error', () => {
-  test('renders disabled datetime component correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders disabled datetime component correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('verifies label, helper text, size, and clock icon for time component', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     // Check for the label text
     const label = page.locator('.tds-datetime-label');
     const helperText = page.locator('.tds-datetime-helper .tds-helper');
@@ -35,8 +35,6 @@ test.describe('tds-datetime-error', () => {
   });
 
   test('helper text in error state has is red and has an error icon', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     // Check helper text color for specific shade of red
     await expect(page.locator('.tds-datetime-helper .tds-helper')).toHaveCSS(
       'color',
@@ -48,8 +46,6 @@ test.describe('tds-datetime-error', () => {
   });
 
   test('Clock icon focuses the time input', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     await page.click('input[type="time"]');
 
     // Check if the time input is focused after clicking the icon
@@ -61,8 +57,6 @@ test.describe('tds-datetime-error', () => {
   });
 
   test('Simulate time selection and verify format', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     await page.click('input[type="time"]');
 
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });

--- a/packages/core/src/components/datetime/test/success/datetime.e2e.ts
+++ b/packages/core/src/components/datetime/test/success/datetime.e2e.ts
@@ -4,15 +4,16 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/datetime/test/success/index.html';
 
 test.describe('tds-datetime-success', () => {
-  test('renders success datetime component correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders success datetime component correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('component should have size "md"', async ({ page }) => {
-    await page.goto(componentTestPath);
     const dateTime = page.locator('tds-datetime');
     const dateTimeContainer = page.locator('.tds-datetime-container');
 

--- a/packages/core/src/components/divider/test/darkmode/darkmode.e2e.ts
+++ b/packages/core/src/components/divider/test/darkmode/darkmode.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/divider/test/darkmode/index.html';
 
 test.describe.parallel('tds-divider', () => {
-  test('expect to render a divider in darkmode', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('expect to render a divider in darkmode', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });

--- a/packages/core/src/components/divider/test/horizontal/divider.e2e.ts
+++ b/packages/core/src/components/divider/test/horizontal/divider.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/divider/test/horizontal/index.html';
 
 test.describe.parallel('tds-divider', () => {
-  test('expect to render a horizontal divider', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('expect to render a horizontal divider', async ({ page }) => {
     // expect width to be greater than height
     const divider = page.getByTestId('divider').locator('div.divider').first();
     const box = await divider.boundingBox();

--- a/packages/core/src/components/divider/test/vertical/divider.e2e.ts
+++ b/packages/core/src/components/divider/test/vertical/divider.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/divider/test/vertical/index.html';
 
 test.describe.parallel('tds-divider', () => {
-  test('expect to render a vertical divider', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('expect to render a vertical divider', async ({ page }) => {
     // expect height to be greater than width
     const divider = page.getByTestId('divider').locator('div.divider').first();
     const box = await divider.boundingBox();

--- a/packages/core/src/components/dropdown/test/basic/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/basic/dropdown.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/dropdown/test/basic/index.html';
 
 test.describe.parallel('tds-dropdown-basic', () => {
-  test('renders basic dropdown correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders basic dropdown correctly', async ({ page }) => {
     const dropdown = page.getByTestId('tds-dropdown-testid');
     await expect(dropdown).toHaveCount(1);
 
@@ -14,25 +17,21 @@ test.describe.parallel('tds-dropdown-basic', () => {
   });
 
   test('should find label and not exist', async ({ page }) => {
-    await page.goto(componentTestPath);
     const labelText = page.getByText(/Label text/);
     await expect(labelText).toHaveCount(0);
   });
 
   test('find helper text and check not exist', async ({ page }) => {
-    await page.goto(componentTestPath);
     const helperText = page.getByText(/Helper text/);
     await expect(helperText).toHaveCount(0);
   });
 
   test('have the button to be visible', async ({ page }) => {
-    await page.goto(componentTestPath);
     const dropdownButton = page.getByRole('button').first();
     await expect(dropdownButton).toBeVisible();
   });
 
   test('clicking the dropdown button opens the dropdown-list', async ({ page }) => {
-    await page.goto(componentTestPath);
     const dropdownButton = page.getByRole('button').first();
     const dropdownListElementOne = page
       .locator('tds-dropdown-option')
@@ -48,8 +47,6 @@ test.describe.parallel('tds-dropdown-basic', () => {
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
   test('reset() method resets the dropdown', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const dropdown = page.getByTestId('tds-dropdown-testid');
 
     const dropdownButton = dropdown.getByRole('button').first();

--- a/packages/core/src/components/dropdown/test/default/disabled/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/default/disabled/dropdown.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/dropdown/test/default/disabled/index.html';
 
 test.describe.parallel('tds-dropdown-disabled', () => {
-  test('clicking the dropdown icon does not open the dropdown-list', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('clicking the dropdown icon does not open the dropdown-list', async ({ page }) => {
     const dropdownButtonIcon = page.locator('tds-icon');
 
     const dropdownListElementOne = page
@@ -24,7 +27,6 @@ test.describe.parallel('tds-dropdown-disabled', () => {
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
   test('clicking the dropdown button does not open the dropdown-list', async ({ page }) => {
-    await page.goto(componentTestPath);
     const dropdownButton = page.getByRole('button').first();
 
     /* check that the icon is inside of a disabled element */

--- a/packages/core/src/components/dropdown/test/default/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/default/dropdown.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/dropdown/test/default/index.html';
 
 test.describe.parallel('tds-dropdown-default', () => {
-  test('renders default dropdown correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default dropdown correctly', async ({ page }) => {
     const dropdown = page.getByTestId('tds-dropdown-testid');
     await expect(dropdown).toHaveCount(1);
 
@@ -14,25 +17,21 @@ test.describe.parallel('tds-dropdown-default', () => {
   });
 
   test('should find label and be visible', async ({ page }) => {
-    await page.goto(componentTestPath);
     const labelText = page.getByText(/Label text/);
     await expect(labelText).toBeVisible();
   });
 
   test('find helper text and check if visible', async ({ page }) => {
-    await page.goto(componentTestPath);
     const helperText = page.getByText(/Helper text/);
     await expect(helperText).toBeVisible();
   });
 
   test('have the placeholder="Placeholder" text', async ({ page }) => {
-    await page.goto(componentTestPath);
     const dropdownButton = page.getByRole('button', { name: 'Placeholder' });
     await expect(dropdownButton).toBeVisible();
   });
 
   test('clicking the dropdown button opens the dropdown-list', async ({ page }) => {
-    await page.goto(componentTestPath);
     const dropdownButton = page.getByRole('button', { name: 'Placeholder' });
     const dropdownListElementOne = page
       .locator('tds-dropdown-option')
@@ -49,8 +48,6 @@ test.describe.parallel('tds-dropdown-default', () => {
   });
 
   test('clicking the dropdown opens the dropdown-list, then click Option 1', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     /* click the dropdown button */
     const dropdownButton = page.getByRole('button', { name: 'Placeholder' });
     await dropdownButton.click();
@@ -73,7 +70,6 @@ test.describe.parallel('tds-dropdown-default', () => {
   test('clicking the dropdown opens the dropdown-list, then click an option 2 that is disabled should not close it', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const dropdownListElementTwoButton = page
       .locator('tds-dropdown-option')
       .filter({ hasText: /Option 2/ });
@@ -94,7 +90,6 @@ test.describe.parallel('tds-dropdown-default', () => {
     await expect(dropdownListElementTwoButton).toBeVisible();
   });
   test('focusElement() method focus and opens the dropdown-list', async ({ page }) => {
-    await page.goto(componentTestPath);
     const dropdownButton = page.getByRole('button').first();
     const dropdownListElementOne = page
       .locator('tds-dropdown-option')

--- a/packages/core/src/components/dropdown/test/error/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/error/dropdown.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/dropdown/test/error/index.html';
 
 test.describe.parallel('tds-dropdown-error', () => {
-  test('renders error dropdown correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders error dropdown correctly', async ({ page }) => {
     const dropdown = page.getByTestId('tds-dropdown-testid');
     await expect(dropdown).toHaveCount(1);
 
@@ -14,7 +17,6 @@ test.describe.parallel('tds-dropdown-error', () => {
   });
 
   test('find helper text and check if visible and have icon', async ({ page }) => {
-    await page.goto(componentTestPath);
     const helperText = page.getByText(/Helper text/);
     await expect(helperText).toBeVisible();
     const helperTextIcon = helperText.getByRole('img');
@@ -22,7 +24,6 @@ test.describe.parallel('tds-dropdown-error', () => {
   });
 
   test('clicking the dropdown opens the dropdown-list', async ({ page }) => {
-    await page.goto(componentTestPath);
     const dropdownListElementOneButton = page
       .locator('tds-dropdown-option')
       .filter({ hasText: /Option 1/ })

--- a/packages/core/src/components/dropdown/test/filter/disabled/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/filter/disabled/dropdown.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/dropdown/test/filter/disabled/index.html';
 
 test.describe('tds-dropdown-filter-disabled', () => {
-  test('clicking the dropdown icon does not open the dropdown-list', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('clicking the dropdown icon does not open the dropdown-list', async ({ page }) => {
     const dropdownButtonIcon = page.locator('.menu-icon');
 
     const dropdownListElementOne = page
@@ -23,8 +26,8 @@ test.describe('tds-dropdown-filter-disabled', () => {
 
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
+
   test('clicking the dropdown button does not open the dropdown-list', async ({ page }) => {
-    await page.goto(componentTestPath);
     const dropdownButton = page.getByRole('textbox').first();
 
     /* check that the icon is inside of a disabled element */

--- a/packages/core/src/components/dropdown/test/filter/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/filter/dropdown.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/dropdown/test/filter/index.html';
 
 test.describe.parallel('tds-dropdown-filter', () => {
-  test('renders filter dropdown correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders filter dropdown correctly', async ({ page }) => {
     const dropdown = page.getByTestId('tds-dropdown-testid');
     await expect(dropdown).toHaveCount(1);
 
@@ -16,8 +19,6 @@ test.describe.parallel('tds-dropdown-filter', () => {
   test('clicking the dropdown opens the dropdown-list, then start typing "iles" to only show that option in the dropdown list', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
-
     const inputElement = page.getByRole('textbox');
     const dropdownListElementOneButton = page
       .locator('tds-dropdown-option')
@@ -75,8 +76,6 @@ test.describe.parallel('tds-dropdown-filter', () => {
   });
 
   test('reset button icon appears when typing in the filter input', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const inputElement = page.getByRole('textbox');
     const resetButton = page.locator('tds-icon[name="cross"]');
 
@@ -98,8 +97,6 @@ test.describe.parallel('tds-dropdown-filter', () => {
   });
 
   test('toggle dropdown visibility and select option two', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const inputElement = page.getByRole('textbox');
     const dropdownListElementTwoButton = page
       .locator('tds-dropdown-option')

--- a/packages/core/src/components/dropdown/test/filter/hide-no-result-message/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/filter/hide-no-result-message/dropdown.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/dropdown/test/filter/hide-no-result-message/index.html';
 
 test.describe('tds-dropdown-filter', () => {
-  test('renders filter dropdown correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders filter dropdown correctly', async ({ page }) => {
     const dropdown = page.getByTestId('tds-dropdown-testid');
     await expect(dropdown).toHaveCount(1);
 
@@ -14,8 +17,6 @@ test.describe('tds-dropdown-filter', () => {
   });
 
   test('typing non existing value does not show "No results!" message', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const inputElement = page.getByRole('textbox');
 
     /* Add text and only Option 1 should be visible */

--- a/packages/core/src/components/dropdown/test/filter/normalize-text-false/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/filter/normalize-text-false/dropdown.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/dropdown/test/filter/normalize-text-false/index.html';
 
 test.describe('tds-dropdown-filter', () => {
-  test('renders filter dropdown correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders filter dropdown correctly', async ({ page }) => {
     const dropdown = page.getByTestId('tds-dropdown-testid');
     await expect(dropdown).toHaveCount(1);
 
@@ -16,8 +19,6 @@ test.describe('tds-dropdown-filter', () => {
   test('typing "iles" should not show anything in dropdown with normalize text set to false', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
-
     const inputElement = page.getByRole('textbox');
     const dropdownListElementOneButton = page
       .locator('tds-dropdown-option')

--- a/packages/core/src/components/dropdown/test/multiselect-filter/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/multiselect-filter/dropdown.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/dropdown/test/multiselect-filter/index.html';
 
 test.describe.parallel('tds-dropdown-multiselect-filter', () => {
-  test('When focusing on the input it should clear itself', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('When focusing on the input it should clear itself', async ({ page }) => {
     // Click the dropdown button
     const dropdownButton = page.locator('tds-icon[aria-label="Open/Close dropdown"]');
     await dropdownButton.click();

--- a/packages/core/src/components/dropdown/test/multiselect/disabled/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/multiselect/disabled/dropdown.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/dropdown/test/multiselect/disabled/index.html';
 
 test.describe('tds-dropdown-multiselect-disabled', () => {
-  test('clicking the dropdown icon does not open the dropdown-list', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('clicking the dropdown icon does not open the dropdown-list', async ({ page }) => {
     const dropdownButtonIcon = page.locator('tds-icon');
 
     const dropdownListElementOne = page
@@ -24,7 +27,6 @@ test.describe('tds-dropdown-multiselect-disabled', () => {
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
   test('clicking the dropdown button does not open the dropdown-list', async ({ page }) => {
-    await page.goto(componentTestPath);
     const dropdownButton = page.getByRole('button').first();
 
     /* check that the icon is inside of a disabled element */

--- a/packages/core/src/components/dropdown/test/multiselect/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/multiselect/dropdown.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/dropdown/test/multiselect/index.html';
 
 test.describe.parallel('tds-dropdown-multiselect', () => {
-  test('renders multiselect dropdown correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders multiselect dropdown correctly', async ({ page }) => {
     const dropdown = page.getByTestId('tds-dropdown-testid');
     await expect(dropdown).toHaveCount(1);
 
@@ -16,8 +19,6 @@ test.describe.parallel('tds-dropdown-multiselect', () => {
   test('clicking the dropdown opens the dropdown-list, then click Option 1, should not close it', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
-
     /* click the dropdown button */
     const dropdownButton = page.getByRole('button', { name: 'Placeholder' });
     await dropdownButton.click();
@@ -39,8 +40,6 @@ test.describe.parallel('tds-dropdown-multiselect', () => {
   test('clicking the dropdown opens the dropdown-list, then click on all the options', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
-
     /* click the button */
     const dropdownButton = page.getByRole('button', { name: 'Placeholder' });
     await dropdownButton.click();

--- a/packages/core/src/components/footer/test/default/footer.e2e.ts
+++ b/packages/core/src/components/footer/test/default/footer.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/footer/test/default/index.html';
 
 test.describe.parallel('tds-footer-default', () => {
-  test('renders default footer correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default footer correctly', async ({ page }) => {
     const footerComponent = page.locator('footer');
     await expect(footerComponent).toHaveCount(1);
 
@@ -14,26 +17,22 @@ test.describe.parallel('tds-footer-default', () => {
   });
 
   test('Footer contains four links "Link text"', async ({ page }) => {
-    await page.goto(componentTestPath);
     const footerLinks = page.getByRole('link').filter({ hasText: /Link text/ });
     await expect(footerLinks).toHaveCount(4);
   });
 
   test('Footer contains three truck icons', async ({ page }) => {
-    await page.goto(componentTestPath);
     const footerTruckIcons = page.getByRole('link').filter({ has: page.getByRole('img') });
     await expect(footerTruckIcons).toHaveCount(3);
   });
 
   test('Footer contains copyright text', async ({ page }) => {
-    await page.goto(componentTestPath);
     const footerCopyrightText = page.getByText(`Copyright © ${new Date().getFullYear()} Scania`);
     await expect(footerCopyrightText).toHaveCount(1);
     await expect(footerCopyrightText).toBeVisible();
   });
 
   test('Footer contains brand label (Scania)', async ({ page }) => {
-    await page.goto(componentTestPath);
     const footerBrandText = page.getByText('Scania', { exact: true });
     await expect(footerBrandText).toHaveCount(1);
     await expect(footerBrandText).toBeHidden();

--- a/packages/core/src/components/header/test/default/header.e2e.ts
+++ b/packages/core/src/components/header/test/default/header.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/header/test/default/index.html';
 
 test.describe.parallel('tds-header-default', () => {
-  test('renders default header correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default header correctly', async ({ page }) => {
     const headerComponent = page.getByRole('navigation');
     await expect(headerComponent).toHaveCount(1);
     await expect(headerComponent).toBeVisible();
@@ -15,28 +18,24 @@ test.describe.parallel('tds-header-default', () => {
   });
 
   test('title exists and is "Example: default"', async ({ page }) => {
-    await page.goto(componentTestPath);
     const headerComponentHeaderText = page.getByText('Example: default');
     await expect(headerComponentHeaderText).toHaveCount(1);
     await expect(headerComponentHeaderText).toBeVisible();
   });
 
   test('luncher button icon exists', async ({ page }) => {
-    await page.goto(componentTestPath);
     const headerComponentLuncherButton = page.getByRole('button');
     await expect(headerComponentLuncherButton).toHaveCount(1);
     await expect(headerComponentLuncherButton).toBeVisible();
   });
 
   test('brand label with link exists', async ({ page }) => {
-    await page.goto(componentTestPath);
     const headerComponentBrandLink = page.getByLabel('Scania - red gryphon on blue shield');
     await expect(headerComponentBrandLink).toHaveCount(1);
     await expect(headerComponentBrandLink).toBeVisible();
   });
 
   test('launcher should open on click', async ({ page }) => {
-    await page.goto(componentTestPath);
     const headerComponentLuncherButton = page.getByRole('button');
     await headerComponentLuncherButton.click();
 

--- a/packages/core/src/components/link/test/default/link.e2e.ts
+++ b/packages/core/src/components/link/test/default/link.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/link/test/default/index.html';
 
 test.describe.parallel('tds-link-default', () => {
-  test('is default link rendered correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('is default link rendered correctly', async ({ page }) => {
     const tdsLink = page.getByTestId('tds-link-testid');
 
     await expect(tdsLink).toHaveCount(1);
@@ -16,7 +18,6 @@ test.describe.parallel('tds-link-default', () => {
   });
 
   test('text shows on page', async ({ page }) => {
-    await page.goto(componentTestPath);
     const pageText = page.getByText(
       'The Tegel Design System is for digital products and services at Scania. It enables an efficient' +
         "    development process and ensures a premium experience across all of Scania's digital touchpoints.",
@@ -27,7 +28,6 @@ test.describe.parallel('tds-link-default', () => {
   });
 
   test('word Tegel is a link', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tdsLink = page.locator('tds-link a');
     await expect(tdsLink).toHaveAttribute('href');
     await expect(tdsLink).toHaveText('Tegel');
@@ -35,7 +35,6 @@ test.describe.parallel('tds-link-default', () => {
   });
 
   test('link is underlined', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tdsLink = page.getByText('Tegel', { exact: true });
     const linkUnderlineState = await tdsLink.evaluate(
       (style) => getComputedStyle(style).textDecorationLine,
@@ -44,7 +43,6 @@ test.describe.parallel('tds-link-default', () => {
   });
 
   test('component is not disabled', async ({ page }) => {
-    await page.goto(componentTestPath);
     await page.locator('tds-link').click();
     await expect(page).toHaveURL('https://tegel.scania.com/home');
   });

--- a/packages/core/src/components/link/test/disabled/link.e2e.ts
+++ b/packages/core/src/components/link/test/disabled/link.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/link/test/disabled/index.html';
 
 test.describe.parallel('tds-link-disabled', () => {
-  test('disabled link is rendered correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('disabled link is rendered correctly', async ({ page }) => {
     const tdsLink = page.getByTestId('tds-link-testid');
     await expect(tdsLink).toHaveCount(1);
     /* Check diff on screenshot */
@@ -13,7 +16,6 @@ test.describe.parallel('tds-link-disabled', () => {
   });
 
   test('text shows on page', async ({ page }) => {
-    await page.goto(componentTestPath);
     const pageText = page.getByText(
       'The Tegel Design System is for digital products and services at Scania. It enables an efficient' +
         "    development process and ensures a premium experience across all of Scania's digital touchpoints.",
@@ -24,7 +26,6 @@ test.describe.parallel('tds-link-disabled', () => {
   });
 
   test('link is underlined', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tdsLink = page.getByText('Tegel', { exact: true });
     const linkUnderlineState = await tdsLink.evaluate(
       (style) => getComputedStyle(style).textDecorationLine,
@@ -33,7 +34,6 @@ test.describe.parallel('tds-link-disabled', () => {
   });
 
   test('component is disabled', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tdsLink = page.getByText('Tegel', { exact: true });
     const linkUnderlineState = await tdsLink.evaluate(
       (style) => getComputedStyle(style).pointerEvents,

--- a/packages/core/src/components/message/test/basic/message.e2e.ts
+++ b/packages/core/src/components/message/test/basic/message.e2e.ts
@@ -4,15 +4,16 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/message/test/basic/index.html';
 
 test.describe.parallel('tds-message-basic', () => {
-  test('is basic message rendered correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('is basic message rendered correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('has icon', async ({ page }) => {
-    await page.goto(componentTestPath);
     const messageIcon = page.getByRole('img');
     await expect(messageIcon).toHaveCount(1);
     await expect(messageIcon).toBeVisible();

--- a/packages/core/src/components/message/test/error/message.e2e.ts
+++ b/packages/core/src/components/message/test/error/message.e2e.ts
@@ -4,29 +4,28 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/message/test/error/index.html';
 
 test.describe.parallel('tds-message-error', () => {
-  test('is error message rendered correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('is error message rendered correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('has header text', async ({ page }) => {
-    await page.goto(componentTestPath);
     const messageComponentHeader = page.getByText('Message header', { exact: true });
     await expect(messageComponentHeader).toHaveCount(1);
     await expect(messageComponentHeader).toBeVisible();
   });
 
   test('has subheader text', async ({ page }) => {
-    await page.goto(componentTestPath);
     const messageComponentSubHeader = page.getByText('Longer Message text can be placed here.');
     await expect(messageComponentSubHeader).toHaveCount(1);
     await expect(messageComponentSubHeader).toBeVisible();
   });
 
   test('has error icon', async ({ page }) => {
-    await page.goto(componentTestPath);
     const messageIcon = page.getByRole('img');
     await expect(messageIcon).toHaveCount(1);
     await expect(messageIcon).toBeVisible();

--- a/packages/core/src/components/message/test/information/message.e2e.ts
+++ b/packages/core/src/components/message/test/information/message.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/message/test/information/index.html';
 
 test.describe('tds-message-information', () => {
-  test('is information message rendered correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('is information message rendered correctly', async ({ page }) => {
     /* Take screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });

--- a/packages/core/src/components/message/test/success/message.e2e.ts
+++ b/packages/core/src/components/message/test/success/message.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/message/test/success/index.html';
 
 test.describe('tds-message-success', () => {
-  test('is success message rendered correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('is success message rendered correctly', async ({ page }) => {
     /* Take screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });

--- a/packages/core/src/components/message/test/warning/message.e2e.ts
+++ b/packages/core/src/components/message/test/warning/message.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/message/test/warning/index.html';
 
 test.describe('tds-message-warning', () => {
-  test('is warning message rendered correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('is warning message rendered correctly', async ({ page }) => {
     /* Take screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });

--- a/packages/core/src/components/modal/test/closable/modal.e2e.ts
+++ b/packages/core/src/components/modal/test/closable/modal.e2e.ts
@@ -1,6 +1,8 @@
 import { E2EPage, test } from 'stencil-playwright';
 import { expect } from '@playwright/test';
 
+const componentTestPath = 'src/components/modal/test/closable/index.html';
+
 test.describe.parallel('tds-modal-closable', () => {
   const isClosable = async (page: E2EPage, id: string) => {
     // get modal by id
@@ -16,7 +18,7 @@ test.describe.parallel('tds-modal-closable', () => {
   };
 
   test.beforeEach(async ({ page }) => {
-    await page.goto('src/components/modal/test/closable/index.html');
+    await page.goto(componentTestPath);
   });
 
   test('x button is visible', async ({ page }) => {

--- a/packages/core/src/components/modal/test/default/modal.e2e.ts
+++ b/packages/core/src/components/modal/test/default/modal.e2e.ts
@@ -4,15 +4,17 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/modal/test/default/index.html';
 
 test.describe.parallel('tds-modal-default', () => {
-  test('renders modal correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders modal correctly', async ({ page }) => {
     const tdsModal = page.getByTestId('tds-modal-testid');
     await expect(tdsModal).toHaveCount(1);
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('modal contains three buttons', async ({ page }) => {
-    await page.goto(componentTestPath);
     // Locate the buttons within the modal
     const modalButtons = page.getByRole('button');
 
@@ -21,8 +23,6 @@ test.describe.parallel('tds-modal-default', () => {
   });
 
   test('modal contains a header and a body', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const modalHeader = page.getByText('This is a header', { exact: true });
     const modalBody = page.getByText('Where you can put anything you want!', {
       exact: true,

--- a/packages/core/src/components/popover-canvas/test/default/popover-canvas.e2e.ts
+++ b/packages/core/src/components/popover-canvas/test/default/popover-canvas.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/popover-canvas/test/default/index.html';
 
 test.describe.parallel('tds-popover-canvas-default', () => {
-  test('renders default popover-canvas correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default popover-canvas correctly', async ({ page }) => {
     const triggerButton = page.getByRole('button');
     await triggerButton.click();
 
@@ -16,7 +19,6 @@ test.describe.parallel('tds-popover-canvas-default', () => {
   test('make sure popover canvas shows after trigger button is pressed and content is displayed', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const triggerButton = page.getByRole('button');
     const popoverCanvasHeader = page.getByRole('heading');
     const popoverCanvasBody = page.getByText('Where you can put anything you want!', {
@@ -37,7 +39,6 @@ test.describe.parallel('tds-popover-canvas-default', () => {
   });
 
   test('activating close method should close the dialog', async ({ page }) => {
-    await page.goto(componentTestPath);
     const triggerButton = page.getByRole('button');
     await triggerButton.click();
 

--- a/packages/core/src/components/popover-canvas/test/show-false/popover-canvas.e2e.ts
+++ b/packages/core/src/components/popover-canvas/test/show-false/popover-canvas.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/popover-canvas/test/show-false/index.html';
 
 test.describe.parallel('tds-popover-canvas-show-false', () => {
-  test('renders show=false popover-canvas correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders show=false popover-canvas correctly', async ({ page }) => {
     const triggerButton = page.getByRole('button');
     await triggerButton.click();
 
@@ -16,7 +19,6 @@ test.describe.parallel('tds-popover-canvas-show-false', () => {
   test('make sure popover canvas does not show after trigger button is pressed and content is not displayed before or after button click', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const triggerButton = page.getByRole('button');
     const popoverCanvasHeader = page.getByRole('heading');
     const popoverCanvasBody = page.getByText('Where you can put anything you want!', {

--- a/packages/core/src/components/popover-canvas/test/show-true/popover-canvas.e2e.ts
+++ b/packages/core/src/components/popover-canvas/test/show-true/popover-canvas.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/popover-canvas/test/show-true/index.html';
 
 test.describe.parallel('tds-popover-canvas-show-true', () => {
-  test('renders show=true popover-canvas correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders show=true popover-canvas correctly', async ({ page }) => {
     const triggerButton = page.getByRole('button');
     await triggerButton.click();
 
@@ -22,7 +25,6 @@ test.describe.parallel('tds-popover-canvas-show-true', () => {
   test('make sure the popover canvas content is displayed both before and after the trigger button is pressed', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const triggerButton = page.getByRole('button');
     const popoverCanvasHeader = page.getByRole('heading');
     const popoverCanvasBody = page.getByText('Where you can put anything you want!', {

--- a/packages/core/src/components/popover-menu/test/default/popover-menu.e2e.ts
+++ b/packages/core/src/components/popover-menu/test/default/popover-menu.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/popover-menu/test/default/index.html';
 
 test.describe.parallel('tds-popover-menu-default', () => {
-  test('renders default popover-menu correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default popover-menu correctly', async ({ page }) => {
     const triggerButton = page.getByRole('button').filter({ has: page.getByRole('img') });
     await triggerButton.click();
 
@@ -14,7 +17,6 @@ test.describe.parallel('tds-popover-menu-default', () => {
   });
 
   test('clicking the trigger button should open the popover menu dialog', async ({ page }) => {
-    await page.goto(componentTestPath);
     const triggerButton = page.getByRole('button').filter({ has: page.getByRole('img') });
     const dropDownList = page.getByRole('list');
 
@@ -37,7 +39,6 @@ test.describe.parallel('tds-popover-menu-default', () => {
   });
 
   test('hover active menu item -> active item should be clickable', async ({ page }) => {
-    await page.goto(componentTestPath);
     const triggerButton = page.getByRole('button').filter({ has: page.getByRole('img') });
     const dropDownList = page.getByRole('list');
     await triggerButton.click();
@@ -57,7 +58,6 @@ test.describe.parallel('tds-popover-menu-default', () => {
   test('hover inactive menu item -> inactive menu item should not be clickable', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const triggerButton = page.getByRole('button').filter({ has: page.getByRole('img') });
     await triggerButton.click();
 
@@ -72,7 +72,6 @@ test.describe.parallel('tds-popover-menu-default', () => {
   });
 
   test('icons are not existing for menu items', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tdsMenuItemListItemIcons = page
       .getByRole('listitem')
       .filter({ has: page.getByRole('img') });
@@ -80,7 +79,6 @@ test.describe.parallel('tds-popover-menu-default', () => {
   });
 
   test('activating close method should close the dialog', async ({ page }) => {
-    await page.goto(componentTestPath);
     const triggerButton = page.getByRole('button').filter({ has: page.getByRole('img') });
     await triggerButton.click();
 

--- a/packages/core/src/components/popover-menu/test/icons-fluid/popover-menu.e2e.ts
+++ b/packages/core/src/components/popover-menu/test/icons-fluid/popover-menu.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/popover-menu/test/icons-fluid/index.html';
 
 test.describe.parallel('tds-popover-menu-icons-fluid', () => {
-  test('renders icons-fluid popover-menu correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders icons-fluid popover-menu correctly', async ({ page }) => {
     const triggerButton = page.getByRole('button').filter({ has: page.getByRole('img') });
     await triggerButton.click();
 
@@ -14,14 +17,12 @@ test.describe.parallel('tds-popover-menu-icons-fluid', () => {
   });
 
   test('menu item "The menu with adjusts to the widest word" exists', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tdsMenuItemListLongText = page.getByText('The menu width adjusts to the widest word');
     await expect(tdsMenuItemListLongText).toHaveCount(1);
     await expect(tdsMenuItemListLongText).toBeHidden();
   });
 
   test('icons are existing for menu items', async ({ page }) => {
-    await page.goto(componentTestPath);
     const triggerButton = page.getByRole('button').filter({ has: page.getByRole('img') });
     await triggerButton.click();
 

--- a/packages/core/src/components/popover-menu/test/show-false/popover-menu.e2e.ts
+++ b/packages/core/src/components/popover-menu/test/show-false/popover-menu.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/popover-menu/test/show-false/index.html';
 
 test.describe.parallel('tds-popover-menu-show-false', () => {
-  test('renders show=false popover-menu correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders show=false popover-menu correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
@@ -14,7 +16,6 @@ test.describe.parallel('tds-popover-menu-show-false', () => {
   test('clicking the trigger button should not open the popover menu dialog when show is false', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const triggerButton = page.getByRole('button').filter({ has: page.getByRole('img') });
     const dropDownList = page.getByRole('list');
 

--- a/packages/core/src/components/popover-menu/test/show/popover-menu.e2e.ts
+++ b/packages/core/src/components/popover-menu/test/show/popover-menu.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/popover-menu/test/show/index.html';
 
 test.describe.parallel('tds-popover-menu-show', () => {
-  test('renders show=true popover-menu correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders show=true popover-menu correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixelRatio: 0.05 });
   });
@@ -14,7 +16,6 @@ test.describe.parallel('tds-popover-menu-show', () => {
   test('clicking the trigger button should keep the popover menu dialog open when it is open by default', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const triggerButton = page.getByRole('button').filter({ has: page.getByRole('img') });
     const dropDownList = page.getByRole('list');
 

--- a/packages/core/src/components/radio-button/test/default/radio-button.e2e.ts
+++ b/packages/core/src/components/radio-button/test/default/radio-button.e2e.ts
@@ -1,11 +1,13 @@
 import { expect } from '@playwright/test';
 import { test } from 'stencil-playwright';
 
+const componentTestPath = 'src/components/radio-button/test/default/index.html';
+
 test.describe.parallel('TdsRadioButton component tests', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to the index.html page where your component is rendered
     // Adjust the path to the index.html as necessary based on your project structure
-    await page.goto('src/components/radio-button/test/default/index.html');
+    await page.goto(componentTestPath);
   });
 
   test('Radio buttons with Label text = "Label text 1" and "Label text 2" render on the page', async ({

--- a/packages/core/src/components/radio-button/test/disabled/radio-button.e2e.ts
+++ b/packages/core/src/components/radio-button/test/disabled/radio-button.e2e.ts
@@ -1,9 +1,10 @@
 import { expect } from '@playwright/test';
 import { test } from 'stencil-playwright';
 
+const componentTestPath = 'src/components/radio-button/test/disabled/index.html';
 test.describe.parallel('Radio button - disabled state', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('src/components/radio-button/test/disabled/index.html');
+    await page.goto(componentTestPath);
   });
 
   test('Radio buttons with Label text = "Label text 1" and "Label text 2" renders on the page', async ({

--- a/packages/core/src/components/side-menu/test/collapsible/side-menu.e2e.ts
+++ b/packages/core/src/components/side-menu/test/collapsible/side-menu.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/side-menu/test/collapsible/index.html';
 
 test.describe.parallel('tds-side-menu-collapsible', () => {
-  test('renders collapsible side-menu correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders collapsible side-menu correctly', async ({ page }) => {
     const sideMenuNavigation = page.getByRole('navigation');
     await expect(sideMenuNavigation).toHaveCount(1);
     await expect(sideMenuNavigation).toBeVisible();
@@ -15,14 +18,12 @@ test.describe.parallel('tds-side-menu-collapsible', () => {
   });
 
   test('collapse button exists on the bottom of side menu', async ({ page }) => {
-    await page.goto(componentTestPath);
     const sideMenuCollapseButton = page.getByRole('button').filter({ hasText: /Collapse/ });
     await expect(sideMenuCollapseButton).toHaveCount(1);
     await expect(sideMenuCollapseButton).toBeVisible();
   });
 
   test('click collapse button to close the menu', async ({ page }) => {
-    await page.goto(componentTestPath);
     const sideMenuCollapseButton = page.getByRole('button').filter({ hasText: /Collapse/ });
     await sideMenuCollapseButton.click();
     await expect(sideMenuCollapseButton).toHaveCount(1);

--- a/packages/core/src/components/side-menu/test/default/side-menu.e2e.ts
+++ b/packages/core/src/components/side-menu/test/default/side-menu.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/side-menu/test/default/index.html';
 
 test.describe.parallel('tds-side-menu-default', () => {
-  test('renders default side-menu correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default side-menu correctly', async ({ page }) => {
     const sideMenuNavigation = page.getByRole('navigation');
     await expect(sideMenuNavigation).toHaveCount(1);
     await expect(sideMenuNavigation).toBeVisible();
@@ -15,7 +18,6 @@ test.describe.parallel('tds-side-menu-default', () => {
   });
 
   test('all side menu buttons to be visible', async ({ page }) => {
-    await page.goto(componentTestPath);
     const sideMenuButtons = page.getByRole('button');
     await expect(sideMenuButtons).toHaveCount(4);
     const promises = [];
@@ -30,8 +32,6 @@ test.describe.parallel('tds-side-menu-default', () => {
   test('wheel type list is open by default and under Wheel types there are two sublink', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
-
     /* Make sure first list item is there and visible */
     const sideMenuWheelTypeListItemOne = page
       .getByRole('listitem')

--- a/packages/core/src/components/side-menu/test/expand-toggle/expand-toggle.e2e.ts
+++ b/packages/core/src/components/side-menu/test/expand-toggle/expand-toggle.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/side-menu/test/expand-toggle/index.html';
 
 test.describe.parallel('tds-side-menu-toggle-expand', () => {
-  test('toggle collapse and expand programmatically', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('toggle collapse and expand programmatically', async ({ page }) => {
     const wrapper = await page.locator('tds-side-menu-dropdown > .wrapper');
     await expect(wrapper).toHaveClass(/state-open/);
 
@@ -25,8 +27,6 @@ test.describe.parallel('tds-side-menu-toggle-expand', () => {
   });
 
   test('collapse programmatically and expand on the UI', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const wrapper = await page.locator('tds-side-menu-dropdown > .wrapper');
 
     const dropdown = await page.locator('tds-side-menu-dropdown');

--- a/packages/core/src/components/slider/test/default/slider.e2e.ts
+++ b/packages/core/src/components/slider/test/default/slider.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/slider/test/default/index.html';
 
 test.describe.parallel('tds-slider-default', () => {
-  test('renders default slider correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default slider correctly', async ({ page }) => {
     const slider = page.locator('tds-slider');
     await expect(slider).toHaveCount(1);
 
@@ -14,13 +17,11 @@ test.describe.parallel('tds-slider-default', () => {
   });
 
   test('value is set to 50', async ({ page }) => {
-    await page.goto(componentTestPath);
     const sliderValue = page.locator('.tds-slider__value');
     await expect(sliderValue).toHaveText('50');
   });
 
   test('min value is set to 0', async ({ page }) => {
-    await page.goto(componentTestPath);
     /* Find thumb and pull it towards a left and check if min value is 0 */
     await page.locator('.tds-slider__thumb-inner').hover();
     await page.mouse.down();
@@ -33,7 +34,6 @@ test.describe.parallel('tds-slider-default', () => {
   });
 
   test('max value is set to 100', async ({ page }) => {
-    await page.goto(componentTestPath);
     /* Find thumb and pull it towards a right and check if min value is 0 */
     await page.locator('.tds-slider__thumb-inner').hover();
     await page.mouse.down();
@@ -46,15 +46,12 @@ test.describe.parallel('tds-slider-default', () => {
   });
 
   test('label is hidden', async ({ page }) => {
-    await page.goto(componentTestPath);
     const slider = page.locator('tds-slider');
     const sliderLabel = slider.locator('label');
     await expect(sliderLabel).toHaveText('');
   });
 
   test('slider is not read only or disabled', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     /* Find thumb and pull it towards a left and check if value in thumb is changing */
     await page.locator('.tds-slider__thumb-inner').hover();
     await page.mouse.down();
@@ -67,7 +64,6 @@ test.describe.parallel('tds-slider-default', () => {
   });
 
   test('thumb is size large', async ({ page }) => {
-    await page.goto(componentTestPath);
     const sliderThumb = page.locator('.tds-slider__thumb-inner');
     const sliderThumbWidth = await sliderThumb.evaluate((style) => getComputedStyle(style).width);
     const sliderThumbHeight = await sliderThumb.evaluate((style) => getComputedStyle(style).height);

--- a/packages/core/src/components/slider/test/disabled/slider.e2e.ts
+++ b/packages/core/src/components/slider/test/disabled/slider.e2e.ts
@@ -3,14 +3,16 @@ import { expect } from '@playwright/test';
 
 const componentTestPath = 'src/components/slider/test/disabled/index.html';
 test.describe.parallel('tds-slider-disabled', () => {
-  test('read-only is false', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('read-only is false', async ({ page }) => {
     const slider = page.locator('tds-slider');
     await expect(slider).not.toHaveAttribute('read-only');
   });
 
   test('slider is disabled', async ({ page }) => {
-    await page.goto(componentTestPath);
     const slider = page.locator('tds-slider input');
     const sliderThumb = page.locator('.tds-slider__thumb');
     const sliderCursorStyle = await sliderThumb.evaluate((style) => getComputedStyle(style).cursor);
@@ -21,7 +23,6 @@ test.describe.parallel('tds-slider-disabled', () => {
   });
 
   test('slider can not be clicked on', async ({ page }) => {
-    await page.goto(componentTestPath);
     const sliderThumb = page.locator('.tds-slider__thumb-inner');
     const sliderPointerEvents = await sliderThumb.evaluate(
       (style) => getComputedStyle(style).pointerEvents,

--- a/packages/core/src/components/slider/test/read-only/slider.e2e.ts
+++ b/packages/core/src/components/slider/test/read-only/slider.e2e.ts
@@ -3,14 +3,16 @@ import { expect } from '@playwright/test';
 
 const componentTestPath = 'src/components/slider/test/read-only/index.html';
 test.describe.parallel('tds-slider-read-only', () => {
-  test('read-only is true', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('read-only is true', async ({ page }) => {
     const slider = page.locator('tds-slider');
     await expect(slider).toHaveAttribute('read-only');
   });
 
   test('is not disabled', async ({ page }) => {
-    await page.goto(componentTestPath);
     const sliderThumb = page.locator('.tds-slider__thumb-inner');
     const sliderCursorStyle = await sliderThumb.evaluate((style) => getComputedStyle(style).cursor);
     expect(sliderCursorStyle).toBe('pointer');
@@ -19,7 +21,6 @@ test.describe.parallel('tds-slider-read-only', () => {
   });
 
   test('slider can not be clicked on', async ({ page }) => {
-    await page.goto(componentTestPath);
     const sliderThumb = page.locator('.tds-slider__thumb-inner');
     const sliderThumbStyle = await sliderThumb.evaluate(
       (style) => getComputedStyle(style).pointerEvents,

--- a/packages/core/src/components/spinner/test/inverted/spinner.e2e.ts
+++ b/packages/core/src/components/spinner/test/inverted/spinner.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/spinner/test/inverted/index.html';
 
 test.describe.parallel('tds-spinner-inverted', () => {
-  test('renders inverted spinner correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders inverted spinner correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });

--- a/packages/core/src/components/spinner/test/standard/spinner.e2e.ts
+++ b/packages/core/src/components/spinner/test/standard/spinner.e2e.ts
@@ -4,16 +4,16 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/spinner/test/standard/index.html';
 
 test.describe.parallel('tds-spinner-standard', () => {
-  test('renders basic spinner correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders basic spinner correctly', async ({ page }) => {
     /* Check diff on screenshot */
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('Check if animation is present', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const spinner = page.locator('tds-spinner:first-child circle');
     const spinnerStyle = await spinner.evaluate((style) => getComputedStyle(style).animationName);
     expect(spinnerStyle).toBe('dash');

--- a/packages/core/src/components/table/table/test/batch/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/batch/table.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/batch/index.html';
 
 test.describe.parallel('tds-table-batch', () => {
-  test('renders batch table correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders batch table correctly', async ({ page }) => {
     const tableComponent = page.getByRole('table');
     await expect(tableComponent).toHaveCount(1);
 
@@ -14,14 +17,12 @@ test.describe.parallel('tds-table-batch', () => {
   });
 
   test('table has a settings button', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tdsTableToolbarSettings = page.getByRole('img');
     await expect(tdsTableToolbarSettings).toHaveCount(1);
     await expect(tdsTableToolbarSettings).toBeVisible();
   });
 
   test('table has a [Download] button', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tdsTableToolbarDownloadButton = page.getByRole('button', { name: /Download/ });
     await expect(tdsTableToolbarDownloadButton).toHaveCount(1);
     await expect(tdsTableToolbarDownloadButton).toBeVisible();

--- a/packages/core/src/components/table/table/test/column-filtering/header-input-wrapper/interaction-fill.e2e.ts
+++ b/packages/core/src/components/table/table/test/column-filtering/header-input-wrapper/interaction-fill.e2e.ts
@@ -5,9 +5,11 @@ const componentTestPath =
   'src/components/table/table/test/column-filtering/header-input-wrapper/index.html';
 
 test.describe.parallel('tds-table-column-filtering fill', () => {
-  test('expect slotted inputs to persist inputed value', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('expect slotted inputs to persist inputed value', async ({ page }) => {
     const inputfield = page.getByTestId('firstHeaderInput');
     await inputfield.fill('Hello World!');
 

--- a/packages/core/src/components/table/table/test/column-filtering/header-input-wrapper/interaction-focus.e2e.ts
+++ b/packages/core/src/components/table/table/test/column-filtering/header-input-wrapper/interaction-focus.e2e.ts
@@ -5,9 +5,11 @@ const componentTestPath =
   'src/components/table/table/test/column-filtering/header-input-wrapper/index.html';
 
 test.describe.parallel('tds-table-column-filtering focus', () => {
-  test('expect wrapper to effect slotted inputs style on focus', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('expect wrapper to effect slotted inputs style on focus', async ({ page }) => {
     const inputfield = page.getByTestId('firstHeaderInput');
 
     await inputfield.focus();

--- a/packages/core/src/components/table/table/test/column-filtering/header-input-wrapper/interaction-hover.e2e.ts
+++ b/packages/core/src/components/table/table/test/column-filtering/header-input-wrapper/interaction-hover.e2e.ts
@@ -5,9 +5,11 @@ const componentTestPath =
   'src/components/table/table/test/column-filtering/header-input-wrapper/index.html';
 
 test.describe.parallel('tds-table-column-filtering hover', () => {
-  test('expect wrapper to effect slotted inputs style on hover', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('expect wrapper to effect slotted inputs style on hover', async ({ page }) => {
     const inputfield = page.getByTestId('firstHeaderInput');
 
     await inputfield.hover();
@@ -23,8 +25,6 @@ test.describe.parallel('tds-table-column-filtering hover', () => {
   });
 
   test('expect slotted input to show search icon on hover', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const inputfield = page.getByTestId('firstHeaderInput');
 
     await inputfield.hover();

--- a/packages/core/src/components/table/table/test/column-filtering/header-input-wrapper/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/column-filtering/header-input-wrapper/table.e2e.ts
@@ -5,8 +5,11 @@ const componentTestPath =
   'src/components/table/table/test/column-filtering/header-input-wrapper/index.html';
 
 test.describe.parallel('tds-table-column-filtering', () => {
-  test('renders table with editable header cell correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders table with editable header cell correctly', async ({ page }) => {
     const tableComponent = page.getByRole('table');
     await expect(tableComponent).toHaveCount(1);
 

--- a/packages/core/src/components/table/table/test/default/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/default/table.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/default/index.html';
 
 test.describe.parallel('tds-table-default', () => {
-  test('renders default table correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default table correctly', async ({ page }) => {
     const tableComponent = page.getByRole('table');
     await expect(tableComponent).toHaveCount(1);
 
@@ -14,14 +17,11 @@ test.describe.parallel('tds-table-default', () => {
   });
 
   test('table has four columns', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableHeaderCells = page.locator('tds-header-cell');
     await expect(tableHeaderCells).toHaveCount(4);
   });
 
   test('columns are: Truck type, Driver name, Country, Mileage', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     /* Expect each header to be visible */
     await expect(page.getByText('Truck type')).toBeVisible();
     await expect(page.getByText('Driver name')).toBeVisible();
@@ -30,16 +30,12 @@ test.describe.parallel('tds-table-default', () => {
   });
 
   test('Row should contain the correct number of rows with', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     /* Expect the number of rows to be correct amount */
     const tableBodyRows = page.locator('tds-table-body-row');
     await expect(tableBodyRows).toHaveCount(6);
   });
 
   test('table has the correct text inside each cell', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     /* Checks all rows to see that they have the correct amount of tds-body-cells with values provided */
     const promises = [];
     for (let i = 1; i <= 8; i++) {

--- a/packages/core/src/components/table/table/test/editing/body-input-wrapper/interaction-fill.e2e.ts
+++ b/packages/core/src/components/table/table/test/editing/body-input-wrapper/interaction-fill.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/editing/body-input-wrapper/index.html';
 
 test.describe.parallel('tds-table-editable-cells fill', () => {
-  test('expect slotted inputs to persist inputed value', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('expect slotted inputs to persist inputed value', async ({ page }) => {
     const inputfield = page.getByTestId('firstInput');
     await inputfield.fill('Hello World!');
 

--- a/packages/core/src/components/table/table/test/editing/body-input-wrapper/interaction-focus.e2e.ts
+++ b/packages/core/src/components/table/table/test/editing/body-input-wrapper/interaction-focus.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/editing/body-input-wrapper/index.html';
 
 test.describe.parallel('tds-table-editable-cells focus', () => {
-  test('expect wrapper to effect slotted inputs style on focus', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('expect wrapper to effect slotted inputs style on focus', async ({ page }) => {
     const inputfield = page.getByTestId('firstInput');
 
     await inputfield.focus();

--- a/packages/core/src/components/table/table/test/editing/body-input-wrapper/interaction-hover.e2e.ts
+++ b/packages/core/src/components/table/table/test/editing/body-input-wrapper/interaction-hover.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/editing/body-input-wrapper/index.html';
 
 test.describe.parallel('tds-table-editable-cells hover', () => {
-  test('expect wrapper to effect slotted inputs style on hover', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('expect wrapper to effect slotted inputs style on hover', async ({ page }) => {
     const inputfield = page.getByTestId('firstInput');
 
     await inputfield.hover();
@@ -22,8 +24,6 @@ test.describe.parallel('tds-table-editable-cells hover', () => {
   });
 
   test('expect slotted input to show pen icon on hover', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     const inputfield = page.getByTestId('firstInput');
 
     await inputfield.hover();

--- a/packages/core/src/components/table/table/test/editing/body-input-wrapper/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/editing/body-input-wrapper/table.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/editing/body-input-wrapper/index.html';
 
 test.describe.parallel('tds-table-editable-cells', () => {
-  test('renders table with editable cells correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders table with editable cells correctly', async ({ page }) => {
     const tableComponent = page.getByRole('table');
     await expect(tableComponent).toHaveCount(1);
 

--- a/packages/core/src/components/table/table/test/expandable-row-part-selector/expandable-row-expanded.e2e.ts
+++ b/packages/core/src/components/table/table/test/expandable-row-part-selector/expandable-row-expanded.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/expandable-row-part-selector/index.html';
 
 test.describe.parallel('tds-table-expandable-row-part-selector', () => {
-  test('part selector is passing on correct background color', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('part selector is passing on correct background color', async ({ page }) => {
     // Find the table and make sure it is visible
     const table = page.locator('tds-table');
     await table.waitFor({ state: 'visible' });

--- a/packages/core/src/components/table/table/test/expandable-row/interaction-1.e2e.ts
+++ b/packages/core/src/components/table/table/test/expandable-row/interaction-1.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/expandable-row/index.html';
 
 test.describe('tds-table-expandable-row-first', () => {
-  test('under first row opened expanded row with text "Hello world 1"', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('under first row opened expanded row with text "Hello world 1"', async ({ page }) => {
     const tableBodyRowFirstInput = page.getByRole('cell').nth(1);
     const tableBodyExpandableRowSlot = page.getByText(/Hello world 1/);
     await expect(tableBodyRowFirstInput).toHaveCount(1);

--- a/packages/core/src/components/table/table/test/expandable-row/interaction-2.e2e.ts
+++ b/packages/core/src/components/table/table/test/expandable-row/interaction-2.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/expandable-row/index.html';
 
 test.describe('tds-table-expandable-row-second', () => {
-  test('under second row opened expanded row with text "Hello to you too"', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('under second row opened expanded row with text "Hello to you too"', async ({ page }) => {
     const tableBodyRowSecondInput = page.getByRole('cell').nth(2);
     const tableBodyExpandableRowSlot = page.getByText(/Hello to you too/);
     await expect(tableBodyRowSecondInput).toHaveCount(1);

--- a/packages/core/src/components/table/table/test/expandable-row/interaction-3.e2e.ts
+++ b/packages/core/src/components/table/table/test/expandable-row/interaction-3.e2e.ts
@@ -4,10 +4,13 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/expandable-row/index.html';
 
 test.describe('tds-table-expandable-row-third', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(componentTestPath);
+  });
+
   test('under third row opened expanded row with a button with text "Call to action"', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const tableBodyRowThirdInput = page.getByRole('cell').nth(3);
     const tableBodyRowButton = page.getByText(/Call to action/);
     await expect(tableBodyRowThirdInput).toHaveCount(1);

--- a/packages/core/src/components/table/table/test/expandable-row/interaction-4.e2e.ts
+++ b/packages/core/src/components/table/table/test/expandable-row/interaction-4.e2e.ts
@@ -4,10 +4,13 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/expandable-row/index.html';
 
 test.describe('tds-table-expandable-row-double-click-first', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(componentTestPath);
+  });
+
   test('double click on expand button in first row -> expanded row should be closed', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const tableBodyRowFirstInput = page.getByRole('cell').nth(1);
     await tableBodyRowFirstInput.dblclick();
 

--- a/packages/core/src/components/table/table/test/filtering/interaction.e2e.ts
+++ b/packages/core/src/components/table/table/test/filtering/interaction.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/filtering/index.html';
 
 test.describe.parallel('tds-table-search', () => {
-  test('look for textbox and click it', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('look for textbox and click it', async ({ page }) => {
     const tdsTableToolbarSearchInput = page.getByRole('textbox');
     await tdsTableToolbarSearchInput.click();
     await expect(tdsTableToolbarSearchInput).toHaveCSS('width', '208px');
@@ -15,7 +18,6 @@ test.describe.parallel('tds-table-search', () => {
   });
 
   test('clicking on search button opens field for entering data', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tdsTableToolbarSearchInput = page.getByRole('textbox');
     await expect(tdsTableToolbarSearchInput).toHaveCount(1);
 

--- a/packages/core/src/components/table/table/test/filtering/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/filtering/table.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/filtering/index.html';
 
 test.describe.parallel('tds-table-filtering', () => {
-  test('renders filtering table correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders filtering table correctly', async ({ page }) => {
     const tableComponent = page.getByRole('table');
     await expect(tableComponent).toHaveCount(1);
 
@@ -14,8 +17,6 @@ test.describe.parallel('tds-table-filtering', () => {
   });
 
   test('table has header "Filter"', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     /* Search for header by text and see if it exists */
     const tdsTableToolbarCaption = page.getByText('Filter');
     await expect(tdsTableToolbarCaption).toHaveCount(1);
@@ -23,7 +24,6 @@ test.describe.parallel('tds-table-filtering', () => {
   });
 
   test('search button inside the header exists', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tdsTableToolbarSearchIcon = page.getByRole('img');
     await expect(tdsTableToolbarSearchIcon).toHaveCount(1);
     await expect(tdsTableToolbarSearchIcon).toBeVisible();

--- a/packages/core/src/components/table/table/test/multiselect/default/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/multiselect/default/table.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/multiselect/default/index.html';
 
 test.describe.parallel('tds-table-multiselect', () => {
-  test('renders multiselect table correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders multiselect table correctly', async ({ page }) => {
     const tableComponent = page.getByRole('table');
     await expect(tableComponent).toHaveCount(1);
 
@@ -14,14 +17,12 @@ test.describe.parallel('tds-table-multiselect', () => {
   });
 
   test('table header contains checkbox', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableHeaderCheckbox = page.getByRole('checkbox').first();
     await expect(tableHeaderCheckbox).toHaveCount(1);
     await expect(tableHeaderCheckbox).toBeVisible();
   });
 
   test('row should contain the correct number of checkboxes in each row', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableBodyRowCheckboxes = page.getByRole('checkbox');
     await expect(tableBodyRowCheckboxes).toHaveCount(5);
 
@@ -34,7 +35,6 @@ test.describe.parallel('tds-table-multiselect', () => {
   });
 
   test('can check every checkbox in the table', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableCheckboxes = page.getByRole('cell');
     await expect(tableCheckboxes).toHaveCount(5);
 

--- a/packages/core/src/components/table/table/test/multiselect/disabled-rows/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/multiselect/disabled-rows/table.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/multiselect/disabled-rows/index.html';
 
 test.describe.parallel('tds-table-multiselect-disabled', () => {
-  test('renders multiselect table correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders multiselect table correctly', async ({ page }) => {
     const tableComponent = page.getByRole('table');
     await expect(tableComponent).toHaveCount(1);
 
@@ -14,14 +17,12 @@ test.describe.parallel('tds-table-multiselect-disabled', () => {
   });
 
   test('table header contains checkbox', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableHeaderCheckbox = page.getByRole('checkbox').first();
     await expect(tableHeaderCheckbox).toHaveCount(1);
     await expect(tableHeaderCheckbox).toBeVisible();
   });
 
   test('row should contain the correct number of checkboxes in each row', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableBodyRowCheckboxes = page.getByRole('checkbox');
     await expect(tableBodyRowCheckboxes).toHaveCount(5);
 
@@ -34,7 +35,6 @@ test.describe.parallel('tds-table-multiselect-disabled', () => {
   });
 
   test('can check enabled checkbox in the table', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableCheckboxes = page.getByRole('cell');
     await expect(tableCheckboxes).toHaveCount(5);
 

--- a/packages/core/src/components/table/table/test/pagination/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/pagination/table.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/pagination/index.html';
 
 test.describe.parallel('tds-table-pagination', () => {
-  test('renders pagination table correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders pagination table correctly', async ({ page }) => {
     const tableComponent = page.getByRole('table');
     await expect(tableComponent).toHaveCount(1);
 
@@ -14,13 +17,11 @@ test.describe.parallel('tds-table-pagination', () => {
   });
 
   test('table has a footer', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableFooter = page.locator('tds-table-footer');
     await expect(tableFooter).toHaveCount(1);
   });
 
   test('footer has field for number of page, value = 1', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableFooterPaginationSpinbutton = page.getByRole('spinbutton');
     await expect(tableFooterPaginationSpinbutton).toHaveCount(1);
     await expect(tableFooterPaginationSpinbutton).toBeVisible();
@@ -28,28 +29,24 @@ test.describe.parallel('tds-table-pagination', () => {
   });
 
   test('footer contains text "of 4 pages"', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableFooterOfPagesText = page.getByText(/of 4 pages/);
     await expect(tableFooterOfPagesText).toHaveCount(1);
     await expect(tableFooterOfPagesText).toBeVisible();
   });
 
   test('Footer contains left chevron button, it is disabled', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableFooterLeftChevronButton = page.getByRole('button').first();
     await expect(tableFooterLeftChevronButton).toBeVisible();
     await expect(tableFooterLeftChevronButton).toHaveAttribute('disabled');
   });
 
   test('Footer contains right chevron button, it is not disabled', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableFooterRightChevronButton = page.getByRole('button').last();
     await expect(tableFooterRightChevronButton).toBeVisible();
     await expect(tableFooterRightChevronButton).not.toHaveAttribute('disabled');
   });
 
   test('Footer contains buttons that are clickable and change value in input', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableFooterPaginationSpinbutton = page.getByRole('spinbutton');
     await expect(tableFooterPaginationSpinbutton).toHaveValue('1');
     const tableFooterRightChevronButton = page.getByRole('button').nth(2);
@@ -63,7 +60,6 @@ test.describe.parallel('tds-table-pagination', () => {
   test('Footer contains skip to last and first page buttons that are clickable', async ({
     page,
   }) => {
-    await page.goto(componentTestPath);
     const tableFooterPaginationSpinbutton = page.getByRole('spinbutton');
     await expect(tableFooterPaginationSpinbutton).toHaveValue('1');
     const tableFooterRightSkipForwardButton = page.getByRole('button').nth(3);
@@ -75,7 +71,6 @@ test.describe.parallel('tds-table-pagination', () => {
   });
 
   test('Footer contains rowsperpage dropdown and text', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tableFooterOfPagesText = page.getByText(/Rows per page/);
     await expect(tableFooterOfPagesText).toHaveCount(1);
     await expect(tableFooterOfPagesText).toBeVisible();
@@ -86,7 +81,6 @@ test.describe.parallel('tds-table-pagination', () => {
   });
 
   test('renders pagination dropdown list correctly', async ({ page }) => {
-    await page.goto(componentTestPath);
     const dropdown = page.locator('tds-dropdown');
     dropdown.click();
 

--- a/packages/core/src/components/table/table/test/zebra-mode/columns-even/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/zebra-mode/columns-even/table.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/zebra-mode/columns-even/index.html';
 
 test.describe.parallel('tds-table-zebra-mode-columns-even', () => {
-  test('renders default table correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default table correctly', async ({ page }) => {
     const tableComponent = page.getByRole('table');
     await expect(tableComponent).toHaveCount(1);
 

--- a/packages/core/src/components/table/table/test/zebra-mode/columns-odd/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/zebra-mode/columns-odd/table.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/zebra-mode/columns-odd/index.html';
 
 test.describe.parallel('tds-table-zebra-mode-columns-odd', () => {
-  test('renders default table correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default table correctly', async ({ page }) => {
     const tableComponent = page.getByRole('table');
     await expect(tableComponent).toHaveCount(1);
 

--- a/packages/core/src/components/table/table/test/zebra-mode/rows-even/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/zebra-mode/rows-even/table.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/zebra-mode/rows-even/index.html';
 
 test.describe.parallel('tds-table-zebra-mode-rows-even', () => {
-  test('renders default table correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default table correctly', async ({ page }) => {
     const tableComponent = page.getByRole('table');
     await expect(tableComponent).toHaveCount(1);
 

--- a/packages/core/src/components/table/table/test/zebra-mode/rows-odd/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/zebra-mode/rows-odd/table.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/table/table/test/zebra-mode/rows-odd/index.html';
 
 test.describe.parallel('tds-table-zebra-mode-rows-odd', () => {
-  test('renders default table correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default table correctly', async ({ page }) => {
     const tableComponent = page.getByRole('table');
     await expect(tableComponent).toHaveCount(1);
 

--- a/packages/core/src/components/text-field/test/read-only-with-suffix/text-field.e2e.ts
+++ b/packages/core/src/components/text-field/test/read-only-with-suffix/text-field.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/text-field/test/read-only-with-suffix/index.html';
 
 test.describe('TdsTextField - readOnly prop effect', () => {
-  test('should hide the suffix icon when readOnly is true', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('should hide the suffix icon when readOnly is true', async ({ page }) => {
     const suffixIcon = await page.locator('.text-field-slot-wrap-suffix');
     await expect(suffixIcon).toBeHidden();
   });

--- a/packages/core/src/components/textarea/test/basic/textarea.e2e.ts
+++ b/packages/core/src/components/textarea/test/basic/textarea.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/textarea/test/basic/index.html';
 
 test.describe.parallel('tds-textarea', () => {
-  test('renders default textarea correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default textarea correctly', async ({ page }) => {
     const tdsTextarea = page.getByTestId('tds-textarea-testid');
     await expect(tdsTextarea).toHaveCount(1);
 
@@ -14,7 +17,6 @@ test.describe.parallel('tds-textarea', () => {
   });
 
   test('test if able to type in textarea', async ({ page }) => {
-    await page.goto(componentTestPath);
     const textarea = page.getByRole('textbox');
 
     /* Expect to have received an event from clicking on the textarea */

--- a/packages/core/src/components/textarea/test/default/textarea.e2e.ts
+++ b/packages/core/src/components/textarea/test/default/textarea.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/textarea/test/default/index.html';
 
 test.describe.parallel('tds-textarea-default', () => {
-  test('renders default textarea correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders default textarea correctly', async ({ page }) => {
     const tdsTextarea = page.getByTestId('tds-textarea-testid');
     await expect(tdsTextarea).toHaveCount(1);
 
@@ -14,7 +17,6 @@ test.describe.parallel('tds-textarea-default', () => {
   });
 
   test('test if able to type in textarea', async ({ page }) => {
-    await page.goto(componentTestPath);
     const textarea = page.getByRole('textbox');
 
     /* Expect to have received an event from clicking on the textarea */
@@ -35,7 +37,6 @@ test.describe.parallel('tds-textarea-default', () => {
   });
 
   test('not able to find label if "no-label" is set', async ({ page }) => {
-    await page.goto(componentTestPath);
     const textareaLabel = page.getByText('Label');
     await expect(textareaLabel).toHaveCount(0);
     await expect(textareaLabel).toBeHidden();

--- a/packages/core/src/components/textarea/test/read-only/textarea.e2e.ts
+++ b/packages/core/src/components/textarea/test/read-only/textarea.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/textarea/test/read-only/index.html';
 
 test.describe.parallel('tds-textarea-read-only', () => {
-  test('renders read-only textarea correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('renders read-only textarea correctly', async ({ page }) => {
     const tdsTextarea = page.getByTestId('tds-textarea-testid');
     await expect(tdsTextarea).toHaveCount(1);
 
@@ -17,7 +20,6 @@ test.describe.parallel('tds-textarea-read-only', () => {
   });
 
   test('read-only textarea - native textarea should have readonly attribute', async ({ page }) => {
-    await page.goto(componentTestPath);
     const textarea = page.getByRole('textbox');
 
     /* Expect the textarea within tds-textarea to have the readonly attribute */
@@ -25,7 +27,6 @@ test.describe.parallel('tds-textarea-read-only', () => {
   });
 
   test('be able to find label if "outside" is set', async ({ page }) => {
-    await page.goto(componentTestPath);
     const textareaLabel = page.getByText('Label');
     await expect(textareaLabel).toHaveCount(1);
     await expect(textareaLabel).toBeVisible();

--- a/packages/core/src/components/toast/test/hide-prop/toast.e2e.ts
+++ b/packages/core/src/components/toast/test/hide-prop/toast.e2e.ts
@@ -4,9 +4,12 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/toast/test/hide-prop/index.html';
 
 test.describe('Toast Component Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(componentTestPath);
+  });
+
   // Test if component is hidden
   test('should be hidden', async ({ page }) => {
-    await page.goto(componentTestPath);
     const tdsToast = page.getByTestId('tds-toast-testid');
     await expect(tdsToast).toHaveCSS('display', 'none');
   });

--- a/packages/core/src/components/toggle/test/default/toggle.e2e.ts
+++ b/packages/core/src/components/toggle/test/default/toggle.e2e.ts
@@ -4,8 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/toggle/test/default/index.html';
 
 test.describe.parallel('tds-toggle', () => {
-  test('Renders basic toggle correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
+
+  test('Renders basic toggle correctly', async ({ page }) => {
     const labelElement = page.locator('tds-toggle label');
     const headlineElement = page.locator('tds-toggle .toggle-headline'); // Target label underneath toggle
 
@@ -17,7 +20,6 @@ test.describe.parallel('tds-toggle', () => {
   });
 
   test('Click on toggle -> should become checked', async ({ page }) => {
-    await page.goto(componentTestPath);
     const toggle = page.locator('tds-toggle input');
 
     // Expect not to be checked on render

--- a/packages/core/src/components/toggle/test/disabled/toggle.e2e.ts
+++ b/packages/core/src/components/toggle/test/disabled/toggle.e2e.ts
@@ -4,9 +4,11 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/toggle/test/disabled/index.html';
 
 test.describe.parallel('tds-toggle', () => {
-  test('Should have disabled attribute', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('Should have disabled attribute', async ({ page }) => {
     const toggle = page.locator('tds-toggle input');
 
     const disabled = await toggle.evaluate((element: HTMLInputElement) => element.disabled);
@@ -17,7 +19,6 @@ test.describe.parallel('tds-toggle', () => {
   });
 
   test('Hover over toggle -> should have inactive cursor', async ({ page }) => {
-    await page.goto(componentTestPath);
     const label = page.locator('tds-toggle label');
     const headline = page.locator('tds-toggle .toggle-headline');
     const input = page.locator('tds-toggle input');

--- a/packages/core/src/components/tooltip/test/click/tooltip.e2e.ts
+++ b/packages/core/src/components/tooltip/test/click/tooltip.e2e.ts
@@ -4,15 +4,15 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/tooltip/test/click/index.html';
 
 test.describe('tds-tooltip', () => {
-  test('renders the tooltip correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders the tooltip correctly', async ({ page }) => {
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('Should not appear on hover', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     // Select the button that triggers the tooltip on click
     const button = page.locator('tds-button#button-3');
 
@@ -25,8 +25,6 @@ test.describe('tds-tooltip', () => {
   });
 
   test('Should appears on button click', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     // Select the button that triggers the tooltip on click
     const button = page.locator('tds-button#button-3');
 
@@ -41,8 +39,6 @@ test.describe('tds-tooltip', () => {
   });
 
   test('Should contain correct HTML content on click', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     // Hover over the button to trigger the tooltip
     const button = page.locator('tds-button#button-3');
     await button.click();

--- a/packages/core/src/components/tooltip/test/default/tooltip.e2e.ts
+++ b/packages/core/src/components/tooltip/test/default/tooltip.e2e.ts
@@ -4,15 +4,15 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/tooltip/test/default/index.html';
 
 test.describe('tds-tooltip', () => {
-  test('renders the tooltip correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders the tooltip correctly', async ({ page }) => {
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('tooltip appears on button hover', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     // Select the button that triggers the tooltip on hover
     const button = page.locator('tds-button#button-1');
 
@@ -28,8 +28,6 @@ test.describe('tds-tooltip', () => {
   });
 
   test('tooltip contains correct HTML content on hover', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     // Hover over the button to trigger the tooltip
     const button = page.locator('tds-button#button-1');
     await button.hover();

--- a/packages/core/src/components/tooltip/test/disabled/tooltip.e2e.ts
+++ b/packages/core/src/components/tooltip/test/disabled/tooltip.e2e.ts
@@ -4,15 +4,15 @@ import { expect } from '@playwright/test';
 const componentTestPath = 'src/components/tooltip/test/disabled/index.html';
 
 test.describe('tds-tooltip', () => {
-  test('renders the tooltip correctly', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(componentTestPath);
+  });
 
+  test('renders the tooltip correctly', async ({ page }) => {
     await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
   });
 
   test('tooltip closes when cursor is removed from the button', async ({ page }) => {
-    await page.goto(componentTestPath);
-
     // Assuming your button and tooltip setup is already appropriate for this test
     const button = page.locator('tds-button#button-2');
 


### PR DESCRIPTION
## **Describe pull-request**  
Removed `await page.goto(componentTestPath);` from the beginning of each test and added 
```
test.beforeEach(async ({ page }) => {
  await page.goto(componentTestPath);
});
```

to each test file.

## **Issue Linking:** 
Partially addresses this ticket:
**Jira:** [CDEP-3604](https://tegel.atlassian.net/browse/CDEP-3604)

## **How to test**  
Run `npm run test`

## **Checklist before submission**
- [x] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [x] `npm run build-all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
Not applicable

## **Additional context**  
None


[CDEP-3604]: https://tegel.atlassian.net/browse/CDEP-3604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ