### PR TITLE
fix: name change webhook file and print node version

### DIFF
--- a/.github/workflows/smoke-test-all.yml
+++ b/.github/workflows/smoke-test-all.yml
@@ -39,6 +39,9 @@ jobs:
           node-version: ${{ github.event.inputs.nodeVersion }}
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Print Node.js version
+        run: node -v
+
       - name: Core - Read Package.json Version
         id: core-version
         working-directory: ${{ env.WORKING_DIRECTORY }}
@@ -190,4 +193,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify in Teams on failure
-        uses: ./.github/workflows/smoke-test-webhook.yml
+        uses: ./.github/workflows/smoke-test-failure-webhook.yml

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ packages/core/results.json
 
 # tegel-styles
 packages/styles/dist/
+
+# github actions
+.github/.secrets

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,3 @@ packages/core/results.json
 
 # tegel-styles
 packages/styles/dist/
-
-# github actions
-.github/.secrets


### PR DESCRIPTION
## **Describe pull-request**  
File name was changed. Probably that was the cause of the teams webhook not running.

Also added a job to echo out the node version. 