### PR TITLE
ci(holy-grail): sync develop and main

### DIFF
--- a/.github/workflows/holy-grail.yml
+++ b/.github/workflows/holy-grail.yml
@@ -418,14 +418,9 @@ jobs:
           git config --global user.email "tegel.design.system@gmail.com"
           git remote set-url origin https://x-access-token:${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }}
 
-      - name: Merge develop into main
+      # Sync develop and main is done with reset to avoid merge conflicts
+      - name: Sync develop and main
         run: |
           git checkout main
-          git merge --squash -X theirs develop
-          git add .
-          if ! git diff-index --quiet HEAD; then
-            git commit -m "release: tegel@${{ needs.create-release-branch.outputs.version  }}"
-            git push --force --no-verify origin main
-          else
-            echo "No changes to commit in main"
-          fi
+          git reset --hard develop
+          git push --force --no-verify origin main


### PR DESCRIPTION
## **Describe pull-request**  
This pull request updates our GitHub Actions workflow to address the recurring merge conflicts between the develop and main branches. The conflicts have been causing disruptions in our release process, primarily due to file modifications, deletions, and renames that cannot be automatically resolved.

#### Why This Change is Needed:
Consistency: By resetting main to match develop, we ensure that the main branch always reflects the latest and most accurate state of our codebase.

#### Efficiency: 
This approach eliminates the need for manual conflict resolution, streamlining our release process and reducing potential errors.

#### Simplicity:
It simplifies our workflow by ensuring that main is always an exact copy of develop, reducing the complexity of managing two diverging branches.

#### Implementation Details:
The workflow now includes a step to git reset --hard develop on the main branch, followed by a force push.
This ensures that all changes from develop are applied to main, resolving any conflicts in favor of develop.

## **Issue Linking:**  
- **No issue:** Caught again on release today.

## **How to test**  
1. To be confirmed in the next release.


