### PR TITLE
feat(chip): improve accessibility

### DIFF
--- a/packages/core/src/components/chip/chip.stories.tsx
+++ b/packages/core/src/components/chip/chip.stories.tsx
@@ -137,56 +137,62 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         display: flex;
         gap: 8px;
       }
+      label {
+        margin: 8px;
+      }
     </style>
 
+    <label id="group-1">Group 1</label>
     <div class="demo-wrapper">
-      <tds-chip type="checkbox" size="${
-        sizeLookUp[size]
-      }" checked ${disabledAttribute} value="checkbox-1-value">        
+      <div role="group" aria-labelledby="group-1">
+        <tds-chip type="checkbox" size="${
+          sizeLookUp[size]
+        }" checked ${disabledAttribute} value="checkbox-1-value">        
+            ${
+              icon && iconPosition === 'Prefix'
+                ? '<tds-icon slot="prefix" name="heart" size="16px"></tds-icon>'
+                : ''
+            }
+            <span slot="label">
+              ${label} 1
+            </span>
+            ${
+              icon && iconPosition === 'Suffix'
+                ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+                : ''
+            }        
+        </tds-chip>
+        <tds-chip type="checkbox" size="${sizeLookUp[size]}" value="checkbox-2-value">
           ${
             icon && iconPosition === 'Prefix'
-              ? '<tds-icon slot="prefix" name="heart" size="16px"></tds-icon>'
+              ? '<tds-icon slot="prefix" name="email" size="16px"></tds-icon>'
               : ''
           }
-          <span slot="label">
-            ${label} 1
-          </span>
+            <span slot="label">
+              ${label} 2
+            </span>
+            ${
+              icon && iconPosition === 'Suffix'
+                ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+                : ''
+            } 
+        </tds-chip>
+        <tds-chip type="checkbox" size="${sizeLookUp[size]}" value="checkbox-3-value">
           ${
-            icon && iconPosition === 'Suffix'
-              ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+            icon && iconPosition === 'Prefix'
+              ? '<tds-icon slot="prefix" name="smartphone" size="16px"></tds-icon>'
               : ''
-          }        
-      </tds-chip>
-      <tds-chip type="checkbox" size="${sizeLookUp[size]}" value="checkbox-2-value">
-        ${
-          icon && iconPosition === 'Prefix'
-            ? '<tds-icon slot="prefix" name="email" size="16px"></tds-icon>'
-            : ''
-        }
-          <span slot="label">
-            ${label} 2
-          </span>
-          ${
-            icon && iconPosition === 'Suffix'
-              ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
-              : ''
-          } 
-      </tds-chip>
-      <tds-chip type="checkbox" size="${sizeLookUp[size]}" value="checkbox-3-value">
-        ${
-          icon && iconPosition === 'Prefix'
-            ? '<tds-icon slot="prefix" name="smartphone" size="16px"></tds-icon>'
-            : ''
-        }
-          <span slot="label">
-            ${label} 3
-          </span>
-          ${
-            icon && iconPosition === 'Suffix'
-              ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
-              : ''
-          } 
-      </tds-chip>
+          }
+            <span slot="label">
+              ${label} 3
+            </span>
+            ${
+              icon && iconPosition === 'Suffix'
+                ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+                : ''
+            } 
+        </tds-chip>
+      </div>
     </div>
 
     <!-- Script tag for demo purposes -->
@@ -213,105 +219,109 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
       }
     </style>
 
-    <label>Group 1</label>
+    <label id="group-1">Group 1</label>
     <div class="demo-wrapper">
-      <tds-chip name="group1" type="radio" size="${
-        sizeLookUp[size]
-      }" checked ${disabledAttribute} value="radio-1-value">
-        ${
-          icon && iconPosition === 'Prefix'
-            ? '<tds-icon slot="prefix" name="sorting" size="16px"></tds-icon>'
-            : ''
-        }
-          <span slot="label">
-            ${label} 1
-          </span>
+      <div role="group" aria-labelledby="group-1">
+        <tds-chip name="group1" type="radio" size="${
+          sizeLookUp[size]
+        }" checked ${disabledAttribute} value="radio-1-value">
           ${
-            icon && iconPosition === 'Suffix'
-              ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+            icon && iconPosition === 'Prefix'
+              ? '<tds-icon slot="prefix" name="sorting" size="16px"></tds-icon>'
               : ''
-          } 
-      </tds-chip>
-      <tds-chip name="group1" type="radio" size="${sizeLookUp[size]}" value="radio-2-value">
-        ${
-          icon && iconPosition === 'Prefix'
-            ? '<tds-icon slot="prefix" name="cart" size="16px"></tds-icon>'
-            : ''
-        }
-          <span slot="label">
-            ${label} 2
-          </span>
+          }
+            <span slot="label">
+              ${label} 1
+            </span>
+            ${
+              icon && iconPosition === 'Suffix'
+                ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+                : ''
+            } 
+        </tds-chip>
+        <tds-chip name="group1" type="radio" size="${sizeLookUp[size]}" value="radio-2-value">
           ${
-            icon && iconPosition === 'Suffix'
-              ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+            icon && iconPosition === 'Prefix'
+              ? '<tds-icon slot="prefix" name="cart" size="16px"></tds-icon>'
               : ''
-          } 
-      </tds-chip>
-      <tds-chip name="group1" type="radio" size="${sizeLookUp[size]}" value="radio-3-value">
-        ${
-          icon && iconPosition === 'Prefix'
-            ? '<tds-icon slot="prefix" name="star" size="16px"></tds-icon>'
-            : ''
-        }
-          <span slot="label">
-            ${label} 3
-          </span>
+          }
+            <span slot="label">
+              ${label} 2
+            </span>
+            ${
+              icon && iconPosition === 'Suffix'
+                ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+                : ''
+            } 
+        </tds-chip>
+        <tds-chip name="group1" type="radio" size="${sizeLookUp[size]}" value="radio-3-value">
           ${
-            icon && iconPosition === 'Suffix'
-              ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+            icon && iconPosition === 'Prefix'
+              ? '<tds-icon slot="prefix" name="star" size="16px"></tds-icon>'
               : ''
-          } 
-      </tds-chip>
+          }
+            <span slot="label">
+              ${label} 3
+            </span>
+            ${
+              icon && iconPosition === 'Suffix'
+                ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+                : ''
+            } 
+        </tds-chip>
+      </div>
     </div>
-    <label>Group 2</label>
+    <label id="group-2">Group 2</label>
     <div class="demo-wrapper">
-      <tds-chip name="group2" type="radio" size="${
-        sizeLookUp[size]
-      }" checked ${disabledAttribute} value="radio-1-value">
-        ${
-          icon && iconPosition === 'Prefix'
-            ? '<tds-icon slot="prefix" name="sorting" size="16px"></tds-icon>'
-            : ''
-        }
-          <span slot="label">
-            ${label} 1
-          </span>
+      <div role="group" aria-labelledby="group-2">
+        <tds-chip name="group2" type="radio" size="${
+          sizeLookUp[size]
+        }" checked ${disabledAttribute} value="radio-1-value">
           ${
-            icon && iconPosition === 'Suffix'
-              ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+            icon && iconPosition === 'Prefix'
+              ? '<tds-icon slot="prefix" name="sorting" size="16px"></tds-icon>'
               : ''
-          } 
-      </tds-chip>
-      <tds-chip name="group2" type="radio" size="${sizeLookUp[size]}" value="radio-2-value">
-        ${
-          icon && iconPosition === 'Prefix'
-            ? '<tds-icon slot="prefix" name="cart" size="16px"></tds-icon>'
-            : ''
-        }
-          <span slot="label">
-            ${label} 2
-          </span>
+          }
+            <span slot="label">
+              ${label} 1
+            </span>
+            ${
+              icon && iconPosition === 'Suffix'
+                ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+                : ''
+            } 
+        </tds-chip>
+        <tds-chip name="group2" type="radio" size="${sizeLookUp[size]}" value="radio-2-value">
           ${
-            icon && iconPosition === 'Suffix'
-              ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+            icon && iconPosition === 'Prefix'
+              ? '<tds-icon slot="prefix" name="cart" size="16px"></tds-icon>'
               : ''
-          } 
-      </tds-chip>
-      <tds-chip name="group2" type="radio" size="${sizeLookUp[size]}" value="radio-3-value">
-        ${
-          icon && iconPosition === 'Prefix'
-            ? '<tds-icon slot="prefix" name="star" size="16px"></tds-icon>'
-            : ''
-        }
-          <span slot="label">
-            ${label} 3
-          </span>
+          }
+            <span slot="label">
+              ${label} 2
+            </span>
+            ${
+              icon && iconPosition === 'Suffix'
+                ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+                : ''
+            } 
+        </tds-chip>
+        <tds-chip name="group2" type="radio" size="${sizeLookUp[size]}" value="radio-3-value">
           ${
-            icon && iconPosition === 'Suffix'
-              ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+            icon && iconPosition === 'Prefix'
+              ? '<tds-icon slot="prefix" name="star" size="16px"></tds-icon>'
               : ''
-          } 
-      </tds-chip>
+          }
+            <span slot="label">
+              ${label} 3
+            </span>
+            ${
+              icon && iconPosition === 'Suffix'
+                ? '<tds-icon slot="suffix" name="cross" size="16px"></tds-icon>'
+                : ''
+            } 
+        </tds-chip>
+      </div>
     </div>
 
     <!-- Script tag for demo purposes -->

--- a/packages/core/src/components/chip/chip.tsx
+++ b/packages/core/src/components/chip/chip.tsx
@@ -67,7 +67,7 @@ export class TdsChip {
   internalRadioOnChange: EventEmitter<{
     chipId: string;
     checked: boolean;
-    groupName: string
+    groupName: string;
   }>;
 
   private handleChange = () => {
@@ -77,7 +77,11 @@ export class TdsChip {
         this.checked = !this.checked;
       } else if (this.type === 'radio') {
         this.checked = true;
-        this.internalRadioOnChange.emit({ chipId: this.chipId, checked: this.checked, groupName: this.name })
+        this.internalRadioOnChange.emit({
+          chipId: this.chipId,
+          checked: this.checked,
+          groupName: this.name,
+        });
       } else {
         console.error('Unsupported type in Chip component!');
       }
@@ -91,14 +95,16 @@ export class TdsChip {
   };
 
   @Listen('internalRadioOnChange', { target: 'body' })
-  handleInternaRadioChange(event: CustomEvent<{ chipId: string; checked: boolean; groupName: string }>) {
-    const { chipId, checked, groupName } = event.detail
+  handleInternaRadioChange(
+    event: CustomEvent<{ chipId: string; checked: boolean; groupName: string }>,
+  ) {
+    const { chipId, checked, groupName } = event.detail;
 
     // if event comes from different button within the group
-    if(chipId !== this.chipId && groupName === this.name) {
+    if (chipId !== this.chipId && groupName === this.name) {
       //  and both incoming and this is checked
-      if(this.checked && checked) {
-        this.checked = false
+      if (this.checked && checked) {
+        this.checked = false;
       }
     }
   }
@@ -152,6 +158,8 @@ export class TdsChip {
     const hasLabelSlot = hasSlot('label', this.host);
     const hasSuffixSlot = hasSlot('suffix', this.host);
 
+    const textInsideLabel = this.host.querySelector(`[slot="label"]`).innerHTML;
+
     const chipClasses = {
       'tds-chip-component': true,
       'sm': this.size === 'sm',
@@ -165,7 +173,14 @@ export class TdsChip {
       <Host>
         <div class="component">
           <div class={chipClasses}>
-            <input type={this.type} id={this.chipId} {...inputAttributes}></input>
+            <input
+              type={this.type}
+              id={this.chipId}
+              aria-checked={this.type === 'button' ? undefined : this.checked}
+              role={this.type}
+              aria-label={hasLabelSlot && textInsideLabel ? textInsideLabel : 'Chip'}
+              {...inputAttributes}
+            ></input>
             <label onClick={(event) => event.stopPropagation()} htmlFor={this.chipId}>
               {hasPrefixSlot && <slot name="prefix" />}
               {hasLabelSlot && <slot name="label" />}

--- a/packages/core/src/components/chip/chip.tsx
+++ b/packages/core/src/components/chip/chip.tsx
@@ -176,7 +176,7 @@ export class TdsChip {
             <input
               type={this.type}
               id={this.chipId}
-              aria-checked={this.type === 'button' ? undefined : this.checked}
+              aria-checked={this.type === 'button' ? undefined : String(this.checked)}
               role={this.type}
               aria-label={hasLabelSlot && textInsideLabel ? textInsideLabel : 'Chip'}
               {...inputAttributes}

--- a/packages/core/src/components/chip/test/checkbox/chip.axe.ts
+++ b/packages/core/src/components/chip/test/checkbox/chip.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/chip/test/checkbox/index.html';
+
+test.describe.parallel('Chip accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/core/src/components/chip/test/checkbox/index.html
+++ b/packages/core/src/components/chip/test/checkbox/index.html
@@ -12,14 +12,23 @@
   </head>
 
   <body>
-    <tds-chip name="test" type="checkbox" size="lg" checked value="checkbox-1-value" chip-id="option-1">
+    <main>
+      <tds-chip
+        name="test"
+        type="checkbox"
+        size="lg"
+        checked
+        value="checkbox-1-value"
+        chip-id="option-1"
+      >
         <span slot="label">Label 1</span>
-    </tds-chip>
-    <tds-chip name="test" type="checkbox" size="lg" value="checkbox-2-value" chip-id="option-2">
+      </tds-chip>
+      <tds-chip name="test" type="checkbox" size="lg" value="checkbox-2-value" chip-id="option-2">
         <span slot="label">Label 2</span>
-    </tds-chip>
-    <tds-chip name="test" type="checkbox" size="lg" value="checkbox-3-value" chip-id="option-3">
+      </tds-chip>
+      <tds-chip name="test" type="checkbox" size="lg" value="checkbox-3-value" chip-id="option-3">
         <span slot="label">Label 3</span>
-    </tds-chip>
+      </tds-chip>
+    </main>
   </body>
 </html>

--- a/packages/core/src/components/chip/test/default/chip.axe.ts
+++ b/packages/core/src/components/chip/test/default/chip.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/chip/test/default/index.html';
+
+test.describe.parallel('Chip accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/core/src/components/chip/test/default/index.html
+++ b/packages/core/src/components/chip/test/default/index.html
@@ -12,8 +12,10 @@
   </head>
 
   <body>
-    <tds-chip type="button" size="lg">
+    <main>
+      <tds-chip type="button" size="lg">
         <span slot="label">Label</span>
-    </tds-chip>
+      </tds-chip>
+    </main>
   </body>
 </html>

--- a/packages/core/src/components/chip/test/radio/chip.axe.ts
+++ b/packages/core/src/components/chip/test/radio/chip.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/chip/test/radio/index.html';
+
+test.describe.parallel('Chip accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/core/src/components/chip/test/radio/index.html
+++ b/packages/core/src/components/chip/test/radio/index.html
@@ -12,14 +12,16 @@
   </head>
 
   <body>
-    <tds-chip name="test" type="radio" size="lg" value="radio-1-value" chip-id="option-1">
+    <main>
+      <tds-chip name="test" type="radio" size="lg" value="radio-1-value" chip-id="option-1">
         <span slot="label">Label 1</span>
-    </tds-chip>
-    <tds-chip name="test" type="radio" size="lg" checked value="radio-2-value" chip-id="option-2">
+      </tds-chip>
+      <tds-chip name="test" type="radio" size="lg" checked value="radio-2-value" chip-id="option-2">
         <span slot="label">Label 2</span>
-    </tds-chip>
-    <tds-chip name="test" type="radio" size="lg" value="radio-3-value" chip-id="option-3">
+      </tds-chip>
+      <tds-chip name="test" type="radio" size="lg" value="radio-3-value" chip-id="option-3">
         <span slot="label">Label 3</span>
-    </tds-chip>
+      </tds-chip>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
## **Describe pull-request**  
Improves accessibility in the Chip component.

## **Issue Linking:**  
- **Jira:** [CDEP-308](https://jira.scania.com/browse/CDEP-308)

## **How to test**  

### Scenario 1:
Not implemented. See additional notes.
 
### Scenario 2:
Not implemented. See additional notes.
 
### Scenario 3:
1. Go to https://pr-1062.d3fazya28914g3.amplifyapp.com/?path=/story/components-chip--default&args=inputType:Radio to test radio type chips
2. Open dev tools
3. Inspect the chips that are checked and verify that their input elements have the attribute aria-checked="true"
4. Inspect the chips that are not checked and verify that their input elements have the attribute aria-checked="false"
5. In the storybook controls, change the chip type to checkbox
6. Repeat steps 3-4

### Scenario 4:
1. Go to https://pr-1062.d3fazya28914g3.amplifyapp.com/?path=/story/components-chip--default to test button type chips
2. Open dev tools
3. Inspect and verify that all visible chips have role="checkbox", role="radio" or role="button" depending on the type you're testing
4. Open screen reader and verify that it announces the chips correctly
5. In the storybook controls, change type to Radio
7. Repeat steps 3-4
8. In the storybook controls, change type to Checkbox
9. Repeat steps 3-4

### Scenario 5:
1. Go to https://pr-1062.d3fazya28914g3.amplifyapp.com/?path=/story/components-chip--default
2. Open dev tools
3. Inspect the chip and verify that its input element has aria-label="Label" (or whatever text you put in Label text in the storybook controls)
4. In the storybook controls, in Label text, delete everything in the input field to make the button have no label
5. Inspect the chip and verify that its input element has aria-label="Chip" (the default when no label is provided)
**See the extra note about Scenario 5 in the additional notes.**

### Scenario 6:
1. Go to https://pr-1062.d3fazya28914g3.amplifyapp.com/?path=/story/components-chip--default&args=inputType:Radio to test radio type chips
2. Open dev tools
3. Inspect and verify that all chips are child elements to a div with role="group" that has an aria-labelledby="group-x" (where x is either 1 or 2). This references the label element with id="group-x".
4. In the storybook controls, change the chip type to Checkbox
5. Repeat step 3

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
### Regarding Scenario 1:
This has not been fixed.

From Jira ticket:
> Scenario: Ensure type radio chips are navigable via keyboard
> Given multiple radio chips are present in a group
> When the user navigates using the Tab key
> Then it should be possible to focus on unchecked chips
> But currently, only the checked chip is focusable

I'm not sure if this is something we should fix, simply it currently works exactly like it works in native html checkboxes and radio buttons. So, I have not fixed this. **Should we?**


### Regarding Scenario 2:
This has not been fixed.

From Jira ticket:
> Scenario: Ensure type checkbox chips have a visible focus ring
> Given a checkbox chip component
> When the chip is toggled
> Then the focus ring should be clearly visible
> But currently, the focus ring is not obvious
> (Sync with designer how the focus ring should look like)

I talked to Max the designer about this and we currently think that the best solution is to modify _focus-state.scss, which will affect all components. Therefore, I think it's best to fix it in a separate PR. **Maybe we should create a separate ticket for that?**

### Note about Scenario 5:
From Jira ticket:
> And screen readers should have a reliable text label for the chip

I believe this is what we accomplish with aria-label. The screen reader I use reads the text in the aria-label attribute. **Is this the desired behavior?**
