### PR TITLE
feat(color): new brand primitives for Tegel

### DIFF
--- a/color/_scania-color-primitives.scss
+++ b/color/_scania-color-primitives.scss
@@ -1,4 +1,4 @@
-/* Tegel Color Primitives */
+/* Tegel Color Primitives palette */
 
 :root {
   /* Neutral Solid */

--- a/color/_scania-color-primitives.scss
+++ b/color/_scania-color-primitives.scss
@@ -2,85 +2,85 @@
 
 :root {
   /* Neutral Solid */
-  --scania-neutral-solid-1000: rgb(0 0 0 / 100%);
-  --scania-neutral-solid-958: rgb(14 16 19 / 100%);
-  --scania-neutral-solid-928: rgb(21 24 29 / 100%);
-  --scania-neutral-solid-900: rgb(28 34 43 / 100%);
-  --scania-neutral-solid-868: rgb(36 44 55 / 100%);
-  --scania-neutral-solid-846: rgb(45 54 67 / 100%);
-  --scania-neutral-solid-800: rgb(58 69 84 / 100%);
-  --scania-neutral-solid-700: rgb(83 95 112 / 100%);
-  --scania-neutral-solid-600: rgb(117 131 152 / 100%);
-  --scania-neutral-solid-500: rgb(147 161 183 / 100%);
-  --scania-neutral-solid-400: rgb(181 189 204 / 100%);
-  --scania-neutral-solid-300: rgb(206 210 220 / 100%);
-  --scania-neutral-solid-200: rgb(222 224 230 / 100%);
-  --scania-neutral-solid-100: rgb(235 236 238 / 100%);
-  --scania-neutral-solid-50: rgb(243 244 247 / 100%);
-  --scania-neutral-solid-00: rgb(255 255 255 / 100%);
+  --scania-neutral-solid-1000: rgba(0, 0, 0, 1);
+  --scania-neutral-solid-958: rgba(14, 16, 19, 1);
+  --scania-neutral-solid-928: rgba(21, 24, 29, 1);
+  --scania-neutral-solid-900: rgba(28, 34, 43, 1);
+  --scania-neutral-solid-868: rgba(36, 44, 55, 1);
+  --scania-neutral-solid-846: rgba(45, 54, 67, 1);
+  --scania-neutral-solid-800: rgba(58, 69, 84, 1);
+  --scania-neutral-solid-700: rgba(83, 95, 112, 1);
+  --scania-neutral-solid-600: rgba(117, 131, 152, 1);
+  --scania-neutral-solid-500: rgba(147, 161, 183, 1);
+  --scania-neutral-solid-400: rgba(181, 189, 204, 1);
+  --scania-neutral-solid-300: rgba(206, 210, 220, 1);
+  --scania-neutral-solid-200: rgba(222, 224, 230, 1);
+  --scania-neutral-solid-100: rgba(235, 236, 238, 1);
+  --scania-neutral-solid-50: rgba(243, 244, 247, 1);
+  --scania-neutral-solid-00: rgba(255, 255, 255, 1);
 
   /* Neutral Transparent */
   --scania-neutral-transparent-958: var(--scania-neutral-solid-958);
-  --scania-neutral-transparent-826: rgb(28 39 57 / 86%);
-  --scania-neutral-transparent-700: rgb(6 23 49 / 69%);
-  --scania-neutral-transparent-600: rgb(23 50 87 / 60%);
-  --scania-neutral-transparent-500: rgb(41 68 110 / 50%);
-  --scania-neutral-transparent-400: rgb(41 65 110 / 35%);
-  --scania-neutral-transparent-200: rgb(51 64 102 / 17%);
+  --scania-neutral-transparent-826: rgba(28, 39, 57, 0.86);
+  --scania-neutral-transparent-700: rgba(6, 23, 49, 0.69);
+  --scania-neutral-transparent-600: rgba(23, 50, 87, 0.6);
+  --scania-neutral-transparent-500: rgba(41, 68, 110, 0.5);
+  --scania-neutral-transparent-400: rgba(41, 65, 110, 0.35);
+  --scania-neutral-transparent-200: rgba(51, 64, 102, 0.17);
 
   /* Neutral Transparent Inverse */
   --scania-neutral-transparent-inverse-958: var(--scania-neutral-solid-50);
-  --scania-neutral-transparent-inverse-700: rgb(226 235 253 / 80%);
-  --scania-neutral-transparent-inverse-600: rgb(195 213 242 / 75%);
-  --scania-neutral-transparent-inverse-500: rgb(194 218 252 / 60%);
-  --scania-neutral-transparent-inverse-400: rgb(184 212 250 / 45%);
-  --scania-neutral-transparent-inverse-200: rgb(172 204 246 / 34%);
+  --scania-neutral-transparent-inverse-700: rgba(226, 235, 253, 0.8);
+  --scania-neutral-transparent-inverse-600: rgba(195, 213, 242, 0.75);
+  --scania-neutral-transparent-inverse-500: rgba(194, 218, 252, 0.6);
+  --scania-neutral-transparent-inverse-400: rgba(184, 212, 250, 0.45);
+  --scania-neutral-transparent-inverse-200: rgba(172, 204, 246, 0.34);
 
   /* Blue Solid */
-  --scania-blue-900: rgb(0 21 51 / 100%);
-  --scania-blue-800: rgb(4 30 66 / 100%);
-  --scania-blue-700: rgb(15 50 99 / 100%);
-  --scania-blue-600: rgb(22 65 127 / 100%);
-  --scania-blue-500: rgb(32 88 168 / 100%);
-  --scania-blue-400: rgb(43 112 211 / 100%);
-  --scania-blue-300: rgb(74 137 243 / 100%);
-  --scania-blue-200: rgb(135 175 232 / 100%);
-  --scania-blue-100: rgb(186 205 232 / 100%);
-  --scania-blue-50: rgb(216 221 229 / 100%);
+  --scania-blue-900: rgba(0, 21, 51, 1);
+  --scania-blue-800: rgba(4, 30, 66, 1);
+  --scania-blue-700: rgba(15, 50, 99, 1);
+  --scania-blue-600: rgba(22, 65, 127, 1);
+  --scania-blue-500: rgba(32, 88, 168, 1);
+  --scania-blue-400: rgba(43, 112, 211, 1);
+  --scania-blue-300: rgba(74, 137, 243, 1);
+  --scania-blue-200: rgba(135, 175, 232, 1);
+  --scania-blue-100: rgba(186, 205, 232, 1);
+  --scania-blue-50: rgba(216, 221, 229, 1);
 
   /* Extended Red Solid */
-  --scania-extended-red-900: rgb(53 0 4 / 100%);
-  --scania-extended-red-800: rgb(72 0 8 / 100%);
-  --scania-extended-red-700: rgb(108 0 17 / 100%);
-  --scania-extended-red-600: rgb(138 0 25 / 100%);
-  --scania-extended-red-500: rgb(182 0 36 / 100%);
-  --scania-extended-red-400: rgb(227 3 48 / 100%);
-  --scania-extended-red-300: rgb(255 68 79 / 100%);
-  --scania-extended-red-200: rgb(255 141 139 / 100%);
-  --scania-extended-red-100: rgb(255 211 210 / 100%);
-  --scania-extended-red-50: rgb(255 223 227 / 100%);
+  --scania-extended-red-900: rgba(53, 0, 4, 1);
+  --scania-extended-red-800: rgba(72, 0, 8, 1);
+  --scania-extended-red-700: rgba(108, 0, 17, 1);
+  --scania-extended-red-600: rgba(138, 0, 25, 1);
+  --scania-extended-red-500: rgba(182, 0, 36, 1);
+  --scania-extended-red-400: rgba(227, 3, 48, 1);
+  --scania-extended-red-300: rgba(255, 68, 79, 1);
+  --scania-extended-red-200: rgba(255, 141, 139, 1);
+  --scania-extended-red-100: rgba(255, 211, 210, 1);
+  --scania-extended-red-50: rgba(255, 223, 227, 1);
 
   /* Extended Green Solid */
-  --scania-extended-green-900: rgb(0 26 18 / 100%);
-  --scania-extended-green-800: rgb(0 37 27 / 100%);
-  --scania-extended-green-700: rgb(0 58 45 / 100%);
-  --scania-extended-green-600: rgb(0 76 59 / 100%);
-  --scania-extended-green-500: rgb(0 102 80 / 100%);
-  --scania-extended-green-400: rgb(0 129 102 / 100%);
-  --scania-extended-green-300: rgb(0 158 126 / 100%);
-  --scania-extended-green-200: rgb(65 194 159 / 100%);
-  --scania-extended-green-100: rgb(164 215 196 / 100%);
-  --scania-extended-green-50: rgb(209 224 217 / 100%);
+  --scania-extended-green-900: rgba(0, 26, 18, 1);
+  --scania-extended-green-800: rgba(0, 37, 27, 1);
+  --scania-extended-green-700: rgba(0, 58, 45, 1);
+  --scania-extended-green-600: rgba(0, 76, 59, 1);
+  --scania-extended-green-500: rgba(0, 102, 80, 1);
+  --scania-extended-green-400: rgba(0, 129, 102, 1);
+  --scania-extended-green-300: rgba(0, 158, 126, 1);
+  --scania-extended-green-200: rgba(65, 194, 159, 1);
+  --scania-extended-green-100: rgba(164, 215, 196, 1);
+  --scania-extended-green-50: rgba(209, 224, 217, 1);
 
   /* Extended Yellow Solid */
-  --scania-extended-yellow-900: rgb(29 21 0 / 100%);
-  --scania-extended-yellow-800: rgb(40 30 0 / 100%);
-  --scania-extended-yellow-700: rgb(63 49 0 / 100%);
-  --scania-extended-yellow-600: rgb(82 64 0 / 100%);
-  --scania-extended-yellow-500: rgb(110 87 0 / 100%);
-  --scania-extended-yellow-400: rgb(139 110 0 / 100%);
-  --scania-extended-yellow-300: rgb(169 135 0 / 100%);
-  --scania-extended-yellow-200: rgb(211 169 0 / 100%);
-  --scania-extended-yellow-100: rgb(241 194 27 / 100%);
-  --scania-extended-yellow-50: rgb(244 219 153 / 100%);
+  --scania-extended-yellow-900: rgba(29, 21, 0, 1);
+  --scania-extended-yellow-800: rgba(40, 30, 0, 1);
+  --scania-extended-yellow-700: rgba(63, 49, 0, 1);
+  --scania-extended-yellow-600: rgba(82, 64, 0, 1);
+  --scania-extended-yellow-500: rgba(110, 87, 0, 1);
+  --scania-extended-yellow-400: rgba(139, 110, 0, 1);
+  --scania-extended-yellow-300: rgba(169, 135, 0, 1);
+  --scania-extended-yellow-200: rgba(211, 169, 0, 1);
+  --scania-extended-yellow-100: rgba(241, 194, 27, 1);
+  --scania-extended-yellow-50: rgba(244, 219, 153, 1);
 }

--- a/color/_scania-color-primitives.scss
+++ b/color/_scania-color-primitives.scss
@@ -1,86 +1,86 @@
-// Tegel Color Primitives
+/* Tegel Color Primitives */
 
 :root {
-  // Neutral Solid
-  --scania-neutral-solid-1000: rgba(0, 0, 0, 1);
-  --scania-neutral-solid-958: rgba(14, 16, 19, 1);
-  --scania-neutral-solid-928: rgba(21, 24, 29, 1);
-  --scania-neutral-solid-900: rgba(28, 34, 43, 1);
-  --scania-neutral-solid-868: rgba(36, 44, 55, 1);
-  --scania-neutral-solid-846: rgba(45, 54, 67, 1);
-  --scania-neutral-solid-800: rgba(58, 69, 84, 1);
-  --scania-neutral-solid-700: rgba(83, 95, 112, 1);
-  --scania-neutral-solid-600: rgba(117, 131, 152, 1);
-  --scania-neutral-solid-500: rgba(147, 161, 183, 1);
-  --scania-neutral-solid-400: rgba(181, 189, 204, 1);
-  --scania-neutral-solid-300: rgba(206, 210, 220, 1);
-  --scania-neutral-solid-200: rgba(222, 224, 230, 1);
-  --scania-neutral-solid-100: rgba(235, 236, 238, 1);
-  --scania-neutral-solid-50: rgba(243, 244, 247, 1);
-  --scania-neutral-solid-00: rgba(255, 255, 255, 1);
+  /* Neutral Solid */
+  --scania-neutral-solid-1000: rgb(0 0 0 / 100%);
+  --scania-neutral-solid-958: rgb(14 16 19 / 100%);
+  --scania-neutral-solid-928: rgb(21 24 29 / 100%);
+  --scania-neutral-solid-900: rgb(28 34 43 / 100%);
+  --scania-neutral-solid-868: rgb(36 44 55 / 100%);
+  --scania-neutral-solid-846: rgb(45 54 67 / 100%);
+  --scania-neutral-solid-800: rgb(58 69 84 / 100%);
+  --scania-neutral-solid-700: rgb(83 95 112 / 100%);
+  --scania-neutral-solid-600: rgb(117 131 152 / 100%);
+  --scania-neutral-solid-500: rgb(147 161 183 / 100%);
+  --scania-neutral-solid-400: rgb(181 189 204 / 100%);
+  --scania-neutral-solid-300: rgb(206 210 220 / 100%);
+  --scania-neutral-solid-200: rgb(222 224 230 / 100%);
+  --scania-neutral-solid-100: rgb(235 236 238 / 100%);
+  --scania-neutral-solid-50: rgb(243 244 247 / 100%);
+  --scania-neutral-solid-00: rgb(255 255 255 / 100%);
 
-  // Neutral Transparent
+  /* Neutral Transparent */
   --scania-neutral-transparent-958: var(--scania-neutral-solid-958);
-  --scania-neutral-transparent-826: rgba(28, 39, 57, 0.86);
-  --scania-neutral-transparent-700: rgba(6, 23, 49, 0.69);
-  --scania-neutral-transparent-600: rgba(23, 50, 87, 0.6);
-  --scania-neutral-transparent-500: rgba(41, 68, 110, 0.5);
-  --scania-neutral-transparent-400: rgba(41, 65, 110, 0.35);
-  --scania-neutral-transparent-200: rgba(51, 64, 102, 0.17);
+  --scania-neutral-transparent-826: rgb(28 39 57 / 86%);
+  --scania-neutral-transparent-700: rgb(6 23 49 / 69%);
+  --scania-neutral-transparent-600: rgb(23 50 87 / 60%);
+  --scania-neutral-transparent-500: rgb(41 68 110 / 50%);
+  --scania-neutral-transparent-400: rgb(41 65 110 / 35%);
+  --scania-neutral-transparent-200: rgb(51 64 102 / 17%);
 
-  // Neutral Transparent Inverse
+  /* Neutral Transparent Inverse */
   --scania-neutral-transparent-inverse-958: var(--scania-neutral-solid-50);
-  --scania-neutral-transparent-inverse-700: rgba(226, 235, 253, 0.8);
-  --scania-neutral-transparent-inverse-600: rgba(195, 213, 242, 0.75);
-  --scania-neutral-transparent-inverse-500: rgba(194, 218, 252, 0.6);
-  --scania-neutral-transparent-inverse-400: rgba(184, 212, 250, 0.45);
-  --scania-neutral-transparent-inverse-200: rgba(172, 204, 246, 0.34);
+  --scania-neutral-transparent-inverse-700: rgb(226 235 253 / 80%);
+  --scania-neutral-transparent-inverse-600: rgb(195 213 242 / 75%);
+  --scania-neutral-transparent-inverse-500: rgb(194 218 252 / 60%);
+  --scania-neutral-transparent-inverse-400: rgb(184 212 250 / 45%);
+  --scania-neutral-transparent-inverse-200: rgb(172 204 246 / 34%);
 
-  // Blue Solid
-  --scania-blue-900: rgba(0, 21, 51, 1);
-  --scania-blue-800: rgba(4, 30, 66, 1);
-  --scania-blue-700: rgba(15, 50, 99, 1);
-  --scania-blue-600: rgba(22, 65, 127, 1);
-  --scania-blue-500: rgba(32, 88, 168, 1);
-  --scania-blue-400: rgba(43, 112, 211, 1);
-  --scania-blue-300: rgba(74, 137, 243, 1);
-  --scania-blue-200: rgba(135, 175, 232, 1);
-  --scania-blue-100: rgba(186, 205, 232, 1);
-  --scania-blue-50: rgba(216, 221, 229, 1);
+  /* Blue Solid */
+  --scania-blue-900: rgb(0 21 51 / 100%);
+  --scania-blue-800: rgb(4 30 66 / 100%);
+  --scania-blue-700: rgb(15 50 99 / 100%);
+  --scania-blue-600: rgb(22 65 127 / 100%);
+  --scania-blue-500: rgb(32 88 168 / 100%);
+  --scania-blue-400: rgb(43 112 211 / 100%);
+  --scania-blue-300: rgb(74 137 243 / 100%);
+  --scania-blue-200: rgb(135 175 232 / 100%);
+  --scania-blue-100: rgb(186 205 232 / 100%);
+  --scania-blue-50: rgb(216 221 229 / 100%);
 
-  // Extended Red Solid
-  --scania-extended-red-900: rgba(53, 0, 4, 1);
-  --scania-extended-red-800: rgba(72, 0, 8, 1);
-  --scania-extended-red-700: rgba(108, 0, 17, 1);
-  --scania-extended-red-600: rgba(138, 0, 25, 1);
-  --scania-extended-red-500: rgba(182, 0, 36, 1);
-  --scania-extended-red-400: rgba(227, 3, 48, 1);
-  --scania-extended-red-300: rgba(255, 68, 79, 1);
-  --scania-extended-red-200: rgba(255, 141, 139, 1);
-  --scania-extended-red-100: rgba(255, 211, 210, 1);
-  --scania-extended-red-50: rgba(255, 223, 227, 1);
+  /* Extended Red Solid */
+  --scania-extended-red-900: rgb(53 0 4 / 100%);
+  --scania-extended-red-800: rgb(72 0 8 / 100%);
+  --scania-extended-red-700: rgb(108 0 17 / 100%);
+  --scania-extended-red-600: rgb(138 0 25 / 100%);
+  --scania-extended-red-500: rgb(182 0 36 / 100%);
+  --scania-extended-red-400: rgb(227 3 48 / 100%);
+  --scania-extended-red-300: rgb(255 68 79 / 100%);
+  --scania-extended-red-200: rgb(255 141 139 / 100%);
+  --scania-extended-red-100: rgb(255 211 210 / 100%);
+  --scania-extended-red-50: rgb(255 223 227 / 100%);
 
-  // Extended Green Solid
-  --scania-extended-green-900: rgba(0, 26, 18, 1);
-  --scania-extended-green-800: rgba(0, 37, 27, 1);
-  --scania-extended-green-700: rgba(0, 58, 45, 1);
-  --scania-extended-green-600: rgba(0, 76, 59, 1);
-  --scania-extended-green-500: rgba(0, 102, 80, 1);
-  --scania-extended-green-400: rgba(0, 129, 102, 1);
-  --scania-extended-green-300: rgba(0, 158, 126, 1);
-  --scania-extended-green-200: rgba(65, 194, 159, 1);
-  --scania-extended-green-100: rgba(164, 215, 196, 1);
-  --scania-extended-green-50: rgba(209, 224, 217, 1);
+  /* Extended Green Solid */
+  --scania-extended-green-900: rgb(0 26 18 / 100%);
+  --scania-extended-green-800: rgb(0 37 27 / 100%);
+  --scania-extended-green-700: rgb(0 58 45 / 100%);
+  --scania-extended-green-600: rgb(0 76 59 / 100%);
+  --scania-extended-green-500: rgb(0 102 80 / 100%);
+  --scania-extended-green-400: rgb(0 129 102 / 100%);
+  --scania-extended-green-300: rgb(0 158 126 / 100%);
+  --scania-extended-green-200: rgb(65 194 159 / 100%);
+  --scania-extended-green-100: rgb(164 215 196 / 100%);
+  --scania-extended-green-50: rgb(209 224 217 / 100%);
 
-  // Extended Yellow Solid
-  --scania-extended-yellow-900: rgba(29, 21, 0, 1);
-  --scania-extended-yellow-800: rgba(40, 30, 0, 1);
-  --scania-extended-yellow-700: rgba(63, 49, 0, 1);
-  --scania-extended-yellow-600: rgba(82, 64, 0, 1);
-  --scania-extended-yellow-500: rgba(110, 87, 0, 1);
-  --scania-extended-yellow-400: rgba(139, 110, 0, 1);
-  --scania-extended-yellow-300: rgba(169, 135, 0, 1);
-  --scania-extended-yellow-200: rgba(211, 169, 0, 1);
-  --scania-extended-yellow-100: rgba(241, 194, 27, 1);
-  --scania-extended-yellow-50: rgba(244, 219, 153, 1);
+  /* Extended Yellow Solid */
+  --scania-extended-yellow-900: rgb(29 21 0 / 100%);
+  --scania-extended-yellow-800: rgb(40 30 0 / 100%);
+  --scania-extended-yellow-700: rgb(63 49 0 / 100%);
+  --scania-extended-yellow-600: rgb(82 64 0 / 100%);
+  --scania-extended-yellow-500: rgb(110 87 0 / 100%);
+  --scania-extended-yellow-400: rgb(139 110 0 / 100%);
+  --scania-extended-yellow-300: rgb(169 135 0 / 100%);
+  --scania-extended-yellow-200: rgb(211 169 0 / 100%);
+  --scania-extended-yellow-100: rgb(241 194 27 / 100%);
+  --scania-extended-yellow-50: rgb(244 219 153 / 100%);
 }

--- a/color/_scania-color-primitives.scss
+++ b/color/_scania-color-primitives.scss
@@ -1,0 +1,86 @@
+// Tegel Color Primitives
+
+:root {
+  // Neutral Solid
+  --scania-neutral-solid-1000: rgba(0, 0, 0, 1);
+  --scania-neutral-solid-958: rgba(14, 16, 19, 1);
+  --scania-neutral-solid-928: rgba(21, 24, 29, 1);
+  --scania-neutral-solid-900: rgba(28, 34, 43, 1);
+  --scania-neutral-solid-868: rgba(36, 44, 55, 1);
+  --scania-neutral-solid-846: rgba(45, 54, 67, 1);
+  --scania-neutral-solid-800: rgba(58, 69, 84, 1);
+  --scania-neutral-solid-700: rgba(83, 95, 112, 1);
+  --scania-neutral-solid-600: rgba(117, 131, 152, 1);
+  --scania-neutral-solid-500: rgba(147, 161, 183, 1);
+  --scania-neutral-solid-400: rgba(181, 189, 204, 1);
+  --scania-neutral-solid-300: rgba(206, 210, 220, 1);
+  --scania-neutral-solid-200: rgba(222, 224, 230, 1);
+  --scania-neutral-solid-100: rgba(235, 236, 238, 1);
+  --scania-neutral-solid-50: rgba(243, 244, 247, 1);
+  --scania-neutral-solid-00: rgba(255, 255, 255, 1);
+
+  // Neutral Transparent
+  --scania-neutral-transparent-958: var(--scania-neutral-solid-958);
+  --scania-neutral-transparent-826: rgba(28, 39, 57, 0.86);
+  --scania-neutral-transparent-700: rgba(6, 23, 49, 0.69);
+  --scania-neutral-transparent-600: rgba(23, 50, 87, 0.6);
+  --scania-neutral-transparent-500: rgba(41, 68, 110, 0.5);
+  --scania-neutral-transparent-400: rgba(41, 65, 110, 0.35);
+  --scania-neutral-transparent-200: rgba(51, 64, 102, 0.17);
+
+  // Neutral Transparent Inverse
+  --scania-neutral-transparent-inverse-958: var(--scania-neutral-solid-50);
+  --scania-neutral-transparent-inverse-700: rgba(226, 235, 253, 0.8);
+  --scania-neutral-transparent-inverse-600: rgba(195, 213, 242, 0.75);
+  --scania-neutral-transparent-inverse-500: rgba(194, 218, 252, 0.6);
+  --scania-neutral-transparent-inverse-400: rgba(184, 212, 250, 0.45);
+  --scania-neutral-transparent-inverse-200: rgba(172, 204, 246, 0.34);
+
+  // Blue Solid
+  --scania-blue-900: rgba(0, 21, 51, 1);
+  --scania-blue-800: rgba(4, 30, 66, 1);
+  --scania-blue-700: rgba(15, 50, 99, 1);
+  --scania-blue-600: rgba(22, 65, 127, 1);
+  --scania-blue-500: rgba(32, 88, 168, 1);
+  --scania-blue-400: rgba(43, 112, 211, 1);
+  --scania-blue-300: rgba(74, 137, 243, 1);
+  --scania-blue-200: rgba(135, 175, 232, 1);
+  --scania-blue-100: rgba(186, 205, 232, 1);
+  --scania-blue-50: rgba(216, 221, 229, 1);
+
+  // Extended Red Solid
+  --scania-extended-red-900: rgba(53, 0, 4, 1);
+  --scania-extended-red-800: rgba(72, 0, 8, 1);
+  --scania-extended-red-700: rgba(108, 0, 17, 1);
+  --scania-extended-red-600: rgba(138, 0, 25, 1);
+  --scania-extended-red-500: rgba(182, 0, 36, 1);
+  --scania-extended-red-400: rgba(227, 3, 48, 1);
+  --scania-extended-red-300: rgba(255, 68, 79, 1);
+  --scania-extended-red-200: rgba(255, 141, 139, 1);
+  --scania-extended-red-100: rgba(255, 211, 210, 1);
+  --scania-extended-red-50: rgba(255, 223, 227, 1);
+
+  // Extended Green Solid
+  --scania-extended-green-900: rgba(0, 26, 18, 1);
+  --scania-extended-green-800: rgba(0, 37, 27, 1);
+  --scania-extended-green-700: rgba(0, 58, 45, 1);
+  --scania-extended-green-600: rgba(0, 76, 59, 1);
+  --scania-extended-green-500: rgba(0, 102, 80, 1);
+  --scania-extended-green-400: rgba(0, 129, 102, 1);
+  --scania-extended-green-300: rgba(0, 158, 126, 1);
+  --scania-extended-green-200: rgba(65, 194, 159, 1);
+  --scania-extended-green-100: rgba(164, 215, 196, 1);
+  --scania-extended-green-50: rgba(209, 224, 217, 1);
+
+  // Extended Yellow Solid
+  --scania-extended-yellow-900: rgba(29, 21, 0, 1);
+  --scania-extended-yellow-800: rgba(40, 30, 0, 1);
+  --scania-extended-yellow-700: rgba(63, 49, 0, 1);
+  --scania-extended-yellow-600: rgba(82, 64, 0, 1);
+  --scania-extended-yellow-500: rgba(110, 87, 0, 1);
+  --scania-extended-yellow-400: rgba(139, 110, 0, 1);
+  --scania-extended-yellow-300: rgba(169, 135, 0, 1);
+  --scania-extended-yellow-200: rgba(211, 169, 0, 1);
+  --scania-extended-yellow-100: rgba(241, 194, 27, 1);
+  --scania-extended-yellow-50: rgba(244, 219, 153, 1);
+}


### PR DESCRIPTION
## **Describe pull-request**  
New primitives color palette for Tegel from Tegel project

## **Issue Linking:**  
- **Jira:** Add ticket number after `CDEP-`: [CDEP-395](https://jira.scania.com/browse/CDEP-395)

## **How to test**  
1. Check the [Figma file](https://www.figma.com/design/oXyzzbDmusEfy6GWIbyEEw/TRATON-UI-Kit-(Frozen)?m=auto&node-id=0-1&vars=1&var-id=3-3).
2. Compare color names and values. They should match.

Note: prefix --tds2 is added to avoid conflicts with current palette. It will be changed to --tds once we change all components and we phase out the current palette in use. 

## **Checklist before submission**
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Additional context**  
File is not connected to any other CSS file. That will happen in later stage of project. 
