### PR TITLE
feat(block): accessibility improvements

### DIFF
--- a/packages/core/src/components/block/block.stories.tsx
+++ b/packages/core/src/components/block/block.stories.tsx
@@ -57,8 +57,9 @@ Default.argTypes = {
     name: 'Component Tag',
     description: 'Specifies the HTML tag used for the component wrapper.',
     control: {
-      type: 'text',
+      type: 'radio',
     },
+    options: ['section', 'div', 'article', 'aside', 'header', 'footer', 'nav', 'main'],
     table: {
       defaultValue: { summary: 'section' },
     },
@@ -117,8 +118,9 @@ Nested.argTypes = {
     name: 'Component Tag',
     description: 'Specifies the HTML tag used for the component wrapper.',
     control: {
-      type: 'text',
+      type: 'radio',
     },
+    options: ['section', 'div', 'article', 'aside', 'header', 'footer', 'nav', 'main'],
     table: {
       defaultValue: { summary: 'article' },
     },

--- a/packages/core/src/components/block/block.stories.tsx
+++ b/packages/core/src/components/block/block.stories.tsx
@@ -33,7 +33,6 @@ const SingleTemplate = ({ modeVariant, componentTag }) =>
         <section>
           <h2 class="tds-headline-02">Semantic Block</h2>
           <p class="tds-body-01">This block is now structured using a <code>&lt;section&gt;</code> element for better accessibility.</p>
-          <button class="tds-button">Click me</button>
         </section>
       </tds-block>
     `,

--- a/packages/core/src/components/block/block.stories.tsx
+++ b/packages/core/src/components/block/block.stories.tsx
@@ -28,9 +28,11 @@ const SingleTemplate = ({ modeVariant }) =>
       <tds-block ${
         modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''
       }>
-        <h2 class="tds-headline-02">Block</h2>
-        <p class="tds-body-01">Lorem ipsum dolor sit amet, consectetur adipiscing elit. In condimentum nisi ut eleifend ultrices. Nunc venenatis maximus sapien, ac bibendum nisl aliquam in. Morbi ac velit et ligula consectetur interdum. Vestibulum condimentum, augue vitae lobortis rhoncus, mi est ultricies mi, sed tincidunt magna nibh in lectus. Pellentesque vel vulputate orci, vel lacinia orci. Sed suscipit leo at diam ullamcorper, vitae volutpat neque dapibus. Maecenas sit amet rhoncus arcu. Sed sed molestie elit. Nullam in interdum est, vitae aliquam ipsum. Nunc rutrum nibh ut arcu egestas egestas.</p>
-       
+        <section>
+          <h2 class="tds-headline-02">Semantic Block</h2>
+          <p class="tds-body-01">This block is now structured using a <code>&lt;section&gt;</code> element for better accessibility.</p>
+          <button class="tds-button">Click me</button>
+        </section>
       </tds-block>
     `,
   );
@@ -64,16 +66,22 @@ const NestedTemplate = ({ outerModeVariant }) =>
           : ''
       }>
         <tds-block>
-          <h2 class="tds-headline-02">Outer Block</h2>
-          <p class="tds-body-01">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-          <tds-block>
-            <h3 class="tds-headline-04">Middle Block</h3>
-            <p class="tds-detail-03">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+          <article>
+            <h2 class="tds-headline-02">Outer Block (Article)</h2>
+            <p class="tds-body-01">This block is now structured using an <code>&lt;article&gt;</code>.</p>
             <tds-block>
-              <h4 class="tds-headline-06">Inner Block</h4>
-              <p class="tds-detail-03">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+              <aside>
+                <h3 class="tds-headline-04">Middle Block (Aside)</h3>
+                <p class="tds-detail-03">Nested content inside an <code>&lt;aside&gt;</code> element.</p>
+                <tds-block>
+                  <section>
+                    <h4 class="tds-headline-06">Inner Block (Section)</h4>
+                    <p class="tds-detail-03">Ensuring meaningful content structure with semantic HTML.</p>
+                  </section>
+                </tds-block>
+              </aside>
             </tds-block>
-          </tds-block>
+          </article>
         </tds-block>
       </div>
     `,

--- a/packages/core/src/components/block/block.stories.tsx
+++ b/packages/core/src/components/block/block.stories.tsx
@@ -119,12 +119,12 @@ Nested.argTypes = {
     },
     options: ['section', 'div', 'article', 'aside', 'header', 'footer', 'nav', 'main'],
     table: {
-      defaultValue: { summary: 'article' },
+      defaultValue: { summary: 'div' },
     },
   },
 };
 
 Nested.args = {
   outerModeVariant: 'Primary',
-  componentTag: 'article',
+  componentTag: 'div',
 };

--- a/packages/core/src/components/block/block.stories.tsx
+++ b/packages/core/src/components/block/block.stories.tsx
@@ -85,12 +85,10 @@ const NestedTemplate = ({ outerModeVariant, componentTag }) =>
             <aside>
               <h3 class="tds-headline-04">Middle Block (Aside)</h3>
               <p class="tds-detail-03">Nested content inside an <code>&lt;aside&gt;</code> element.</p>
-              <button>Test</button>
-              <tds-block component-tag="section">
+              <tds-block component-tag="${componentTag}">
                 <section>
                   <h4 class="tds-headline-06">Inner Block (Section)</h4>
                   <p class="tds-detail-03">Ensuring meaningful content structure with semantic HTML.</p>
-                  <button>Test</button>
                 </section>
               </tds-block>
             </aside>

--- a/packages/core/src/components/block/block.stories.tsx
+++ b/packages/core/src/components/block/block.stories.tsx
@@ -22,17 +22,19 @@ export default {
   },
 };
 
-const SingleTemplate = ({ modeVariant }) =>
+const SingleTemplate = ({ modeVariant, componentTag }) =>
   formatHtmlPreview(
     `
-      <tds-block ${
-        modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''
-      }>
-        <section>
+      <tds-block 
+        ${
+          modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''
+        } 
+        component-tag="${componentTag}">
+        <${componentTag}>
           <h2 class="tds-headline-02">Semantic Block</h2>
-          <p class="tds-body-01">This block is now structured using a <code>&lt;section&gt;</code> element for better accessibility.</p>
+          <p class="tds-body-01">This block is now structured using a <code>&lt;${componentTag}&gt;</code> element for better accessibility.</p>
           <button class="tds-button">Click me</button>
-        </section>
+        </${componentTag}>
       </tds-block>
     `,
   );
@@ -42,7 +44,7 @@ Default.argTypes = {
   modeVariant: {
     name: 'Mode variant',
     description:
-      'Mode variant adjusts component colors to have better visibility depending on global mode and background. ',
+      'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
     control: {
       type: 'radio',
     },
@@ -51,13 +53,24 @@ Default.argTypes = {
       defaultValue: { summary: 'Inherit from parent' },
     },
   },
+  componentTag: {
+    name: 'Component Tag',
+    description: 'Specifies the HTML tag used for the component wrapper.',
+    control: {
+      type: 'text',
+    },
+    table: {
+      defaultValue: { summary: 'section' },
+    },
+  },
 };
 
 Default.args = {
   modeVariant: 'Inherit from parent',
+  componentTag: 'section',
 };
 
-const NestedTemplate = ({ outerModeVariant }) =>
+const NestedTemplate = ({ outerModeVariant, componentTag }) =>
   formatHtmlPreview(
     `
       <div ${
@@ -65,15 +78,15 @@ const NestedTemplate = ({ outerModeVariant }) =>
           ? `class="tds-mode-variant-${outerModeVariant.toLowerCase()}"`
           : ''
       }>
-        <tds-block>
-          <article>
-            <h2 class="tds-headline-02">Outer Block (Article)</h2>
-            <p class="tds-body-01">This block is now structured using an <code>&lt;article&gt;</code>.</p>
-            <tds-block>
+        <tds-block component-tag="${componentTag}">
+          <${componentTag}>
+            <h2 class="tds-headline-02">Outer Block (${componentTag})</h2>
+            <p class="tds-body-01">This block is now structured using a <code>&lt;${componentTag}&gt;</code>.</p>
+            <tds-block component-tag="aside">
               <aside>
                 <h3 class="tds-headline-04">Middle Block (Aside)</h3>
                 <p class="tds-detail-03">Nested content inside an <code>&lt;aside&gt;</code> element.</p>
-                <tds-block>
+                <tds-block component-tag="section">
                   <section>
                     <h4 class="tds-headline-06">Inner Block (Section)</h4>
                     <p class="tds-detail-03">Ensuring meaningful content structure with semantic HTML.</p>
@@ -81,7 +94,7 @@ const NestedTemplate = ({ outerModeVariant }) =>
                 </tds-block>
               </aside>
             </tds-block>
-          </article>
+          </${componentTag}>
         </tds-block>
       </div>
     `,
@@ -100,8 +113,19 @@ Nested.argTypes = {
       defaultValue: { summary: 'Primary' },
     },
   },
+  componentTag: {
+    name: 'Component Tag',
+    description: 'Specifies the HTML tag used for the component wrapper.',
+    control: {
+      type: 'text',
+    },
+    table: {
+      defaultValue: { summary: 'article' },
+    },
+  },
 };
 
 Nested.args = {
   outerModeVariant: 'Primary',
+  componentTag: 'article',
 };

--- a/packages/core/src/components/block/block.stories.tsx
+++ b/packages/core/src/components/block/block.stories.tsx
@@ -80,7 +80,7 @@ const NestedTemplate = ({ outerModeVariant, componentTag }) =>
           : ''
       }>
         <tds-block component-tag="${componentTag}">
-          <${componentTag}>
+          <tds-block component-tag="${componentTag}">
             <h2 class="tds-headline-02">Outer Block (${componentTag})</h2>
             <p class="tds-body-01">This block is now structured using a <code>&lt;${componentTag}&gt;</code>.</p>
             <tds-block component-tag="aside">
@@ -95,7 +95,7 @@ const NestedTemplate = ({ outerModeVariant, componentTag }) =>
                 </tds-block>
               </aside>
             </tds-block>
-          </${componentTag}>
+          </tds-block> 
         </tds-block>
       </div>
     `,

--- a/packages/core/src/components/block/block.stories.tsx
+++ b/packages/core/src/components/block/block.stories.tsx
@@ -79,22 +79,22 @@ const NestedTemplate = ({ outerModeVariant, componentTag }) =>
           : ''
       }>
         <tds-block component-tag="${componentTag}">
-          <tds-block component-tag="${componentTag}">
-            <h2 class="tds-headline-02">Outer Block (${componentTag})</h2>
-            <p class="tds-body-01">This block is now structured using a <code>&lt;${componentTag}&gt;</code>.</p>
-            <tds-block component-tag="aside">
-              <aside>
-                <h3 class="tds-headline-04">Middle Block (Aside)</h3>
-                <p class="tds-detail-03">Nested content inside an <code>&lt;aside&gt;</code> element.</p>
-                <tds-block component-tag="section">
-                  <section>
-                    <h4 class="tds-headline-06">Inner Block (Section)</h4>
-                    <p class="tds-detail-03">Ensuring meaningful content structure with semantic HTML.</p>
-                  </section>
-                </tds-block>
-              </aside>
-            </tds-block>
-          </tds-block> 
+          <h2 class="tds-headline-02">Outer Block (${componentTag})</h2>
+          <p class="tds-body-01">This block is now structured using a <code>&lt;${componentTag}&gt;</code>.</p>
+          <tds-block component-tag="aside">
+            <aside>
+              <h3 class="tds-headline-04">Middle Block (Aside)</h3>
+              <p class="tds-detail-03">Nested content inside an <code>&lt;aside&gt;</code> element.</p>
+              <button>Test</button>
+              <tds-block component-tag="section">
+                <section>
+                  <h4 class="tds-headline-06">Inner Block (Section)</h4>
+                  <p class="tds-detail-03">Ensuring meaningful content structure with semantic HTML.</p>
+                  <button>Test</button>
+                </section>
+              </tds-block>
+            </aside>
+          </tds-block>
         </tds-block>
       </div>
     `,

--- a/packages/core/src/components/block/block.stories.tsx
+++ b/packages/core/src/components/block/block.stories.tsx
@@ -30,11 +30,11 @@ const SingleTemplate = ({ modeVariant, componentTag }) =>
           modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''
         } 
         component-tag="${componentTag}">
-        <${componentTag}>
+        <section>
           <h2 class="tds-headline-02">Semantic Block</h2>
-          <p class="tds-body-01">This block is now structured using a <code>&lt;${componentTag}&gt;</code> element for better accessibility.</p>
+          <p class="tds-body-01">This block is now structured using a <code>&lt;section&gt;</code> element for better accessibility.</p>
           <button class="tds-button">Click me</button>
-        </${componentTag}>
+        <section>
       </tds-block>
     `,
   );

--- a/packages/core/src/components/block/block.stories.tsx
+++ b/packages/core/src/components/block/block.stories.tsx
@@ -34,7 +34,7 @@ const SingleTemplate = ({ modeVariant, componentTag }) =>
           <h2 class="tds-headline-02">Semantic Block</h2>
           <p class="tds-body-01">This block is now structured using a <code>&lt;section&gt;</code> element for better accessibility.</p>
           <button class="tds-button">Click me</button>
-        <section>
+        </section>
       </tds-block>
     `,
   );

--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -19,9 +19,7 @@ export class TdsBlock {
   /** Mode variant of the component, based on current mode. */
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
-  /** Specifies the HTML tag to be used for the component wrapper.
-   *
-   *  @default 'div'. */
+  /** Specifies the HTML tag to be used for the component wrapper. */
   @Prop() componentTag:
     | 'section'
     | 'div'

--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -19,6 +19,9 @@ export class TdsBlock {
   /** Mode variant of the component, based on current mode. */
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
+  /** Specifies the HTML tag to be used for the component wrapper. Default is 'section'. */
+  @Prop() componentTag: string = 'section';
+
   private getNestingLevel(): number {
     let level = 0;
     let parent = this.host.parentElement;
@@ -53,6 +56,7 @@ export class TdsBlock {
   }
 
   render() {
+    const TagType = this.componentTag as keyof HTMLElementTagNameMap;
     const nestingLevel = this.getNestingLevel();
 
     let evenOddClass = '';
@@ -65,13 +69,13 @@ export class TdsBlock {
     }
 
     return (
-      <section
+      <TagType
         class={`tds-block ${evenOddClass} ${
           this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''
         }`}
       >
         <slot></slot>
-      </section>
+      </TagType>
     );
   }
 }

--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -44,30 +44,6 @@ export class TdsBlock {
     return level;
   }
 
-  private ensureKeyboardAccessibility() {
-    const childElements = Array.from(this.host.children);
-
-    childElements.forEach((child) => {
-      const isInteractive =
-        child instanceof HTMLButtonElement ||
-        child instanceof HTMLAnchorElement ||
-        child instanceof HTMLInputElement ||
-        child instanceof HTMLSelectElement ||
-        child instanceof HTMLTextAreaElement ||
-        child.getAttribute('tabindex') !== null ||
-        child.getAttribute('role') === 'button' ||
-        child.getAttribute('role') === 'link';
-
-      if (!isInteractive) {
-        child.setAttribute('tabindex', '-1');
-      }
-    });
-  }
-
-  componentDidLoad() {
-    this.ensureKeyboardAccessibility();
-  }
-
   render() {
     const TagType = this.componentTag as keyof HTMLElementTagNameMap;
     const nestingLevel = this.getNestingLevel();

--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -46,6 +46,7 @@ export class TdsBlock {
 
   private ensureKeyboardAccessibility() {
     const childElements = Array.from(this.host.children);
+
     childElements.forEach((child) => {
       const isInteractive =
         child instanceof HTMLButtonElement ||
@@ -53,14 +54,11 @@ export class TdsBlock {
         child instanceof HTMLInputElement ||
         child instanceof HTMLSelectElement ||
         child instanceof HTMLTextAreaElement ||
-        child.getAttribute('tabindex') !== null;
-
-      if (!isInteractive) {
         child.getAttribute('tabindex') !== null ||
         child.getAttribute('role') === 'button' ||
         child.getAttribute('role') === 'link';
 
-      if (!isInteractive && child.getAttribute('role') === null) {
+      if (!isInteractive) {
         child.setAttribute('tabindex', '-1');
       }
     });

--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -1,7 +1,12 @@
 import { Component, h, Prop, Element } from '@stencil/core';
 
 /**
- * @slot <default> - <b>Unnamed slot.</b> For the content.
+ * @slot - Default slot for content inside the block.
+ *
+ * @example
+ * <tds-block>
+ *   <section>Semantic section content</section>
+ * </tds-block>
  */
 @Component({
   tag: 'tds-block',
@@ -26,6 +31,27 @@ export class TdsBlock {
     return level;
   }
 
+  private ensureKeyboardAccessibility() {
+    const childElements = Array.from(this.host.children);
+    childElements.forEach((child) => {
+      const isInteractive =
+        child instanceof HTMLButtonElement ||
+        child instanceof HTMLAnchorElement ||
+        child instanceof HTMLInputElement ||
+        child instanceof HTMLSelectElement ||
+        child instanceof HTMLTextAreaElement ||
+        child.getAttribute('tabindex') !== null;
+
+      if (!isInteractive) {
+        child.setAttribute('tabindex', '0');
+      }
+    });
+  }
+
+  componentDidLoad() {
+    this.ensureKeyboardAccessibility();
+  }
+
   render() {
     const nestingLevel = this.getNestingLevel();
 
@@ -39,13 +65,13 @@ export class TdsBlock {
     }
 
     return (
-      <div
+      <section
         class={`tds-block ${evenOddClass} ${
           this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''
         }`}
       >
         <slot></slot>
-      </div>
+      </section>
     );
   }
 }

--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Prop, Element } from '@stencil/core';
 
 /**
- * @slot - Default slot for content inside the block.
+ * @slot - <default> - <b>Default</b> slot for content inside the block.
  *
  * @example
  * <tds-block>

--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -19,8 +19,8 @@ export class TdsBlock {
   /** Mode variant of the component, based on current mode. */
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
-  /** Specifies the HTML tag to be used for the component wrapper.  
-   * 
+  /** Specifies the HTML tag to be used for the component wrapper.
+   *
    *  @default 'section'. */
   @Prop() componentTag:
     | 'section'

--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -19,7 +19,9 @@ export class TdsBlock {
   /** Mode variant of the component, based on current mode. */
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
-  /** Specifies the HTML tag to be used for the component wrapper. Default is 'section'. */
+  /** Specifies the HTML tag to be used for the component wrapper.  
+   * 
+   *  @default 'section'. */
   @Prop() componentTag:
     | 'section'
     | 'div'

--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -56,7 +56,12 @@ export class TdsBlock {
         child.getAttribute('tabindex') !== null;
 
       if (!isInteractive) {
-        child.setAttribute('tabindex', '0');
+        child.getAttribute('tabindex') !== null ||
+        child.getAttribute('role') === 'button' ||
+        child.getAttribute('role') === 'link';
+
+      if (!isInteractive && child.getAttribute('role') === null) {
+        child.setAttribute('tabindex', '-1');
       }
     });
   }

--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -20,7 +20,15 @@ export class TdsBlock {
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
   /** Specifies the HTML tag to be used for the component wrapper. Default is 'section'. */
-  @Prop() componentTag: string = 'section';
+  @Prop() componentTag:
+    | 'section'
+    | 'div'
+    | 'article'
+    | 'aside'
+    | 'header'
+    | 'footer'
+    | 'nav'
+    | 'main' = 'div';
 
   private getNestingLevel(): number {
     let level = 0;

--- a/packages/core/src/components/block/block.tsx
+++ b/packages/core/src/components/block/block.tsx
@@ -21,7 +21,7 @@ export class TdsBlock {
 
   /** Specifies the HTML tag to be used for the component wrapper.
    *
-   *  @default 'section'. */
+   *  @default 'div'. */
   @Prop() componentTag:
     | 'section'
     | 'div'

--- a/packages/core/src/components/block/readme.md
+++ b/packages/core/src/components/block/readme.md
@@ -13,17 +13,17 @@ The `tds-block` component can be nested to create more complex layouts. When nes
 
 ## Properties
 
-| Property       | Attribute       | Description                                                                        | Type                                                                                    | Default |
-| -------------- | --------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------- |
-| `componentTag` | `component-tag` | Specifies the HTML tag to be used for the component wrapper. Default is 'section'. | `"article" \| "aside" \| "div" \| "footer" \| "header" \| "main" \| "nav" \| "section"` | `'div'` |
-| `modeVariant`  | `mode-variant`  | Mode variant of the component, based on current mode.                              | `"primary" \| "secondary"`                                                              | `null`  |
+| Property       | Attribute       | Description                                                  | Type                                                                                    | Default |
+| -------------- | --------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------- | ------- |
+| `componentTag` | `component-tag` | Specifies the HTML tag to be used for the component wrapper. | `"article" \| "aside" \| "div" \| "footer" \| "header" \| "main" \| "nav" \| "section"` | `'div'` |
+| `modeVariant`  | `mode-variant`  | Mode variant of the component, based on current mode.        | `"primary" \| "secondary"`                                                              | `null`  |
 
 
 ## Slots
 
-| Slot | Description                                |
-| ---- | ------------------------------------------ |
-|      | Default slot for content inside the block. |
+| Slot | Description                                                   |
+| ---- | ------------------------------------------------------------- |
+|      | <default> - <b>Default</b> slot for content inside the block. |
 
 
 ----------------------------------------------

--- a/packages/core/src/components/block/readme.md
+++ b/packages/core/src/components/block/readme.md
@@ -13,9 +13,10 @@ The `tds-block` component can be nested to create more complex layouts. When nes
 
 ## Properties
 
-| Property      | Attribute      | Description                                           | Type                       | Default |
-| ------------- | -------------- | ----------------------------------------------------- | -------------------------- | ------- |
-| `modeVariant` | `mode-variant` | Mode variant of the component, based on current mode. | `"primary" \| "secondary"` | `null`  |
+| Property       | Attribute       | Description                                                                        | Type                       | Default     |
+| -------------- | --------------- | ---------------------------------------------------------------------------------- | -------------------------- | ----------- |
+| `componentTag` | `component-tag` | Specifies the HTML tag to be used for the component wrapper. Default is 'section'. | `string`                   | `'section'` |
+| `modeVariant`  | `mode-variant`  | Mode variant of the component, based on current mode.                              | `"primary" \| "secondary"` | `null`      |
 
 
 ## Slots

--- a/packages/core/src/components/block/readme.md
+++ b/packages/core/src/components/block/readme.md
@@ -13,10 +13,10 @@ The `tds-block` component can be nested to create more complex layouts. When nes
 
 ## Properties
 
-| Property       | Attribute       | Description                                                                        | Type                       | Default     |
-| -------------- | --------------- | ---------------------------------------------------------------------------------- | -------------------------- | ----------- |
-| `componentTag` | `component-tag` | Specifies the HTML tag to be used for the component wrapper. Default is 'section'. | `string`                   | `'section'` |
-| `modeVariant`  | `mode-variant`  | Mode variant of the component, based on current mode.                              | `"primary" \| "secondary"` | `null`      |
+| Property       | Attribute       | Description                                                                        | Type                                                                                    | Default |
+| -------------- | --------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------- |
+| `componentTag` | `component-tag` | Specifies the HTML tag to be used for the component wrapper. Default is 'section'. | `"article" \| "aside" \| "div" \| "footer" \| "header" \| "main" \| "nav" \| "section"` | `'div'` |
+| `modeVariant`  | `mode-variant`  | Mode variant of the component, based on current mode.                              | `"primary" \| "secondary"`                                                              | `null`  |
 
 
 ## Slots

--- a/packages/core/src/components/block/readme.md
+++ b/packages/core/src/components/block/readme.md
@@ -20,9 +20,9 @@ The `tds-block` component can be nested to create more complex layouts. When nes
 
 ## Slots
 
-| Slot          | Description                           |
-| ------------- | ------------------------------------- |
-| `"<default>"` | <b>Unnamed slot.</b> For the content. |
+| Slot | Description                                |
+| ---- | ------------------------------------------ |
+|      | Default slot for content inside the block. |
 
 
 ----------------------------------------------

--- a/packages/core/src/components/block/test/block.axe.ts
+++ b/packages/core/src/components/block/test/block.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/block/test/2-level-light-mode/index.html';
+
+test.describe.parallel('Block accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/core/src/utils/axeHelpers.ts
+++ b/packages/core/src/utils/axeHelpers.ts
@@ -1,7 +1,7 @@
 import AxeBuilder from '@axe-core/playwright';
 import type { Page } from '@playwright/test';
 
-const disabledRules = ['page-has-heading-one', 'landmark-one-main'];
+const disabledRules = ['page-has-heading-one', 'landmark-one-main', 'region'];
 
 export const tegelAnalyze = async (page: Page) =>
   new AxeBuilder({ page }).disableRules(disabledRules).analyze();


### PR DESCRIPTION
## **Describe pull-request**  
The pull request addresses the issues we have found in the a11y audit related to the block component.

✅ Added analyze test file to component
✅ Make sure its possible to navigate the nested blocks with screen reader.
✅ Added a prop called componentTag so the user can decide which html tag the block should be
✅ Update storybook documentation to use meaningful HTML elements for structure

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:**  [CDEP-301](https://jira.scania.com/browse/CDEP-301)    

## **How to test**  

Verify Keyboard Accessibility for Interactive Child Blocks
1. Go to react demo page /about [[LINK TO REACT DEMO PAGE](https://pr-220.d2vh2lmnzgzrkl.amplifyapp.com/about)]
2. Turn on screen reader
3. Try to navigate through the blocks with a screenreader [control+option + arrow right/left]. 
(I tested this with firefox and it worked well)

Verify Developers Use Meaningful HTML Elements for Structure
1. Go to the AWS preview link
2. Navigate to the block component
3. Make sure the documentation is updated in Storybook so we provide example with meaningful html elements

## **Checklist before submission**
- [x] No accessibility violations in storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in storybook with documented descriptions (if applicable)
- [x] `npm run build-all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [x] Keyboard operability
- [x] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
