### PR TITLE
fix(tooltip): space claim and text wrapping

### DIFF
--- a/packages/core/src/components/tooltip/tooltip.scss
+++ b/packages/core/src/components/tooltip/tooltip.scss
@@ -1,6 +1,10 @@
 @import '../../mixins/z-index';
 @import '../../mixins/box-sizing';
 
+:host {
+  position: absolute;
+}
+
 .tds-tooltip {
   @include tds-box-sizing;
 

--- a/packages/core/src/components/tooltip/tooltip.scss
+++ b/packages/core/src/components/tooltip/tooltip.scss
@@ -15,6 +15,7 @@
   border-radius: 4px;
   padding: 8px;
   word-wrap: break-word;
+  white-space: normal;
   max-width: 192px;
   z-index: tds-z-index(tooltip);
   opacity: 0;


### PR DESCRIPTION
## **Describe pull-request**  
Tooltip tends to claim space in user's application as it has no position defined. We control it by visibility attribute but in some occasions, it tends to occupy space and break the layout. With position absolute issue is removed. 
Text wrapping: additional CSS rule is added to help text wrapping due to limited width.

## **Issue Linking:**  
- **No issue:** Came in support channel.

## **How to test**  
1. Compare the preview link with the prod Storybook.
2. There should be no changes.

## **Checklist before submission**
- [x] No accessibility violations in storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [x] `npm run build-all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events