### PR TITLE
fix: highlight language warning in browser console

### DIFF
--- a/packages/core/src/stories/Installation/javascript.stories.ts
+++ b/packages/core/src/stories/Installation/javascript.stories.ts
@@ -13,6 +13,7 @@ const meta: Meta = {
   },
 };
 
+hljs.registerAliases('undefined', { languageName: 'javascript' });
 hljs.highlightAll();
 
 export default meta;


### PR DESCRIPTION
## **Describe pull-request**  
Fixes the issue of the console.log warning related to "undefined" language. This isn't necessarily a good solution, it's more of a work-around I would say. Please read _Additional context_ below.

## **Issue Linking:**
- **Jira:** [CDEP-2660](https://tegel.atlassian.net/browse/CDEP-2660)

## **How to test** 
1. Go to https://tds-storybook.tegel.scania.com/?path=/story/components-accordion--default
2. Open browser console
3. Click any of the toggles for the props of the component
4. Notice the warning messages
5. Go to https://pr-990.d3fazya28914g3.amplifyapp.com/?path=/story/components-accordion--default
6. Repeat steps 2-3 and note that the warning messages don't appear

## **Checklist before submission**
- [ ] No accessibility violations in storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [x] `npm run build-all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
I did a bit of digging by modifying files in node_modules, and my understanding now is this:

In **packages/core/src/stories/Installation/javascript.stories.ts**, it seems we tell highlight js to highlight all code snippets using the hljs.highlightAll function (I think the default is code tags within pre tags). If this line is commented away, we don’t get the warning in the browser console, but we don’t get any code highlighting either, which we want.

In **packages/core/node_modules/@storybook/core-server/node_modules/@storybook/core-common/templates/base-preview-body.html**, it seems like the following code snippet is where the problem occurs:

`<code id="error-stack"></code>`.

It appears this snippet is changed to 

`<code id="error-stack" class="hljs language-undefined"></code>`

during runtime, which causes highlight js to interpret it as the language of this code snippet being called ”undefined”.

If we change the snippet from

`<code id="error-stack"></code>`

to e.g.

`<code id="error-stack" class="language-javascript”></code>`

then the warning doesn’t appear in the browser console, which is probably because ”javascript” is one of the languages loaded by highlight js, which we can verify e.g. by, in javascript.stories.ts, add this: console.log(hljs.listLanguages()). There we can also see that ”undefined” of course isn’t a language, which is why we get the warning. This however of course involves modifying the node_modules files, which we can’t do.

In javascript.stories.js, if we add 

`hljs.registerAliases('undefined', { languageName: 'javascript' });`
(relevant documentation page: https://highlightjs.readthedocs.io/en/latest/api.html)

then the warning disappears, as ”undefined” is now an alias for javascript.

**This is clearly a work-around** rather than a solution, but it gets the job done. The main problem I can’t figure out is why `class="hljs language-undefined”` is inserted into the code-snippet mentioned above, when it doesn’t seem to happen to any of the other code snippets in the repo.


[CDEP-2660]: https://tegel.atlassian.net/browse/CDEP-2660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ