### PR TITLE
fix(slider): increase clickable area of slider

### DIFF
--- a/packages/core/src/components/slider/slider.scss
+++ b/packages/core/src/components/slider/slider.scss
@@ -228,6 +228,17 @@ tds-slider {
     position: relative;
     cursor: pointer;
 
+    // Add invisible clickable area
+    &::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: -10px;
+      bottom: -10px;
+      cursor: pointer;
+    }
+
     &:focus {
       outline: 0;
 

--- a/packages/core/src/components/slider/slider.scss
+++ b/packages/core/src/components/slider/slider.scss
@@ -228,7 +228,7 @@ tds-slider {
     position: relative;
     cursor: pointer;
 
-    // Add invisible clickable area
+    // invisible clickable area
     &::after {
       content: '';
       position: absolute;
@@ -237,6 +237,7 @@ tds-slider {
       top: -10px;
       bottom: -10px;
       cursor: pointer;
+      z-index: 0;
     }
 
     &:focus {
@@ -262,6 +263,10 @@ tds-slider {
       position: absolute;
       left: 0;
       top: -1px;
+    }
+
+    .tds-slider__thumb {
+      z-index: 1; // Ensure thumb stays above the clickable area
     }
   }
 


### PR DESCRIPTION
## **Describe pull-request**  
The clickable area of the Slider is too narrow in current solution. This PR adds an invisible clickable area that does not affect visual appearance. 

## **Issue Linking:**  
- **Jira:** [CDEP-147](https://jira.scania.com/browse/CDEP-147)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to Storybook
2. Check in Slider component
3. Compare to the one in production and verify clickable area is bigger.

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors
- [x] Needs visual approval from design/UX
