### PR TITLE
feat(header-item): header item ignores end slot

### DIFF
--- a/packages/core/src/components/header/header-item/header-item.tsx
+++ b/packages/core/src/components/header/header-item/header-item.tsx
@@ -21,6 +21,8 @@ export class TdsHeaderItem {
 
   private slotEl: HTMLSlotElement;
 
+  private mutationObserver: MutationObserver;
+
   updateSlotted(
     searchPredicate: (element: HTMLElement) => boolean,
     mutationCallback: (element: HTMLElement) => void,
@@ -51,10 +53,46 @@ export class TdsHeaderItem {
     }
   }
 
+  /**
+   * Read the native "order" attribute on the host and update the CSS order accordingly.
+   * If the attribute "order" has the value "end", the order is set to 1. Otherwise, 0.
+   */
+  updateOrder() {
+    if (this.host.getAttribute('order') === 'end') {
+      this.host.style.order = '1';
+    } else {
+      this.host.style.order = '0';
+    }
+  }
+
   componentDidLoad() {
     this.slotEl = this.host.shadowRoot.querySelector('slot');
     this.updateSlottedElements();
     this.slotEl.addEventListener('slotchange', this.updateSlottedElements);
+
+    // Set the order on initial load.
+    this.updateOrder();
+
+    // Create a MutationObserver to listen for changes on the "order" attribute.
+    this.mutationObserver = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'order') {
+          this.updateOrder();
+        }
+      });
+    });
+
+    // Start observing the host element for attribute changes (specifically "order").
+    this.mutationObserver.observe(this.host, {
+      attributes: true,
+      attributeFilter: ['order'],
+    });
+  }
+
+  disconnectedCallback() {
+    if (this.mutationObserver) {
+      this.mutationObserver.disconnect();
+    }
   }
 
   render() {

--- a/packages/core/src/components/header/header-item/header-item.tsx
+++ b/packages/core/src/components/header/header-item/header-item.tsx
@@ -58,10 +58,16 @@ export class TdsHeaderItem {
    * If the attribute "order" has the value "end", the order is set to 1. Otherwise, 0.
    */
   updateOrder() {
-    if (this.host.getAttribute('order') === 'end') {
-      this.host.style.order = '1';
-    } else {
-      this.host.style.order = '0';
+    const orderValue = this.host.getAttribute('order');
+    switch (orderValue) {
+      case 'end':
+        this.host.style.order = '1';
+        break;
+      case 'start':
+      case null:
+      default:
+        this.host.style.order = '0';
+        break;
     }
   }
 


### PR DESCRIPTION
## **Describe pull-request**  
- Updated the `tds-header-item` component to listen for changes on the native "order" attribute using a MutationObserver.
- When the "order" attribute changes (for example, set to "end"), the component updates its inline CSS `order` property accordingly (e.g., "end" sets the order to "1", otherwise it defaults to "0").
- This solution allows dynamic reordering of header items without introducing a new prop and without re-rendering all child components.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://jira.scania.com/browse/CDEP-347)
- **GitHub:** [Include issue link  ](https://github.com/scania-digital-design-system/tegel/issues/528)

## **How to test**  

1. visit the angular demo page: https://pr-127.d1ax919pz49q2z.amplifyapp.com/
2. Go to about us
3. Rich click on the "orders" tds-header-item element and inspect element
4. Double check that that order attribute is set to "end"
5. Click "x" on keyboard to toggle and check that the element stays in its position

## **Checklist before submission**
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
