### PR TITLE
fix(popover-menu): disabled option cursor

### DIFF
--- a/packages/core/src/components/popover-menu/popover-menu-item/popover-menu-item.scss
+++ b/packages/core/src/components/popover-menu/popover-menu-item/popover-menu-item.scss
@@ -21,11 +21,19 @@
     }
 
     &.disabled {
-      pointer-events: none;
+      cursor: not-allowed;
       color: var(--tds-popover-menu-divider-disabled-color);
+
+      &:hover {
+        background-color: inherit;
+      }
 
       ::slotted(tds-icon) {
         color: var(--tds-popover-menu-divider-disabled-icon-color);
+      }
+
+      ::slotted(*) {
+        pointer-events: none;
       }
     }
   }


### PR DESCRIPTION
## **Describe pull-request**  
Sets the cursor to not-allowed when hovering on a disabled menu item.

## **Issue Linking:**  
- **Jira:** [CDEP-165](https://jira.scania.com/browse/CDEP-165)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to https://pr-1017.d3fazya28914g3.amplifyapp.com/?path=/story/components-popover-menu--default
2. Click the blue popover-menu button
3. Hover over the disabled menu item and see that the cursor becomes not-allowed

## **Checklist before submission**
- [ ] No accessibility violations in storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [x] `npm run build-all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
None