### PR TITLE
chore(datetime): refactor ternary operators 

### DIFF
--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -170,7 +170,7 @@ export class TdsDatetime {
 
   /** Method that resets the dateteime without emitting an event. */
   private internalReset() {
-    let value = '';
+    const value = '';
     if (this.defaultValue !== 'none') {
       this.value = this.getDefaultValue();
     }
@@ -187,19 +187,17 @@ export class TdsDatetime {
     }
     return (
       <div
-        class={`
-        ${this.noMinWidth ? 'tds-form-datetime-nomin' : ''}
-        ${this.focusInput ? 'tds-form-datetime tds-datetime-focus' : ' tds-form-datetime'}
-        ${this.value.length > 0 ? 'tds-datetime-data' : ''}
-        ${this.disabled ? 'tds-form-datetime-disabled' : ''}
-        ${this.size === 'md' ? 'tds-form-datetime-md' : ''}
-        ${this.size === 'sm' ? 'tds-form-datetime-sm' : ''}
-        ${
-          this.state === 'error' || this.state === 'success'
-            ? `tds-form-datetime-${this.state}`
-            : ''
-        }
-        ${this.modeVariant !== null ? `tds-mode-variant-${this.modeVariant}` : ''}`}
+        class={{
+          'tds-form-datetime-nomin': this.noMinWidth,
+          'tds-form-datetime tds-datetime-focus': this.focusInput,
+          'tds-form-datetime': !this.focusInput,
+          'tds-datetime-data': this.value.length > 0,
+          'tds-form-datetime-disabled': this.disabled,
+          'tds-form-datetime-md': this.size === 'md',
+          'tds-form-datetime-sm': this.size === 'sm',
+          [`tds-form-datetime-${this.state}`]: this.state === 'error' || this.state === 'success',
+          [`tds-mode-variant-${this.modeVariant}`]: this.modeVariant !== null,
+        }}
       >
         {this.label && (
           <label htmlFor={this.name} class="tds-datetime-label">
@@ -209,7 +207,9 @@ export class TdsDatetime {
         <div onClick={(e) => this.handleFocusClick(e)} class="tds-datetime-container">
           <div class="tds-datetime-input-container">
             <input
-              ref={(inputEl) => (this.textInput = inputEl as HTMLInputElement)}
+              ref={(inputEl) => {
+                this.textInput = inputEl as HTMLInputElement;
+              }}
               class={className}
               type={this.type}
               disabled={this.disabled}
@@ -222,14 +222,6 @@ export class TdsDatetime {
               onBlur={(e) => this.handleBlur(e)}
               onChange={(e) => this.handleChange(e)}
             />
-
-            <div class="datetime-icon icon-datetime-local">
-              <tds-icon size="20px" name="calendar"></tds-icon>
-            </div>
-
-            <div class="datetime-icon icon-time">
-              <tds-icon size="20px" name="clock"></tds-icon>
-            </div>
           </div>
           <div class="tds-datetime-bar"></div>
         </div>

--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -185,20 +185,20 @@ export class TdsDatetime {
     if (this.size === 'sm') {
       className += `${className}-sm`;
     }
+
+    const classNames = {
+      'tds-form-datetime-nomin': this.noMinWidth,
+      'tds-form-datetime': true,
+      'tds-datetime-focus': this.focusInput,
+      'tds-datetime-data': this.value.length > 0,
+      'tds-form-datetime-disabled': this.disabled,
+      [`tds-form-datetime-${this.size}`]: ['md', 'sm'].includes(this.size),
+      [`tds-form-datetime-${this.state}`]: ['error', 'success'].includes(this.state),
+      [`tds-mode-variant-${this.modeVariant}`]: this.modeVariant !== null,
+    };
+
     return (
-      <div
-        class={{
-          'tds-form-datetime-nomin': this.noMinWidth,
-          'tds-form-datetime tds-datetime-focus': this.focusInput,
-          'tds-form-datetime': !this.focusInput,
-          'tds-datetime-data': this.value.length > 0,
-          'tds-form-datetime-disabled': this.disabled,
-          'tds-form-datetime-md': this.size === 'md',
-          'tds-form-datetime-sm': this.size === 'sm',
-          [`tds-form-datetime-${this.state}`]: this.state === 'error' || this.state === 'success',
-          [`tds-mode-variant-${this.modeVariant}`]: this.modeVariant !== null,
-        }}
-      >
+      <div class={classNames}>
         {this.label && (
           <label htmlFor={this.name} class="tds-datetime-label">
             {this.label}

--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -222,6 +222,13 @@ export class TdsDatetime {
               onBlur={(e) => this.handleBlur(e)}
               onChange={(e) => this.handleChange(e)}
             />
+            <div class="datetime-icon icon-datetime-local">
+              <tds-icon size="20px" name="calendar"></tds-icon>
+            </div>
+
+            <div class="datetime-icon icon-time">
+              <tds-icon size="20px" name="clock"></tds-icon>
+            </div>
           </div>
           <div class="tds-datetime-bar"></div>
         </div>


### PR DESCRIPTION
## **Describe pull-request**  
refactor ternary operators + odd looking icon

## **Issue Linking:**  
- **Jira:** `Datetime - ternary operators in class names`: [CDEP-227](https://jira.scania.com/browse/CDEP-227)

## **How to test**  
1. Go to storybook
2. Play around with datetime
3. Check that Icon looks ok

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Storybook controls
- [ ] Dark/light mode and variants 

## **Screenshots**  
Before removing icons:
<img width="325" alt="image" src="https://github.com/user-attachments/assets/dd448535-2d79-43cf-aa5f-c068039bbfe6" />

After:
<img width="325" alt="image" src="https://github.com/user-attachments/assets/0d17f9bb-e3ec-4b63-9306-11075ab5a841" />

## **Additional context**  
There is something odd with the icon in the datetime component, I removed the two icons in the code because they did not seem to make any impact, let's see what happens...
