### PR TITLE
fix(slider): improve value snapping and calculation logic

### DIFF
--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -222,18 +222,21 @@ export class TdsSlider {
 
   private updateValue(event) {
     const trackWidth = this.getTrackWidth();
-    const numTicks = parseInt(this.ticks);
+    const min = parseFloat(this.min);
+    const max = parseFloat(this.max);
 
-    /* if snapping (supposedValueSlot > 0) is enabled, make sure we display the supposed value (instead of maybe getting a -1/+1 depending on rounding)  */
-    if (this.useSnapping && numTicks) {
-      const supposedValue = this.tickValues[this.supposedValueSlot];
-      this.value = `${supposedValue}`;
-      this.calculateThumbLeftFromValue(supposedValue);
+    // If snapping is enabled and a valid supposedValueSlot is available,
+    // snap the value to the closest tick. Use the snapped value to update
+    // the slider's thumb position and internal value.
+    if (this.useSnapping && this.supposedValueSlot >= 0) {
+      const snappedValue = this.tickValues[this.supposedValueSlot];
+      this.value = snappedValue.toString();
+      this.calculateThumbLeftFromValue(snappedValue);
     } else {
       const percentage = this.thumbLeft / trackWidth;
-      this.value = `${Math.trunc(
-        parseFloat(this.min) + percentage * (parseFloat(this.max) - parseFloat(this.min)),
-      )}`;
+      const calculatedValue = min + percentage * (max - min);
+
+      this.value = Math.round(calculatedValue).toString();
     }
     this.updateTrack();
 


### PR DESCRIPTION
## **Describe pull-request**  
This pull request addresses an issue in the updateValue method of the tds-slider component, where the slider thumb exhibited "jumping" behavior when decreasing values. To fix this issue I replaced the `Math.trunc` to `Math.round`. 

Math.trunc always rounds downwards, so 4.9 becomes 4. This results in a flaky appearance.

## **Issue Linking:**  
- **Jira:** Add ticket number after: [CDEP-3125](https://tegel.atlassian.net/browse/CDEP-3125)    

## **How to test**  
1. Go to aws link
2. Navigate to the slider component
3. decrease and increase the value of the slider and make sure it operates smooth.

## **Checklist before submission**
- [x] No accessibility violations in storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [ ] `npm run build-all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [x] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
https://github.com/user-attachments/assets/bdc68c76-ac92-4eba-a3e9-f57f506c4aca


[CDEP-3125]: https://tegel.atlassian.net/browse/CDEP-3125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ