### PR TITLE
feat(checkbox): improve accessibility

### DIFF
--- a/packages/core/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/core/src/components/checkbox/checkbox.stories.tsx
@@ -85,7 +85,7 @@ const Template = ({ label, checked, disabled, indeterminate, tdsAriaLabel }) =>
       checkbox-id="first-checkbox"
       tds-aria-label="${tdsAriaLabel}"
       aria-describedby="checkbox-1-label"
-      aria-labelledby="checkbox-1-l abel"
+      aria-labelledby="checkbox-1-label"
     >
       <div slot="label" id="checkbox-1-label">${label}</div>
     </tds-checkbox>

--- a/packages/core/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/core/src/components/checkbox/checkbox.stories.tsx
@@ -57,6 +57,13 @@ export default {
       table: {
         defaultValue: { summary: false },
       },
+      tdsAriaLabel: {
+        name: 'Aria Label',
+        description: 'Value to be used for the aria-label attribute',
+        control: {
+          type: 'text',
+        },
+      },
     },
   },
   args: {
@@ -64,10 +71,11 @@ export default {
     checked: false,
     disabled: false,
     indeterminate: false,
+    tdsAriaLabel: 'A checkbox component',
   },
 };
 
-const Template = ({ label, checked, disabled, indeterminate }) =>
+const Template = ({ label, checked, disabled, indeterminate, tdsAriaLabel }) =>
   formatHtmlPreview(`
     <tds-checkbox
       ${checked ? 'checked' : ''}
@@ -75,7 +83,7 @@ const Template = ({ label, checked, disabled, indeterminate }) =>
       ${indeterminate ? 'indeterminate' : ''}
       value="checkbox-1"
       checkbox-id="first-checkbox"
-      aria-label-value="A checkbox component on a demo page in Storybook to showcase how it can be used"
+      tds-aria-label="${tdsAriaLabel}"
       aria-describedby="checkbox-1-label"
       aria-labelledby="checkbox-1-label"
     >

--- a/packages/core/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/core/src/components/checkbox/checkbox.stories.tsx
@@ -57,12 +57,12 @@ export default {
       table: {
         defaultValue: { summary: false },
       },
-      tdsAriaLabel: {
-        name: 'Aria Label',
-        description: 'Value to be used for the aria-label attribute',
-        control: {
-          type: 'text',
-        },
+    },
+    tdsAriaLabel: {
+      name: 'Aria Label',
+      description: 'Value to be used for the aria-label attribute',
+      control: {
+        type: 'text',
       },
     },
   },
@@ -85,7 +85,7 @@ const Template = ({ label, checked, disabled, indeterminate, tdsAriaLabel }) =>
       checkbox-id="first-checkbox"
       tds-aria-label="${tdsAriaLabel}"
       aria-describedby="checkbox-1-label"
-      aria-labelledby="checkbox-1-label"
+      aria-labelledby="checkbox-1-l abel"
     >
       <div slot="label" id="checkbox-1-label">${label}</div>
     </tds-checkbox>

--- a/packages/core/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/core/src/components/checkbox/checkbox.stories.tsx
@@ -84,8 +84,8 @@ const Template = ({ label, checked, disabled, indeterminate, tdsAriaLabel }) =>
       value="checkbox-1"
       checkbox-id="first-checkbox"
       tds-aria-label="${tdsAriaLabel}"
-      aria-describedby="checkbox-1-label"
-      aria-labelledby="checkbox-1-label"
+      tds-aria-describedby="checkbox-1-label"
+      tds-aria-labelledby="checkbox-1-label"
     >
       <div slot="label" id="checkbox-1-label">${label}</div>
     </tds-checkbox>

--- a/packages/core/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/core/src/components/checkbox/checkbox.stories.tsx
@@ -84,10 +84,8 @@ const Template = ({ label, checked, disabled, indeterminate, tdsAriaLabel }) =>
       value="checkbox-1"
       checkbox-id="first-checkbox"
       tds-aria-label="${tdsAriaLabel}"
-      tds-aria-describedby="checkbox-1-label"
-      tds-aria-labelledby="checkbox-1-label"
     >
-      <div slot="label" id="checkbox-1-label">${label}</div>
+      <div slot="label">${label}</div>
     </tds-checkbox>
     
     <!-- Script tag with event listener for demo purposes. -->

--- a/packages/core/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/core/src/components/checkbox/checkbox.stories.tsx
@@ -70,13 +70,16 @@ export default {
 const Template = ({ label, checked, disabled, indeterminate }) =>
   formatHtmlPreview(`
     <tds-checkbox
-        ${checked ? 'checked' : ''}
-        ${disabled ? 'disabled' : ''}
-        ${indeterminate ? 'indeterminate' : ''}
-        value="checkbox-1"
-        checkbox-id="first-checkbox"
-        >
-        <div slot="label">${label}</div>
+      ${checked ? 'checked' : ''}
+      ${disabled ? 'disabled' : ''}
+      ${indeterminate ? 'indeterminate' : ''}
+      value="checkbox-1"
+      checkbox-id="first-checkbox"
+      aria-label-value="A checkbox component on a demo page in Storybook to showcase how it can be used"
+      aria-describedby="checkbox-1-label"
+      aria-labelledby="checkbox-1-label"
+    >
+      <div slot="label" id="checkbox-1-label">${label}</div>
     </tds-checkbox>
     
     <!-- Script tag with event listener for demo purposes. -->

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -44,6 +44,9 @@ export class TdsCheckbox {
   /** Value for the Checkbox */
   @Prop() value: string;
 
+  /** Value to be used for the aria-label attribute */
+  @Prop() ariaLabelValue: string;
+
   private inputElement: HTMLInputElement;
 
   /** Toggles the checked value of the component. */
@@ -124,16 +127,6 @@ export class TdsCheckbox {
     }
   }
 
-  componentDidRender() {
-    const label = this.host.getElementsByTagName('label')[0];
-    const div = label.getElementsByTagName('div')[0];
-    const missingText = div.innerHTML.length === 0;
-
-    if (missingText) {
-      label.innerText = 'Checkbox';
-    }
-  }
-
   render() {
     const hasLabeledAndDescribedBy =
       this.host.getAttribute('aria-describedby') && this.host.getAttribute('aria-labelledby');
@@ -142,6 +135,10 @@ export class TdsCheckbox {
       console.warn(
         'Tegel Checkbox component: aria-describedby or aria-labelledby attributes are missing',
       );
+    }
+
+    if (!this.ariaLabelValue) {
+      console.warn('Tegel Checkbox component: ariaLabelValue prop is missing');
     }
 
     return (
@@ -154,11 +151,7 @@ export class TdsCheckbox {
           aria-required={this.required}
           aria-describedby={this.host.getAttribute('aria-describedby')}
           aria-labelledby={this.host.getAttribute('aria-labelledby')}
-          aria-label={
-            hasLabeledAndDescribedBy
-              ? undefined
-              : 'A checkbox that is missing aria-labelledby or aria-describedby attributes'
-          }
+          aria-label={this.ariaLabelValue}
           required={this.required}
           type="checkbox"
           name={this.name}

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -47,9 +47,6 @@ export class TdsCheckbox {
   /** Value to be used for the aria-label attribute */
   @Prop() tdsAriaLabel: string;
 
-  /** Value to be used for the aria-labelledby attribute */
-  @Prop() tdsAriaLabelledby: string;
-
   /** Value to be used for the aria-describedby attribute */
   @Prop() tdsAriaDescribedby: string;
 
@@ -137,14 +134,6 @@ export class TdsCheckbox {
     if (!this.tdsAriaLabel) {
       console.warn('Tegel Checkbox component: tdsAriaLabel prop is missing');
     }
-
-    if (!this.tdsAriaLabelledby) {
-      console.warn('Tegel Checkbox component: tdsAriaLabelledby prop is missing');
-    }
-
-    if (!this.tdsAriaDescribedby) {
-      console.warn('Tegel Checkbox component: tdsAriaDescribedby prop is missing');
-    }
   }
 
   render() {
@@ -157,7 +146,6 @@ export class TdsCheckbox {
           aria-checked={this.checked}
           aria-required={this.required}
           aria-label={this.tdsAriaLabel}
-          aria-labelledby={this.tdsAriaLabelledby}
           aria-describedby={this.tdsAriaDescribedby}
           required={this.required}
           type="checkbox"

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -127,7 +127,7 @@ export class TdsCheckbox {
     }
   }
 
-  render() {
+  connectedCallback() {
     const hasLabeledAndDescribedBy =
       this.host.getAttribute('aria-describedby') && this.host.getAttribute('aria-labelledby');
 
@@ -140,7 +140,9 @@ export class TdsCheckbox {
     if (!this.tdsAriaLabel) {
       console.warn('Tegel Checkbox component: tdsAriaLabel prop is missing');
     }
+  }
 
+  render() {
     return (
       <div class="tds-checkbox">
         <input

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -45,7 +45,7 @@ export class TdsCheckbox {
   @Prop() value: string;
 
   /** Value to be used for the aria-label attribute */
-  @Prop() ariaLabelValue: string;
+  @Prop() tdsAriaLabel: string;
 
   private inputElement: HTMLInputElement;
 
@@ -137,7 +137,7 @@ export class TdsCheckbox {
       );
     }
 
-    if (!this.ariaLabelValue) {
+    if (!this.tdsAriaLabel) {
       console.warn('Tegel Checkbox component: ariaLabelValue prop is missing');
     }
 
@@ -151,7 +151,7 @@ export class TdsCheckbox {
           aria-required={this.required}
           aria-describedby={this.host.getAttribute('aria-describedby')}
           aria-labelledby={this.host.getAttribute('aria-labelledby')}
-          aria-label={this.ariaLabelValue}
+          aria-label={this.tdsAriaLabel}
           required={this.required}
           type="checkbox"
           name={this.name}

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -125,12 +125,12 @@ export class TdsCheckbox {
   }
 
   componentDidRender() {
-    const labels = this.host.getElementsByTagName('label');
-    const firstLabel = labels[0];
-    const missingText = firstLabel.children.length === 0;
+    const label = this.host.getElementsByTagName('label')[0];
+    const div = label.getElementsByTagName('div')[0];
+    const missingText = div.innerHTML.length === 0;
 
     if (missingText) {
-      firstLabel.innerHTML = '<div>Checkbox</div>';
+      label.innerText = 'Checkbox';
     }
   }
 

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -47,6 +47,12 @@ export class TdsCheckbox {
   /** Value to be used for the aria-label attribute */
   @Prop() tdsAriaLabel: string;
 
+  /** Value to be used for the aria-labelledby attribute */
+  @Prop() tdsAriaLabelledby: string;
+
+  /** Value to be used for the aria-describedby attribute */
+  @Prop() tdsAriaDescribedby: string;
+
   private inputElement: HTMLInputElement;
 
   /** Toggles the checked value of the component. */
@@ -128,17 +134,16 @@ export class TdsCheckbox {
   }
 
   connectedCallback() {
-    const hasLabeledAndDescribedBy =
-      this.host.getAttribute('aria-describedby') && this.host.getAttribute('aria-labelledby');
-
-    if (!hasLabeledAndDescribedBy) {
-      console.warn(
-        'Tegel Checkbox component: aria-describedby or aria-labelledby attributes are missing',
-      );
-    }
-
     if (!this.tdsAriaLabel) {
       console.warn('Tegel Checkbox component: tdsAriaLabel prop is missing');
+    }
+
+    if (!this.tdsAriaLabelledby) {
+      console.warn('Tegel Checkbox component: tdsAriaLabelledby prop is missing');
+    }
+
+    if (!this.tdsAriaDescribedby) {
+      console.warn('Tegel Checkbox component: tdsAriaDescribedby prop is missing');
     }
   }
 
@@ -151,9 +156,9 @@ export class TdsCheckbox {
           indeterminate={this.indeterminate}
           aria-checked={this.checked}
           aria-required={this.required}
-          aria-describedby={this.host.getAttribute('aria-describedby')}
-          aria-labelledby={this.host.getAttribute('aria-labelledby')}
           aria-label={this.tdsAriaLabel}
+          aria-labelledby={this.tdsAriaLabelledby}
+          aria-describedby={this.tdsAriaDescribedby}
           required={this.required}
           type="checkbox"
           name={this.name}

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -138,7 +138,7 @@ export class TdsCheckbox {
     }
 
     if (!this.tdsAriaLabel) {
-      console.warn('Tegel Checkbox component: ariaLabelValue prop is missing');
+      console.warn('Tegel Checkbox component: tdsAriaLabel prop is missing');
     }
 
     return (

--- a/packages/core/src/components/checkbox/checkbox.tsx
+++ b/packages/core/src/components/checkbox/checkbox.tsx
@@ -124,7 +124,26 @@ export class TdsCheckbox {
     }
   }
 
+  componentDidRender() {
+    const labels = this.host.getElementsByTagName('label');
+    const firstLabel = labels[0];
+    const missingText = firstLabel.children.length === 0;
+
+    if (missingText) {
+      firstLabel.innerHTML = '<div>Checkbox</div>';
+    }
+  }
+
   render() {
+    const hasLabeledAndDescribedBy =
+      this.host.getAttribute('aria-describedby') && this.host.getAttribute('aria-labelledby');
+
+    if (!hasLabeledAndDescribedBy) {
+      console.warn(
+        'Tegel Checkbox component: aria-describedby or aria-labelledby attributes are missing',
+      );
+    }
+
     return (
       <div class="tds-checkbox">
         <input
@@ -135,6 +154,11 @@ export class TdsCheckbox {
           aria-required={this.required}
           aria-describedby={this.host.getAttribute('aria-describedby')}
           aria-labelledby={this.host.getAttribute('aria-labelledby')}
+          aria-label={
+            hasLabeledAndDescribedBy
+              ? undefined
+              : 'A checkbox that is missing aria-labelledby or aria-describedby attributes'
+          }
           required={this.required}
           type="checkbox"
           name={this.name}

--- a/packages/core/src/components/checkbox/readme.md
+++ b/packages/core/src/components/checkbox/readme.md
@@ -17,7 +17,6 @@
 | `required`           | `required`             | Make the Checkbox required                                                | `boolean` | `false`              |
 | `tdsAriaDescribedby` | `tds-aria-describedby` | Value to be used for the aria-describedby attribute                       | `string`  | `undefined`          |
 | `tdsAriaLabel`       | `tds-aria-label`       | Value to be used for the aria-label attribute                             | `string`  | `undefined`          |
-| `tdsAriaLabelledby`  | `tds-aria-labelledby`  | Value to be used for the aria-labelledby attribute                        | `string`  | `undefined`          |
 | `value`              | `value`                | Value for the Checkbox                                                    | `string`  | `undefined`          |
 
 

--- a/packages/core/src/components/checkbox/readme.md
+++ b/packages/core/src/components/checkbox/readme.md
@@ -7,16 +7,16 @@
 
 ## Properties
 
-| Property         | Attribute          | Description                                                               | Type      | Default              |
-| ---------------- | ------------------ | ------------------------------------------------------------------------- | --------- | -------------------- |
-| `ariaLabelValue` | `aria-label-value` | Value to be used for the aria-label attribute                             | `string`  | `undefined`          |
-| `checkboxId`     | `checkbox-id`      | ID for the Checkbox's input element. Randomly generated if not specified. | `string`  | `generateUniqueId()` |
-| `checked`        | `checked`          | Sets the Checkbox as checked                                              | `boolean` | `false`              |
-| `disabled`       | `disabled`         | Sets the Checkbox in a disabled state                                     | `boolean` | `false`              |
-| `indeterminate`  | `indeterminate`    | Sets the Checkbox as indeterminate                                        | `boolean` | `false`              |
-| `name`           | `name`             | Name for the Checkbox's input element.                                    | `string`  | `undefined`          |
-| `required`       | `required`         | Make the Checkbox required                                                | `boolean` | `false`              |
-| `value`          | `value`            | Value for the Checkbox                                                    | `string`  | `undefined`          |
+| Property        | Attribute        | Description                                                               | Type      | Default              |
+| --------------- | ---------------- | ------------------------------------------------------------------------- | --------- | -------------------- |
+| `checkboxId`    | `checkbox-id`    | ID for the Checkbox's input element. Randomly generated if not specified. | `string`  | `generateUniqueId()` |
+| `checked`       | `checked`        | Sets the Checkbox as checked                                              | `boolean` | `false`              |
+| `disabled`      | `disabled`       | Sets the Checkbox in a disabled state                                     | `boolean` | `false`              |
+| `indeterminate` | `indeterminate`  | Sets the Checkbox as indeterminate                                        | `boolean` | `false`              |
+| `name`          | `name`           | Name for the Checkbox's input element.                                    | `string`  | `undefined`          |
+| `required`      | `required`       | Make the Checkbox required                                                | `boolean` | `false`              |
+| `tdsAriaLabel`  | `tds-aria-label` | Value to be used for the aria-label attribute                             | `string`  | `undefined`          |
+| `value`         | `value`          | Value for the Checkbox                                                    | `string`  | `undefined`          |
 
 
 ## Events

--- a/packages/core/src/components/checkbox/readme.md
+++ b/packages/core/src/components/checkbox/readme.md
@@ -7,15 +7,16 @@
 
 ## Properties
 
-| Property        | Attribute       | Description                                                               | Type      | Default              |
-| --------------- | --------------- | ------------------------------------------------------------------------- | --------- | -------------------- |
-| `checkboxId`    | `checkbox-id`   | ID for the Checkbox's input element. Randomly generated if not specified. | `string`  | `generateUniqueId()` |
-| `checked`       | `checked`       | Sets the Checkbox as checked                                              | `boolean` | `false`              |
-| `disabled`      | `disabled`      | Sets the Checkbox in a disabled state                                     | `boolean` | `false`              |
-| `indeterminate` | `indeterminate` | Sets the Checkbox as indeterminate                                        | `boolean` | `false`              |
-| `name`          | `name`          | Name for the Checkbox's input element.                                    | `string`  | `undefined`          |
-| `required`      | `required`      | Make the Checkbox required                                                | `boolean` | `false`              |
-| `value`         | `value`         | Value for the Checkbox                                                    | `string`  | `undefined`          |
+| Property         | Attribute          | Description                                                               | Type      | Default              |
+| ---------------- | ------------------ | ------------------------------------------------------------------------- | --------- | -------------------- |
+| `ariaLabelValue` | `aria-label-value` | Value to be used for the aria-label attribute                             | `string`  | `undefined`          |
+| `checkboxId`     | `checkbox-id`      | ID for the Checkbox's input element. Randomly generated if not specified. | `string`  | `generateUniqueId()` |
+| `checked`        | `checked`          | Sets the Checkbox as checked                                              | `boolean` | `false`              |
+| `disabled`       | `disabled`         | Sets the Checkbox in a disabled state                                     | `boolean` | `false`              |
+| `indeterminate`  | `indeterminate`    | Sets the Checkbox as indeterminate                                        | `boolean` | `false`              |
+| `name`           | `name`             | Name for the Checkbox's input element.                                    | `string`  | `undefined`          |
+| `required`       | `required`         | Make the Checkbox required                                                | `boolean` | `false`              |
+| `value`          | `value`            | Value for the Checkbox                                                    | `string`  | `undefined`          |
 
 
 ## Events

--- a/packages/core/src/components/checkbox/readme.md
+++ b/packages/core/src/components/checkbox/readme.md
@@ -7,16 +7,18 @@
 
 ## Properties
 
-| Property        | Attribute        | Description                                                               | Type      | Default              |
-| --------------- | ---------------- | ------------------------------------------------------------------------- | --------- | -------------------- |
-| `checkboxId`    | `checkbox-id`    | ID for the Checkbox's input element. Randomly generated if not specified. | `string`  | `generateUniqueId()` |
-| `checked`       | `checked`        | Sets the Checkbox as checked                                              | `boolean` | `false`              |
-| `disabled`      | `disabled`       | Sets the Checkbox in a disabled state                                     | `boolean` | `false`              |
-| `indeterminate` | `indeterminate`  | Sets the Checkbox as indeterminate                                        | `boolean` | `false`              |
-| `name`          | `name`           | Name for the Checkbox's input element.                                    | `string`  | `undefined`          |
-| `required`      | `required`       | Make the Checkbox required                                                | `boolean` | `false`              |
-| `tdsAriaLabel`  | `tds-aria-label` | Value to be used for the aria-label attribute                             | `string`  | `undefined`          |
-| `value`         | `value`          | Value for the Checkbox                                                    | `string`  | `undefined`          |
+| Property             | Attribute              | Description                                                               | Type      | Default              |
+| -------------------- | ---------------------- | ------------------------------------------------------------------------- | --------- | -------------------- |
+| `checkboxId`         | `checkbox-id`          | ID for the Checkbox's input element. Randomly generated if not specified. | `string`  | `generateUniqueId()` |
+| `checked`            | `checked`              | Sets the Checkbox as checked                                              | `boolean` | `false`              |
+| `disabled`           | `disabled`             | Sets the Checkbox in a disabled state                                     | `boolean` | `false`              |
+| `indeterminate`      | `indeterminate`        | Sets the Checkbox as indeterminate                                        | `boolean` | `false`              |
+| `name`               | `name`                 | Name for the Checkbox's input element.                                    | `string`  | `undefined`          |
+| `required`           | `required`             | Make the Checkbox required                                                | `boolean` | `false`              |
+| `tdsAriaDescribedby` | `tds-aria-describedby` | Value to be used for the aria-describedby attribute                       | `string`  | `undefined`          |
+| `tdsAriaLabel`       | `tds-aria-label`       | Value to be used for the aria-label attribute                             | `string`  | `undefined`          |
+| `tdsAriaLabelledby`  | `tds-aria-labelledby`  | Value to be used for the aria-labelledby attribute                        | `string`  | `undefined`          |
+| `value`              | `value`                | Value for the Checkbox                                                    | `string`  | `undefined`          |
 
 
 ## Events

--- a/packages/core/src/components/checkbox/test/default/checkbox.axe.ts
+++ b/packages/core/src/components/checkbox/test/default/checkbox.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/checkbox/test/default/index.html';
+
+test.describe.parallel('Checkbox accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/core/src/components/checkbox/test/default/index.html
+++ b/packages/core/src/components/checkbox/test/default/index.html
@@ -12,8 +12,10 @@
   </head>
 
   <body>
-    <tds-checkbox>
-      <span slot="label">Label</span>
-    </tds-checkbox>
+    <main>
+      <tds-checkbox>
+        <span slot="label">Label</span>
+      </tds-checkbox>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
## **Describe pull-request**  
Addresses the accessibility improvements in the Checkbox component.

## **Issue Linking:**  
- **Jira:** [CDEP-307](https://jira.scania.com/browse/CDEP-307)

## **How to test**  

### Scenario 1
Not implemented, see additional context.

### Scenario 2
Not implemented, see additional context.

### Scenario 2a
This is an alternative to Scenario 2 for the current implementation. @ckrook or @Lunkan89 please confirm whether this test is sufficient.
1. Go to https://pr-1057.d3fazya28914g3.amplifyapp.com/?path=/story/components-checkbox--default
2. Open dev tools
3. Inspect the checkbox and verify that its input element has aria-label="A checkbox component" (or whatever text is in the Aria Label input in the storybook controls)
4. Make sure that the screen reader reads the aria-label.

### Scenario 3
Not implemented, see additional context.

### Scenario 3a
This is an alternative to Scenario 3 for the current implementation. @ckrook or @Lunkan89 please confirm whether this test is sufficient.
1. Go to https://pr-1057.d3fazya28914g3.amplifyapp.com/?path=/story/components-checkbox--default
2. Open the browser console
3. In the storybook controls, remove the text in the Aria Label input
4. A warning should appear in the browser console


## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  

### Regarding Scenario 1:

From the Jira ticket:
> Scenario: Ensure proper communication of the indeterminate state
Given a checkbox component that can be in an indeterminate state
When the checkbox is rendered in this state
Then the aria-checked attribute should be set to "mixed" on the wrapper` <div>`
And screen readers should correctly announce the indeterminate state
Link example: https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/examples/checkbox-mixed/

If you look at the example on the linked page, you'll see that there's a "parent" checkbox that is either checked, unchecked or indeterminate based on the values of its four child checkboxes.

We currently don't have support for using checkboxes like this in Tegel. **For this reason, I don't think there is anything for us to fix here.**

Talked to @ckrook who agrees this is not something we should fix.

### Regarding Scenario 2:

From the Jira ticket:
> Scenario: Ensure the checkbox has an accessible label when the slot is empty
Given a checkbox component with an empty slot="label"
When the checkbox is rendered
Then a default label like "Checkbox" should be provided
And screen readers should always have a meaningful label

@ckrook and I talked about this and we agreed it's not always the case that the user of Tegel will want a text next to a checkbox. **Instead, I included the ~~ariaLabelValue~~ tdsAriaLabel prop for the user to specify when using the checkbox component.**

### Regarding Scenario 3:

From the Jira ticket:
> Scenario: Ensure consistent labeling for aria-labelledby and aria-describedby
Given a checkbox component that relies on host attributes for accessibility
When the checkbox is rendered
Then fallback aria-label values should be provided
And screen readers should always have a consistent label and description

I found it unclear what the desired outcome of this test scenario was, so I'm not sure I've fixed it, as I don't know how to test it. **However, I've added a console warning that appears if tdsAriaLabel is missing.** @ckrook and I agreed that aria-labelledby probably isn't necessary, so I removed that one. aria-describedby (with tdsAriaDescribedby) is still present, but now optional. **Please let me know if you think there's a problem with this implementation.**