### PR TITLE
fix(chip): Internal event for radio button

### DIFF
--- a/packages/core/src/components/chip/chip.stories.tsx
+++ b/packages/core/src/components/chip/chip.stories.tsx
@@ -205,10 +205,17 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         display: flex;
         gap: 8px;
       }
+      .demo-wrapper:first-of-type {
+        margin-bottom: 8px;
+      }
+      label {
+        margin: 8px;
+      }
     </style>
 
+    <label>Group 1</label>
     <div class="demo-wrapper">
-      <tds-chip name="test" type="radio" size="${
+      <tds-chip name="group1" type="radio" size="${
         sizeLookUp[size]
       }" checked ${disabledAttribute} value="radio-1-value">
         ${
@@ -225,7 +232,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
               : ''
           } 
       </tds-chip>
-      <tds-chip name="test" type="radio" size="${sizeLookUp[size]}" value="radio-2-value">
+      <tds-chip name="group1" type="radio" size="${sizeLookUp[size]}" value="radio-2-value">
         ${
           icon && iconPosition === 'Prefix'
             ? '<tds-icon slot="prefix" name="cart" size="16px"></tds-icon>'
@@ -240,7 +247,57 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
               : ''
           } 
       </tds-chip>
-      <tds-chip name="test" type="radio" size="${sizeLookUp[size]}" value="radio-3-value">
+      <tds-chip name="group1" type="radio" size="${sizeLookUp[size]}" value="radio-3-value">
+        ${
+          icon && iconPosition === 'Prefix'
+            ? '<tds-icon slot="prefix" name="star" size="16px"></tds-icon>'
+            : ''
+        }
+          <span slot="label">
+            ${label} 3
+          </span>
+          ${
+            icon && iconPosition === 'Suffix'
+              ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+              : ''
+          } 
+      </tds-chip>
+    </div>
+    <label>Group 2</label>
+    <div class="demo-wrapper">
+      <tds-chip name="group2" type="radio" size="${
+        sizeLookUp[size]
+      }" checked ${disabledAttribute} value="radio-1-value">
+        ${
+          icon && iconPosition === 'Prefix'
+            ? '<tds-icon slot="prefix" name="sorting" size="16px"></tds-icon>'
+            : ''
+        }
+          <span slot="label">
+            ${label} 1
+          </span>
+          ${
+            icon && iconPosition === 'Suffix'
+              ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+              : ''
+          } 
+      </tds-chip>
+      <tds-chip name="group2" type="radio" size="${sizeLookUp[size]}" value="radio-2-value">
+        ${
+          icon && iconPosition === 'Prefix'
+            ? '<tds-icon slot="prefix" name="cart" size="16px"></tds-icon>'
+            : ''
+        }
+          <span slot="label">
+            ${label} 2
+          </span>
+          ${
+            icon && iconPosition === 'Suffix'
+              ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+              : ''
+          } 
+      </tds-chip>
+      <tds-chip name="group2" type="radio" size="${sizeLookUp[size]}" value="radio-3-value">
         ${
           icon && iconPosition === 'Prefix'
             ? '<tds-icon slot="prefix" name="star" size="16px"></tds-icon>'

--- a/packages/core/src/components/chip/chip.tsx
+++ b/packages/core/src/components/chip/chip.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Event, EventEmitter, Prop, Element } from '@stencil/core';
+import { Component, Host, h, Event, EventEmitter, Prop, Element, Listen } from '@stencil/core';
 import generateUniqueId from '../../utils/generateUniqueId';
 import hasSlot from '../../utils/hasSlot';
 
@@ -57,6 +57,18 @@ export class TdsChip {
     checked?: boolean;
   }>;
 
+  /** @internal Emit checked value if type is radio */
+  @Event({
+    eventName: 'internalRadioOnChange',
+    composed: true,
+    cancelable: false,
+    bubbles: true,
+  })
+  internalRadioOnChange: EventEmitter<{
+    chipId: string;
+    checked: boolean;
+  }>;
+
   private handleChange = () => {
     if (!this.disabled) {
       // Only proceed if not disabled
@@ -64,6 +76,7 @@ export class TdsChip {
         this.checked = !this.checked;
       } else if (this.type === 'radio') {
         this.checked = true;
+        this.internalRadioOnChange.emit({ chipId: this.chipId, checked: this.checked })
       } else {
         console.error('Unsupported type in Chip component!');
       }
@@ -75,6 +88,18 @@ export class TdsChip {
       });
     }
   };
+
+  @Listen('internalRadioOnChange', { target: 'body' })
+  handleInternaRadioChange(event: CustomEvent<{ chipId: string; checked?: boolean; }>) {
+    const { chipId, checked } = event.detail
+
+    // if event comes from different button and both incoming and this is checked
+    if(chipId !== this.chipId) {
+      if(this.checked && checked) {
+        this.checked = false
+      }
+    }
+  }
 
   /** Sends unique Chip identifier when Chip is clicked.
    * Valid only for type button.

--- a/packages/core/src/components/chip/chip.tsx
+++ b/packages/core/src/components/chip/chip.tsx
@@ -67,6 +67,7 @@ export class TdsChip {
   internalRadioOnChange: EventEmitter<{
     chipId: string;
     checked: boolean;
+    groupName: string
   }>;
 
   private handleChange = () => {
@@ -76,7 +77,7 @@ export class TdsChip {
         this.checked = !this.checked;
       } else if (this.type === 'radio') {
         this.checked = true;
-        this.internalRadioOnChange.emit({ chipId: this.chipId, checked: this.checked })
+        this.internalRadioOnChange.emit({ chipId: this.chipId, checked: this.checked, groupName: this.name })
       } else {
         console.error('Unsupported type in Chip component!');
       }
@@ -90,11 +91,12 @@ export class TdsChip {
   };
 
   @Listen('internalRadioOnChange', { target: 'body' })
-  handleInternaRadioChange(event: CustomEvent<{ chipId: string; checked?: boolean; }>) {
-    const { chipId, checked } = event.detail
+  handleInternaRadioChange(event: CustomEvent<{ chipId: string; checked: boolean; groupName: string }>) {
+    const { chipId, checked, groupName } = event.detail
 
-    // if event comes from different button and both incoming and this is checked
-    if(chipId !== this.chipId) {
+    // if event comes from different button within the group
+    if(chipId !== this.chipId && groupName === this.name) {
+      //  and both incoming and this is checked
       if(this.checked && checked) {
         this.checked = false
       }


### PR DESCRIPTION
## **Describe pull-request**  
Added a internal event to listen to so if chip has type `radio` it responds to other `tds-chip` component changing.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-3818](https://tegel.atlassian.net/browse/CDEP-3818)
- **GitHub:** [Issue 983](https://github.com/scania-digital-design-system/tegel/issues/983)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to amplify link
2. Go to chip component
3. Click type `radio`
4. Inspect `tds-chip` in the browser, the checked flag should now move to next clicked element.

## **Checklist before submission**
- [ ] No accessibility violations in storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [x] `npm run build-all` without errors



[CDEP-3818]: https://tegel.atlassian.net/browse/CDEP-3818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ