### PR TITLE
Fix(table): Console log error when drag-drop rows in angular

### DIFF
--- a/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
+++ b/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
@@ -89,13 +89,16 @@ export class TdsTableBodyCell {
 
   connectedCallback() {
     this.tableEl = this.host.closest('tds-table');
-    this.tableId = this.tableEl.tableId;
+    this.tableId = this.tableEl?.tableId;
   }
 
   componentWillLoad() {
-    relevantTableProps.forEach((tablePropName) => {
-      this[tablePropName] = this.tableEl[tablePropName];
-    });
+    if (this.tableEl) {
+      relevantTableProps.forEach((tablePropName) => {
+        this[tablePropName] = this.tableEl[tablePropName];
+      });
+    }
+
     if (this.textAlign) {
       this.textAlignState = this.textAlign;
     }

--- a/packages/core/src/components/table/table-body-row/table-body-row.tsx
+++ b/packages/core/src/components/table/table-body-row/table-body-row.tsx
@@ -120,16 +120,32 @@ export class TdsTableBodyRow {
   }
 
   private updateTableProperties() {
-    this.tableEl = this.host.closest('tds-table');
-    if (!this.tableEl) {
-      console.warn('TdsTableBodyRow: No parent table found');
-      return;
-    }
-    this.tableId = this.tableEl.tableId;
-    // Update all relevant properties from the new parent table
+    // Clear previous state
+    this.tableEl = null;
+    this.tableId = '';
     relevantTableProps.forEach((tablePropName) => {
-      this[tablePropName] = this.tableEl[tablePropName];
+      this[tablePropName] = false;
     });
+
+    // Find new parent table and update properties
+    requestAnimationFrame(() => {
+      this.tableEl = this.host.closest('tds-table');
+      if (!this.tableEl) {
+        console.warn('TdsTableBodyRow: No parent table found');
+        return;
+      }
+      this.tableId = this.tableEl.tableId;
+      relevantTableProps.forEach((tablePropName) => {
+        this[tablePropName] = this.tableEl[tablePropName];
+      });
+    });
+  }
+
+  @Listen('DOMNodeInserted', { target: 'window' })
+  handleDOMChange() {
+    if (this.host.isConnected) {
+      this.updateTableProperties();
+    }
   }
 
   connectedCallback() {
@@ -140,7 +156,6 @@ export class TdsTableBodyRow {
     this.updateTableProperties();
   }
 
-  // Add disconnectedCallback to clean up state when removed
   disconnectedCallback() {
     this.tableEl = null;
     this.tableId = '';

--- a/packages/core/src/components/table/table-body-row/table-body-row.tsx
+++ b/packages/core/src/components/table/table-body-row/table-body-row.tsx
@@ -119,48 +119,14 @@ export class TdsTableBodyRow {
     }
   }
 
-  private updateTableProperties() {
-    // Clear previous state
-    this.tableEl = null;
-    this.tableId = '';
-    relevantTableProps.forEach((tablePropName) => {
-      this[tablePropName] = false;
-    });
-
-    // Find new parent table and update properties
-    requestAnimationFrame(() => {
-      this.tableEl = this.host.closest('tds-table');
-      if (!this.tableEl) {
-        console.warn('TdsTableBodyRow: No parent table found');
-        return;
-      }
-      this.tableId = this.tableEl.tableId;
-      relevantTableProps.forEach((tablePropName) => {
-        this[tablePropName] = this.tableEl[tablePropName];
-      });
-    });
-  }
-
-  @Listen('DOMNodeInserted', { target: 'window' })
-  handleDOMChange() {
-    if (this.host.isConnected) {
-      this.updateTableProperties();
-    }
-  }
-
   connectedCallback() {
-    this.updateTableProperties();
+    this.tableEl = this.host.closest('tds-table');
+    this.tableId = this.tableEl?.tableId;
   }
 
   componentWillLoad() {
-    this.updateTableProperties();
-  }
-
-  disconnectedCallback() {
-    this.tableEl = null;
-    this.tableId = '';
     relevantTableProps.forEach((tablePropName) => {
-      this[tablePropName] = false;
+      this[tablePropName] = this.tableEl[tablePropName];
     });
   }
 

--- a/packages/core/src/components/table/table-body-row/table-body-row.tsx
+++ b/packages/core/src/components/table/table-body-row/table-body-row.tsx
@@ -119,14 +119,33 @@ export class TdsTableBodyRow {
     }
   }
 
-  connectedCallback() {
+  private updateTableProperties() {
     this.tableEl = this.host.closest('tds-table');
+    if (!this.tableEl) {
+      console.warn('TdsTableBodyRow: No parent table found');
+      return;
+    }
     this.tableId = this.tableEl.tableId;
+    // Update all relevant properties from the new parent table
+    relevantTableProps.forEach((tablePropName) => {
+      this[tablePropName] = this.tableEl[tablePropName];
+    });
+  }
+
+  connectedCallback() {
+    this.updateTableProperties();
   }
 
   componentWillLoad() {
+    this.updateTableProperties();
+  }
+
+  // Add disconnectedCallback to clean up state when removed
+  disconnectedCallback() {
+    this.tableEl = null;
+    this.tableId = '';
     relevantTableProps.forEach((tablePropName) => {
-      this[tablePropName] = this.tableEl[tablePropName];
+      this[tablePropName] = false;
     });
   }
 

--- a/packages/core/src/components/table/table-body-row/table-body-row.tsx
+++ b/packages/core/src/components/table/table-body-row/table-body-row.tsx
@@ -98,6 +98,14 @@ export class TdsTableBodyRow {
     });
   }
 
+  @Listen('click')
+  click(event: MouseEvent) {
+    this.tableEl = this.host.closest('tds-table');
+    console.log('Table Id: ', this.tableEl.tableId);
+
+    console.log('event', event);
+  }
+
   handleKeyDown(e) {
     if (this.clickable && (e.key === 'Enter' || e.key === ' ')) {
       e.preventDefault();
@@ -122,15 +130,14 @@ export class TdsTableBodyRow {
   connectedCallback() {
     this.tableEl = this.host.closest('tds-table');
     this.tableId = this.tableEl?.tableId;
-
-    console.log('1', this.tableEl);
-    console.log('2', this.tableId);
   }
 
   componentWillLoad() {
-    relevantTableProps.forEach((tablePropName) => {
-      this[tablePropName] = this.tableEl[tablePropName];
-    });
+    if (this.tableEl) {
+      relevantTableProps.forEach((tablePropName) => {
+        this[tablePropName] = this.tableEl[tablePropName];
+      });
+    }
   }
 
   render() {

--- a/packages/core/src/components/table/table-body-row/table-body-row.tsx
+++ b/packages/core/src/components/table/table-body-row/table-body-row.tsx
@@ -122,6 +122,9 @@ export class TdsTableBodyRow {
   connectedCallback() {
     this.tableEl = this.host.closest('tds-table');
     this.tableId = this.tableEl?.tableId;
+
+    console.log('1', this.tableEl);
+    console.log('2', this.tableId);
   }
 
   componentWillLoad() {


### PR DESCRIPTION
## **Describe pull-request**  
When a row is dragged and dropped between two tables using Angular CDK Drag & Drop, the row is temporarily detached from the DOM, meaning it no longer has a valid parent tds-table. This causes a closest('tds-table') call to return null, and any attempt to access tableId or other properties on null results in a TypeError: Cannot read properties of null. 

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-171](https://jira.scania.com/browse/CDEP-171)
- **GitHub:** https://github.com/scania-digital-design-system/tegel/issues/533
- **No issue:** Describe the problem being solved.  

## **How to test**  
I'll soon include a link to angular demo page, WIP

## **Checklist before submission**
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
