### PR TITLE
fix(block): nested blocks background color

### DIFF
--- a/packages/core/src/components/block/block-vars.scss
+++ b/packages/core/src/components/block/block-vars.scss
@@ -2,39 +2,95 @@
 .tds-mode-light {
   --tds-block-color: var(--tds-grey-985);
   --tds-block-background-primary: var(--tds-grey-50);
-  --tds-block-background-nested-primary: var(--tds-white);
   --tds-block-background-secondary: var(--tds-white);
-  --tds-block-background-nested-secondary: var(--tds-grey-50);
-  --tds-block-background: var(--tds-block-background-primary);
-  --tds-block-background-nested: var(--tds-block-background-nested-primary);
-
-  .tds-mode-variant-primary {
-    --tds-block-background: var(--tds-block-background-primary);
-    --tds-block-background-nested: var(--tds-block-background-nested-primary);
-  }
-
-  .tds-mode-variant-secondary {
-    --tds-block-background: var(--tds-block-background-secondary);
-    --tds-block-background-nested: var(--tds-block-background-nested-secondary);
-  }
 }
 
 .tds-mode-dark {
   --tds-block-color: var(--tds-grey-50);
   --tds-block-background-primary: var(--tds-grey-900);
-  --tds-block-background-nested-primary: var(--tds-grey-868);
   --tds-block-background-secondary: var(--tds-grey-868);
-  --tds-block-background-nested-secondary: var(--tds-grey-900);
+}
+
+// problem with the solution below: it only works for 5 levels of nesting, or
+// however many levels we adjust the code here for
+
+tds-block,
+.tds-mode-variant-primary tds-block {
   --tds-block-background: var(--tds-block-background-primary);
-  --tds-block-background-nested: var(--tds-block-background-nested-primary);
 
-  .tds-mode-variant-primary {
-    --tds-block-background: var(--tds-block-background-primary);
-    --tds-block-background-nested: var(--tds-block-background-nested-primary);
-  }
-
-  .tds-mode-variant-secondary {
+  tds-block {
     --tds-block-background: var(--tds-block-background-secondary);
-    --tds-block-background-nested: var(--tds-block-background-nested-secondary);
+
+    tds-block {
+      --tds-block-background: var(--tds-block-background-primary);
+
+      tds-block {
+        --tds-block-background: var(--tds-block-background-secondary);
+
+        tds-block {
+          --tds-block-background: var(--tds-block-background-primary);
+        }
+      }
+    }
+  }
+}
+
+.tds-mode-variant-secondary tds-block {
+  --tds-block-background: var(--tds-block-background-secondary);
+
+  tds-block {
+    --tds-block-background: var(--tds-block-background-primary);
+
+    tds-block {
+      --tds-block-background: var(--tds-block-background-secondary);
+
+      tds-block {
+        --tds-block-background: var(--tds-block-background-primary);
+
+        tds-block {
+          --tds-block-background: var(--tds-block-background-secondary);
+        }
+      }
+    }
+  }
+}
+
+tds-block[mode-variant='primary'] {
+  --tds-block-background: var(--tds-block-background-primary);
+
+  tds-block {
+    --tds-block-background: var(--tds-block-background-secondary);
+
+    tds-block {
+      --tds-block-background: var(--tds-block-background-primary);
+
+      tds-block {
+        --tds-block-background: var(--tds-block-background-secondary);
+
+        tds-block {
+          --tds-block-background: var(--tds-block-background-primary);
+        }
+      }
+    }
+  }
+}
+
+tds-block[mode-variant='secondary'] {
+  --tds-block-background: var(--tds-block-background-secondary);
+
+  tds-block {
+    --tds-block-background: var(--tds-block-background-primary);
+
+    tds-block {
+      --tds-block-background: var(--tds-block-background-secondary);
+
+      tds-block {
+        --tds-block-background: var(--tds-block-background-primary);
+
+        tds-block {
+          --tds-block-background: var(--tds-block-background-secondary);
+        }
+      }
+    }
   }
 }

--- a/packages/core/src/components/block/block-vars.scss
+++ b/packages/core/src/components/block/block-vars.scss
@@ -11,86 +11,71 @@
   --tds-block-background-secondary: var(--tds-grey-868);
 }
 
-// problem with the solution below: it only works for 5 levels of nesting, or
-// however many levels we adjust the code here for
-
 tds-block,
 .tds-mode-variant-primary tds-block {
   --tds-block-background: var(--tds-block-background-primary);
 
-  tds-block {
-    --tds-block-background: var(--tds-block-background-secondary);
-
-    tds-block {
-      --tds-block-background: var(--tds-block-background-primary);
-
-      tds-block {
-        --tds-block-background: var(--tds-block-background-secondary);
-
-        tds-block {
-          --tds-block-background: var(--tds-block-background-primary);
-        }
-      }
+  $selector: 'tds-block';
+  @for $i from 1 through 10 {
+    #{$selector} {
+      --tds-block-background: #{if(
+        $i % 2 == 0,
+        var(--tds-block-background-primary),
+        var(--tds-block-background-secondary)
+      )};
     }
+
+    $selector: '#{$selector} tds-block';
   }
 }
 
 .tds-mode-variant-secondary tds-block {
   --tds-block-background: var(--tds-block-background-secondary);
 
-  tds-block {
-    --tds-block-background: var(--tds-block-background-primary);
-
-    tds-block {
-      --tds-block-background: var(--tds-block-background-secondary);
-
-      tds-block {
-        --tds-block-background: var(--tds-block-background-primary);
-
-        tds-block {
-          --tds-block-background: var(--tds-block-background-secondary);
-        }
-      }
+  $selector: 'tds-block';
+  @for $i from 1 through 10 {
+    #{$selector} {
+      --tds-block-background: #{if(
+        $i % 2 == 0,
+        var(--tds-block-background-secondary),
+        var(--tds-block-background-primary)
+      )};
     }
+
+    $selector: '#{$selector} tds-block';
   }
 }
 
 tds-block[mode-variant='primary'] {
   --tds-block-background: var(--tds-block-background-primary);
 
-  tds-block {
-    --tds-block-background: var(--tds-block-background-secondary);
-
-    tds-block {
-      --tds-block-background: var(--tds-block-background-primary);
-
-      tds-block {
-        --tds-block-background: var(--tds-block-background-secondary);
-
-        tds-block {
-          --tds-block-background: var(--tds-block-background-primary);
-        }
-      }
+  $selector: 'tds-block';
+  @for $i from 1 through 10 {
+    #{$selector} {
+      --tds-block-background: #{if(
+        $i % 2 == 0,
+        var(--tds-block-background-primary),
+        var(--tds-block-background-secondary)
+      )};
     }
+
+    $selector: '#{$selector} tds-block';
   }
 }
 
 tds-block[mode-variant='secondary'] {
   --tds-block-background: var(--tds-block-background-secondary);
 
-  tds-block {
-    --tds-block-background: var(--tds-block-background-primary);
-
-    tds-block {
-      --tds-block-background: var(--tds-block-background-secondary);
-
-      tds-block {
-        --tds-block-background: var(--tds-block-background-primary);
-
-        tds-block {
-          --tds-block-background: var(--tds-block-background-secondary);
-        }
-      }
+  $selector: 'tds-block';
+  @for $i from 1 through 10 {
+    #{$selector} {
+      --tds-block-background: #{if(
+        $i % 2 == 0,
+        var(--tds-block-background-secondary),
+        var(--tds-block-background-primary)
+      )};
     }
+
+    $selector: '#{$selector} tds-block';
   }
 }

--- a/packages/core/src/components/block/block.scss
+++ b/packages/core/src/components/block/block.scss
@@ -10,13 +10,3 @@
   letter-spacing: var(--tds-body-01-ls);
   background-color: var(--tds-block-background);
 }
-
-.tds-mode-variant-primary {
-  --tds-block-background: var(--tds-block-background-primary);
-  --tds-block-background-nested: var(--tds-block-background-nested-primary);
-}
-
-.tds-mode-variant-secondary {
-  --tds-block-background: var(--tds-block-background-secondary);
-  --tds-block-background-nested: var(--tds-block-background-nested-secondary);
-}

--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, Element } from '@stencil/core';
+import { Component, h } from '@stencil/core';
 
 /**
  * @slot <default> - <b>Unnamed slot.</b> For the content.
@@ -9,35 +9,9 @@ import { Component, h, Prop, Element } from '@stencil/core';
   shadow: true,
 })
 export class TdsBlock {
-  @Element() host: HTMLElement;
-
-  /** Mode variant of the component, based on current mode. */
-  @Prop() modeVariant: 'primary' | 'secondary' = null;
-
-  children: Array<HTMLTdsBlockElement>;
-
-  setModeVariantOnChildBlocks() {
-    this.children = Array.from(this.host.children).filter(
-      (item) => item.tagName === 'TDS-BLOCK',
-    ) as HTMLTdsBlockElement[];
-
-    this.children?.forEach((item) => {
-      if (!this.modeVariant) {
-        item.setAttribute('mode-variant', 'secondary');
-      } else {
-        item.setAttribute('mode-variant', this.modeVariant === 'primary' ? 'secondary' : 'primary');
-      }
-    });
-  }
-
   render() {
-    this.setModeVariantOnChildBlocks();
     return (
-      <div
-        class={`tds-block ${
-          this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''
-        }`}
-      >
+      <div class="tds-block">
         <slot></slot>
       </div>
     );

--- a/packages/core/src/components/block/readme.md
+++ b/packages/core/src/components/block/readme.md
@@ -5,13 +5,6 @@
 <!-- Auto Generated Below -->
 
 
-## Properties
-
-| Property      | Attribute      | Description                                           | Type                       | Default |
-| ------------- | -------------- | ----------------------------------------------------- | -------------------------- | ------- |
-| `modeVariant` | `mode-variant` | Mode variant of the component, based on current mode. | `"primary" \| "secondary"` | `null`  |
-
-
 ## Slots
 
 | Slot          | Description                           |


### PR DESCRIPTION
## **Describe pull-request**  
Fixes the background colors of nested block elements.

## **Issue Linking:** 
- **Jira:** [CDEP-3342](https://tegel.atlassian.net/browse/CDEP-3342)

## **How to test**  
1. Clone https://github.com/scania-digital-design-system/tegel-react-demo/tree/testing-nested-blocks-colors (and use the testing-nested-blocks-colors)
2. Run that code with npm install && npm run start
3. Open the page in the browser and go to the About tab to see the nested blocks
4. Play around with activating primary and secondary mode variant and lightmode/darkmode with the toggles in the top right of the page, and also manually setting by changing `<TdsBlock>` to `<TdsBlock mode-variant="primary">` and `<TdsBlock mode-variant="secondary">` in About.tsx in the tegel-react-demo code.

The commit [fix(block): background color of nested block elements, temporary solution](https://github.com/scania-digital-design-system/tegel/pull/984/commits/ba7c2ed9b1571b0fc6b303dd0ba4629a18af60c1) can be tested in React by using the @scania/tegel-react package "1.21.1-block-nested-secondary-mode-variant-colors-beta.0"

The commit [fix(block): better solution in scss for nested blocks](https://github.com/scania-digital-design-system/tegel/pull/984/commits/166a2d659d0cce6d545799a8e5a4cba254359298) can be tested in React by using the @scania/tegel-react package "1.21.1-block-nested-secondary-mode-variant-colors-beta.1". This is the one used in the testing-nested-blocks branch mentioned above.

## **Checklist before submission**
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [ ] `npm run build-all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
I removed quite a bit of code in block.tsx. I'm unsure if it's a problem that I removed the modeVariant prop, but mode variant styling is now handled in block-vars.scss only. One can still specify the mode variant using "mode-variant" according to step 4 in "How to test" above. Before it was also possible to do it with modeVariant, but as the prop is removed, this doesn't work anymore. The reason for not keeping the modeVariant prop was that I couldn't get it to work how it was handled previously, where in block.tsx the class was set to `tds-mode-variant-primary` or `tds-mode-variant-secondary` depending on the modeVariant prop, and also changing e.g. `tds-block[mode-variant='primary']` to `tds-block.tds-mode-variant-primary` in block-vars.scss. However, I might have done something wrong when trying to solve it, and if it's important to be able to specify the mode variant with "modeVariant" rather than "mode-variant", I'll look into it more. It's a bit difficult to explain by text, so let me know if you want me to explain it to you better.

Note also that only 10 levels of nesting works with the correct colors (see that nested blocks 10 and 11 have the same background color) since this is what is specified in block-vars.scss. However, it's very easy for us to change to e.g. 20 levels of nesting if we would want to.


[CDEP-3342]: https://tegel.atlassian.net/browse/CDEP-3342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ