### PR TITLE
fix(slider): native style form reset handling

### DIFF
--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -398,6 +398,11 @@ export class TdsSlider {
     this.controlsStep(parseInt(this.step), event);
   }
 
+  private resetToInitialValue = () => {
+    this.forceValueUpdate(this.initialValue);
+    this.reset();
+  };
+
   componentWillLoad() {
     const numTicks = parseInt(this.ticks);
 
@@ -461,13 +466,16 @@ export class TdsSlider {
     // Only add the event listener once:
     if (!this.resetEventListenerAdded) {
       const form = this.host.closest('form');
-
-      form.addEventListener('reset', () => {
-        this.forceValueUpdate(this.initialValue);
-        this.reset();
-      });
-
+      form.addEventListener('reset', this.resetToInitialValue);
       this.resetEventListenerAdded = true;
+    }
+  }
+
+  disconnectedCallback() {
+    if (this.resetEventListenerAdded) {
+      const form = this.host.closest('form');
+      form.removeEventListener('reset', this.resetToInitialValue);
+      this.resetEventListenerAdded = false;
     }
   }
 

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -99,6 +99,8 @@ export class TdsSlider {
 
   private resetEventListenerAdded: boolean = false;
 
+  private formElement: HTMLFormElement;
+
   /** Sends the value of the slider when changed. Fires after mouse up and touch end events. */
   @Event({
     eventName: 'tdsChange',
@@ -465,16 +467,18 @@ export class TdsSlider {
   componentDidRender() {
     // Only add the event listener once:
     if (!this.resetEventListenerAdded) {
-      const form = this.host.closest('form');
-      form.addEventListener('reset', this.resetToInitialValue);
-      this.resetEventListenerAdded = true;
+      this.formElement = this.host.closest('form');
+
+      if (this.formElement) {
+        this.formElement.addEventListener('reset', this.resetToInitialValue);
+        this.resetEventListenerAdded = true;
+      }
     }
   }
 
   disconnectedCallback() {
-    if (this.resetEventListenerAdded) {
-      const form = this.host.closest('form');
-      form.removeEventListener('reset', this.resetToInitialValue);
+    if (this.resetEventListenerAdded && this.formElement) {
+      this.formElement.removeEventListener('reset', this.resetToInitialValue);
       this.resetEventListenerAdded = false;
     }
   }

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -1,4 +1,14 @@
-import { Component, h, Prop, Listen, EventEmitter, Event, Method, Watch } from '@stencil/core';
+import {
+  Component,
+  h,
+  Prop,
+  Listen,
+  EventEmitter,
+  Event,
+  Method,
+  Watch,
+  Element,
+} from '@stencil/core';
 import generateUniqueId from '../../utils/generateUniqueId';
 
 @Component({
@@ -7,6 +17,8 @@ import generateUniqueId from '../../utils/generateUniqueId';
   shadow: false,
 })
 export class TdsSlider {
+  @Element() host: HTMLElement;
+
   /** Text for label */
   @Prop() label: string = '';
 
@@ -82,6 +94,10 @@ export class TdsSlider {
   private supposedValueSlot: number = -1;
 
   private resizeObserverAdded: boolean = false;
+
+  private initialValue: string;
+
+  private resetEventListenerAdded: boolean = false;
 
   /** Sends the value of the slider when changed. Fires after mouse up and touch end events. */
   @Event({
@@ -434,6 +450,25 @@ export class TdsSlider {
 
     this.calculateThumbLeftFromValue(this.value);
     this.updateTrack();
+
+    // Only set the initial value once:
+    if (!this.initialValue) {
+      this.initialValue = this.value;
+    }
+  }
+
+  componentDidRender() {
+    // Only add the event listener once:
+    if (!this.resetEventListenerAdded) {
+      const form = this.host.closest('form');
+
+      form.addEventListener('reset', () => {
+        this.forceValueUpdate(this.initialValue);
+        this.reset();
+      });
+
+      this.resetEventListenerAdded = true;
+    }
   }
 
   render() {


### PR DESCRIPTION
## **Describe pull-request**  
Fixes native form reset handling of the slider component.

## **Issue Linking:**  
- **Jira:** [CDEP-3820](https://tegel.atlassian.net/browse/CDEP-3820)

## **How to test**
Unfortunately the form-test repo doesn't create amplify links for PRs, so this has to be done manually to test:
1. Clone this repo: https://github.com/scania-digital-design-system/form-test
2. Check out to branch slider-demo
3. Remove node_modules
4. Run `npm install`
5. Run `npm run start`
6. Open http://localhost:3000/
7. Open browser console and consider only the right panel
8. Click anywhere on the tds-slider component to set it to a new value
9. Click the submit button, see the console
10. Click the reset button
11. Click the submit button, see the console and note that the reset value is logged

## **Checklist before submission**
- [ ] No accessibility violations in storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [x] `npm run build-all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
Thanks to @mistermalm for inspiration with event listener :)


[CDEP-3820]: https://tegel.atlassian.net/browse/CDEP-3820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ