### PR TITLE
fix(header-dropdown):  chevron icon rotation

### DIFF
--- a/packages/core/src/components/header/header-dropdown/header-dropdown.scss
+++ b/packages/core/src/components/header/header-dropdown/header-dropdown.scss
@@ -20,7 +20,7 @@
 
   .state-open {
     .dropdown-icon {
-      transform: rotatetds-z-index(180deg);
+      transform: rotate(180deg);
     }
 
     .button {


### PR DESCRIPTION
## **Describe pull-request**  
Fixes the header dropdown chevron to rotate when the element is clicked.

## **Issue Linking:**  
- **Jira:** [CDEP-3768](https://tegel.atlassian.net/browse/CDEP-3768)   

## **How to test**  
1. Open storybook
2. Go to Patterns → Navigation → Few Navigation Items.
3. Make sure that your window is wide enough that it shows the chevron icon element "Wheel Types" in the header without having to open the side menu
4. Click the "Wheel Types" button

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [ ] `npm run build-all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
None

[CDEP-3768]: https://tegel.atlassian.net/browse/CDEP-3768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ