### PR TITLE
fix(accordion): rename ariaLevel prop to ariaLevelValue

### DIFF
--- a/packages/core/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/packages/core/src/components/accordion/accordion-item/accordion-item.tsx
@@ -28,7 +28,7 @@ export class TdsAccordionItem {
   @Prop() paddingReset: boolean = false;
 
   /** Specifies the heading level (aria-level) for accessibility. Only accepts values between 1 and 6. */
-  @Prop() ariaLevel: '1' | '2' | '3' | '4' | '5' | '6' = '6';
+  @Prop() ariaLevelValue: '1' | '2' | '3' | '4' | '5' | '6' = '6';
 
   /** Method for toggling the expanded state of the Accordion Item. */
   @Method()
@@ -64,7 +64,7 @@ export class TdsAccordionItem {
         ${this.expanded ? 'expanded' : ''}
         `}
         >
-          <div role="heading" aria-level={this.ariaLevel}>
+          <div role="heading" aria-level={this.ariaLevelValue}>
             <button
               id={secondaryElementId}
               aria-controls={primaryElementId}

--- a/packages/core/src/components/accordion/accordion-item/readme.md
+++ b/packages/core/src/components/accordion/accordion-item/readme.md
@@ -9,7 +9,7 @@
 
 | Property             | Attribute              | Description                                                                                      | Type                                     | Default |
 | -------------------- | ---------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------- | ------- |
-| `ariaLevel`          | `aria-level`           | Specifies the heading level (aria-level) for accessibility. Only accepts values between 1 and 6. | `"1" \| "2" \| "3" \| "4" \| "5" \| "6"` | `'6'`   |
+| `ariaLevelValue`     | `aria-level-value`     | Specifies the heading level (aria-level) for accessibility. Only accepts values between 1 and 6. | `"1" \| "2" \| "3" \| "4" \| "5" \| "6"` | `'6'`   |
 | `disabled`           | `disabled`             | Disabled option in `boolean`.                                                                    | `boolean`                                | `false` |
 | `expandIconPosition` | `expand-icon-position` | Changes position of the expand icon.                                                             | `"end" \| "start"`                       | `'end'` |
 | `expanded`           | `expanded`             | Set to true to expand panel open                                                                 | `boolean`                                | `false` |

--- a/packages/core/src/components/accordion/accordion.stories.tsx
+++ b/packages/core/src/components/accordion/accordion.stories.tsx
@@ -59,7 +59,7 @@ export default {
         defaultValue: { summary: false },
       },
     },
-    ariaLevel: {
+    ariaLevelValue: {
       name: 'ARIA heading level',
       description: 'Specifies the heading level for accessibility (1-6).',
       control: {
@@ -92,7 +92,7 @@ export default {
     paddingReset: false,
     disabled: false,
     hideLastBorder: false,
-    ariaLevel: '6',
+    ariaLevelValue: '6',
   },
 };
 
@@ -102,23 +102,23 @@ const Template = ({
   paddingReset,
   modeVariant,
   hideLastBorder,
-  ariaLevel,
+  ariaLevelValue,
 }) => {
   const affixAttr = iconPosition === 'start' ? 'expand-icon-position="start"' : '';
   const disabledAttr = disabled ? 'disabled' : '';
   const paddingResetAttr = paddingReset ? 'padding-reset' : '';
   const hideLastBorderAttr = hideLastBorder ? 'hide-last-border' : '';
-  const ariaLevelAttr = `aria-level="${ariaLevel}"`;
+  const ariaLevelValueAttr = `aria-level="${ariaLevelValue}"`;
 
   return formatHtmlPreview(`
     <tds-accordion ${
       modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''
     } ${hideLastBorderAttr}>
-      <tds-accordion-item header="First item" ${ariaLevelAttr} ${affixAttr} ${disabledAttr} ${paddingResetAttr}>
+      <tds-accordion-item header="First item" ${ariaLevelValueAttr} ${affixAttr} ${disabledAttr} ${paddingResetAttr}>
         This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header.
         Lorem ipsum doler sit amet.
       </tds-accordion-item>
-      <tds-accordion-item ${ariaLevelAttr} ${affixAttr} ${disabledAttr} ${paddingResetAttr} expanded>
+      <tds-accordion-item ${ariaLevelValueAttr} ${affixAttr} ${disabledAttr} ${paddingResetAttr} expanded>
         <div slot="header">Second item</div>
         This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header.
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis laoreet vestibulum fermentum.


### PR DESCRIPTION
## **Describe pull-request**  
This PR adress the typescript error we got after merge PR (feat(accordion): accessibility improvement  (https://github.com/scania-digital-design-system/tegel/pull/1018))

Instead of naming the aria-level Prop ariaLevel, we rename it to ariaLevelValue to avoid any conflicts with existing naming.

## **How to test:**
1. Checkout to the branch
2. run npm run build:all and make sure it runs with no issue.


![1](https://github.com/user-attachments/assets/9d3e831d-6c24-4432-9a9e-38bfb3e02fc6)
![2](https://github.com/user-attachments/assets/f95542c3-1e5d-4d45-892d-d527ced58187)
