### PR TITLE
feat(button): improve accessibility

### DIFF
--- a/packages/core/src/components/button/button.stories.tsx
+++ b/packages/core/src/components/button/button.stories.tsx
@@ -200,6 +200,7 @@ const WebComponentTemplate = ({
           : ''
       }
       animation="${animation}"
+      aria-label-value="A button component on a demo page in Storybook to showcase how it can be used"
     >
         ${
           onlyIcon || (icon && icon !== 'none')

--- a/packages/core/src/components/button/button.stories.tsx
+++ b/packages/core/src/components/button/button.stories.tsx
@@ -128,13 +128,13 @@ export default {
         defaultValue: { summary: 'none' },
       },
     },
-
     tdsAriaLabel: {
       name: 'Aria Label',
       description: 'Value to be used for the aria-label attribute',
       control: {
         type: 'text',
       },
+      if: { arg: 'onlyIcon', truthy: true },
     },
   },
   args: {
@@ -144,10 +144,10 @@ export default {
     size: 'Large',
     text: 'Button',
     fullbleed: false,
-    onlyIcon: false,
     icon: 'none',
     disabled: false,
     animation: 'none',
+    onlyIcon: false,
     tdsAriaLabel: 'A button component',
   },
 };

--- a/packages/core/src/components/button/button.stories.tsx
+++ b/packages/core/src/components/button/button.stories.tsx
@@ -128,6 +128,14 @@ export default {
         defaultValue: { summary: 'none' },
       },
     },
+
+    tdsAriaLabel: {
+      name: 'Aria Label',
+      description: 'Value to be used for the aria-label attribute',
+      control: {
+        type: 'text',
+      },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -140,6 +148,7 @@ export default {
     icon: 'none',
     disabled: false,
     animation: 'none',
+    tdsAriaLabel: 'A button component',
   },
 };
 
@@ -154,6 +163,7 @@ const WebComponentTemplate = ({
   icon,
   disabled,
   animation,
+  tdsAriaLabel,
 }) => {
   const variantLookUp = {
     Primary: 'primary',
@@ -200,7 +210,7 @@ const WebComponentTemplate = ({
           : ''
       }
       animation="${animation}"
-      aria-label-value="A button component on a demo page in Storybook to showcase how it can be used"
+      tds-aria-label="${tdsAriaLabel}"
     >
         ${
           onlyIcon || (icon && icon !== 'none')

--- a/packages/core/src/components/button/button.tsx
+++ b/packages/core/src/components/button/button.tsx
@@ -39,9 +39,17 @@ export class TdsButton {
   @Prop() animation: 'none' | 'fade' = 'none';
 
   /** The value to be used for the aria-label attribute if onlyIcon is set to true */
-  @Prop() ariaLabelValue: string;
+  @Prop() tdsAriaLabel: string;
 
   @State() onlyIcon: boolean = false;
+
+  connectedCallback() {
+    if (this.onlyIcon && !this.tdsAriaLabel) {
+      console.warn(
+        'Tegel button component: please specify the tdsAriaLabel prop when you have the onlyIcon attribute set to true',
+      );
+    }
+  }
 
   render() {
     const hasLabelSlot = hasSlot('label', this.host);
@@ -49,12 +57,6 @@ export class TdsButton {
 
     if (!this.text && !hasLabelSlot) {
       this.onlyIcon = true;
-    }
-
-    if (this.onlyIcon && !this.ariaLabelValue) {
-      console.warn(
-        'Tegel button component: please specify the ariaLabelValue prop when you have the onlyIcon attribute set to true',
-      );
     }
 
     return (
@@ -84,7 +86,7 @@ export class TdsButton {
             'only-icon': this.onlyIcon,
             [`animation-${this.animation}`]: this.animation !== 'none',
           }}
-          {...(this.onlyIcon && this.ariaLabelValue && { 'aria-label': this.ariaLabelValue })}
+          {...(this.onlyIcon && this.tdsAriaLabel && { 'aria-label': this.tdsAriaLabel })}
         >
           {this.text}
           {hasLabelSlot && !this.onlyIcon && <slot name="label" />}

--- a/packages/core/src/components/button/button.tsx
+++ b/packages/core/src/components/button/button.tsx
@@ -38,13 +38,23 @@ export class TdsButton {
   /** Determines if and how the button should animate. */
   @Prop() animation: 'none' | 'fade' = 'none';
 
+  /** The value to be used for the aria-label attribute if onlyIcon is set to true */
+  @Prop() ariaLabelValue: string;
+
   @State() onlyIcon: boolean = false;
 
   render() {
     const hasLabelSlot = hasSlot('label', this.host);
     const hasIconSlot = hasSlot('icon', this.host);
+
     if (!this.text && !hasLabelSlot) {
       this.onlyIcon = true;
+    }
+
+    if (this.onlyIcon && !this.ariaLabelValue) {
+      console.warn(
+        'Tegel button component: please specify the ariaLabelValue prop when you have the onlyIcon attribute set to true',
+      );
     }
 
     return (
@@ -74,7 +84,7 @@ export class TdsButton {
             'only-icon': this.onlyIcon,
             [`animation-${this.animation}`]: this.animation !== 'none',
           }}
-          {...(this.onlyIcon && { 'aria-label': 'button' })}
+          {...(this.onlyIcon && this.ariaLabelValue && { 'aria-label': this.ariaLabelValue })}
         >
           {this.text}
           {hasLabelSlot && !this.onlyIcon && <slot name="label" />}

--- a/packages/core/src/components/button/button.tsx
+++ b/packages/core/src/components/button/button.tsx
@@ -74,6 +74,7 @@ export class TdsButton {
             'only-icon': this.onlyIcon,
             [`animation-${this.animation}`]: this.animation !== 'none',
           }}
+          {...(this.onlyIcon && { 'aria-label': 'button' })}
         >
           {this.text}
           {hasLabelSlot && !this.onlyIcon && <slot name="label" />}

--- a/packages/core/src/components/button/readme.md
+++ b/packages/core/src/components/button/readme.md
@@ -7,16 +7,17 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                      | Type                                              | Default     |
-| ------------- | -------------- | ------------------------------------------------ | ------------------------------------------------- | ----------- |
-| `animation`   | `animation`    | Determines if and how the button should animate. | `"fade" \| "none"`                                | `'none'`    |
-| `disabled`    | `disabled`     | Control for disabled state of a component        | `boolean`                                         | `false`     |
-| `fullbleed`   | `fullbleed`    | When enabled, the Button takes 100% width        | `boolean`                                         | `false`     |
-| `modeVariant` | `mode-variant` | Set the mode variant of the Button.              | `"primary" \| "secondary"`                        | `null`      |
-| `size`        | `size`         | Size of a Button                                 | `"lg" \| "md" \| "sm" \| "xs"`                    | `'lg'`      |
-| `text`        | `text`         | Text displayed inside the Button                 | `string`                                          | `undefined` |
-| `type`        | `type`         | Button's type                                    | `"button" \| "reset" \| "submit"`                 | `'button'`  |
-| `variant`     | `variant`      | Variation of Button's design                     | `"danger" \| "ghost" \| "primary" \| "secondary"` | `'primary'` |
+| Property         | Attribute          | Description                                                                  | Type                                              | Default     |
+| ---------------- | ------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------- | ----------- |
+| `animation`      | `animation`        | Determines if and how the button should animate.                             | `"fade" \| "none"`                                | `'none'`    |
+| `ariaLabelValue` | `aria-label-value` | The value to be used for the aria-label attribute if onlyIcon is set to true | `string`                                          | `undefined` |
+| `disabled`       | `disabled`         | Control for disabled state of a component                                    | `boolean`                                         | `false`     |
+| `fullbleed`      | `fullbleed`        | When enabled, the Button takes 100% width                                    | `boolean`                                         | `false`     |
+| `modeVariant`    | `mode-variant`     | Set the mode variant of the Button.                                          | `"primary" \| "secondary"`                        | `null`      |
+| `size`           | `size`             | Size of a Button                                                             | `"lg" \| "md" \| "sm" \| "xs"`                    | `'lg'`      |
+| `text`           | `text`             | Text displayed inside the Button                                             | `string`                                          | `undefined` |
+| `type`           | `type`             | Button's type                                                                | `"button" \| "reset" \| "submit"`                 | `'button'`  |
+| `variant`        | `variant`          | Variation of Button's design                                                 | `"danger" \| "ghost" \| "primary" \| "secondary"` | `'primary'` |
 
 
 ## Slots

--- a/packages/core/src/components/button/readme.md
+++ b/packages/core/src/components/button/readme.md
@@ -7,17 +7,17 @@
 
 ## Properties
 
-| Property         | Attribute          | Description                                                                  | Type                                              | Default     |
-| ---------------- | ------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------- | ----------- |
-| `animation`      | `animation`        | Determines if and how the button should animate.                             | `"fade" \| "none"`                                | `'none'`    |
-| `ariaLabelValue` | `aria-label-value` | The value to be used for the aria-label attribute if onlyIcon is set to true | `string`                                          | `undefined` |
-| `disabled`       | `disabled`         | Control for disabled state of a component                                    | `boolean`                                         | `false`     |
-| `fullbleed`      | `fullbleed`        | When enabled, the Button takes 100% width                                    | `boolean`                                         | `false`     |
-| `modeVariant`    | `mode-variant`     | Set the mode variant of the Button.                                          | `"primary" \| "secondary"`                        | `null`      |
-| `size`           | `size`             | Size of a Button                                                             | `"lg" \| "md" \| "sm" \| "xs"`                    | `'lg'`      |
-| `text`           | `text`             | Text displayed inside the Button                                             | `string`                                          | `undefined` |
-| `type`           | `type`             | Button's type                                                                | `"button" \| "reset" \| "submit"`                 | `'button'`  |
-| `variant`        | `variant`          | Variation of Button's design                                                 | `"danger" \| "ghost" \| "primary" \| "secondary"` | `'primary'` |
+| Property       | Attribute        | Description                                                                  | Type                                              | Default     |
+| -------------- | ---------------- | ---------------------------------------------------------------------------- | ------------------------------------------------- | ----------- |
+| `animation`    | `animation`      | Determines if and how the button should animate.                             | `"fade" \| "none"`                                | `'none'`    |
+| `disabled`     | `disabled`       | Control for disabled state of a component                                    | `boolean`                                         | `false`     |
+| `fullbleed`    | `fullbleed`      | When enabled, the Button takes 100% width                                    | `boolean`                                         | `false`     |
+| `modeVariant`  | `mode-variant`   | Set the mode variant of the Button.                                          | `"primary" \| "secondary"`                        | `null`      |
+| `size`         | `size`           | Size of a Button                                                             | `"lg" \| "md" \| "sm" \| "xs"`                    | `'lg'`      |
+| `tdsAriaLabel` | `tds-aria-label` | The value to be used for the aria-label attribute if onlyIcon is set to true | `string`                                          | `undefined` |
+| `text`         | `text`           | Text displayed inside the Button                                             | `string`                                          | `undefined` |
+| `type`         | `type`           | Button's type                                                                | `"button" \| "reset" \| "submit"`                 | `'button'`  |
+| `variant`      | `variant`        | Variation of Button's design                                                 | `"danger" \| "ghost" \| "primary" \| "secondary"` | `'primary'` |
 
 
 ## Slots

--- a/packages/core/src/components/button/test/basic/button.axe.ts
+++ b/packages/core/src/components/button/test/basic/button.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/button/test/basic/index.html';
+
+test.describe.parallel('Button accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## **Describe pull-request**  
Improves accessibility for the Button component

## **Issue Linking:**  
- **Jira:** [CDEP-304](https://jira.scania.com/browse/CDEP-304)

## **How to test** 
### Scenario 1
1. Go to preview link and open Button component page
2. Open browser console
3. Focus on the button by tabbing to it
4. Click the button
5. Notice the event mentioned in the console

### Scenario 2
1. Go to preview link and open Button component
2. Activate the "only icon" option for Button in storybook controls
3. Inspect the button
4. Make sure that it has aria-label="A button component" (or whatever text is in the input field in the storybook controls for Aria Label)
 
## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
None
