### PR TITLE
refactor(dropdown-option): initialize state variables and add defensive check 

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -37,15 +37,15 @@ export class TdsDropdownOption {
 
   @State() selected: boolean = false;
 
-  @State() multiselect: boolean;
+  @State() multiselect: boolean = false;
 
   @State() size: 'xs' | 'sm' | 'md' | 'lg' = 'lg';
 
-  private parentElement: HTMLTdsDropdownElement;
+  private parentElement: HTMLTdsDropdownElement | null = null;
 
-  // @ts-ignore
+// @ts-ignore
   // eslint-disable-next-line no-unused-vars,
-  private label: string;
+  private label: string = '';
 
   /** Method to select/deselect an option. */
   @Method()
@@ -93,13 +93,19 @@ export class TdsDropdownOption {
   }
 
   componentWillRender = () => {
+    if (!this.host.parentElement) {
+      return;
+    }
     this.parentElement =
-      this.host.parentElement.tagName === 'TDS-DROPDOWN'
+      this.host.parentElement?.tagName === 'TDS-DROPDOWN'
         ? (this.host.parentElement as HTMLTdsDropdownElement)
         : ((this.host.getRootNode() as ShadowRoot).host as HTMLTdsDropdownElement);
-    this.multiselect = this.parentElement.multiselect;
-    this.size = this.parentElement.size;
-    this.label = this.host.textContent.trim();
+    
+    if (this.parentElement) {
+      this.multiselect = this.parentElement.multiselect ?? false;
+      this.size = this.parentElement.size || 'lg';
+    }
+    this.label = this.host.textContent?.trim() || '';
   };
 
   handleSingleSelect = () => {
@@ -200,3 +206,4 @@ export class TdsDropdownOption {
     );
   }
 }
+


### PR DESCRIPTION
… improve null checks

## **Describe pull-request**  
How it was solved:
Added null checks for host.parentElement at the beginning of the method
Added optional chaining (?.) for safer property access
Added fallback values using ?? and || operators for multiselect and size properties
Made the textContent.trim() call safer with optional chaining and fallback to empty string

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://jira.scania.com/browse/CDEP-)
- **GitHub:** Include issue link  
- **No issue:** Describe the problem being solved.  

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to...
2. Check in...
3. Run ...

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
