### PR TITLE
feat(toggle): added accessibility test and aria-label

### DIFF
--- a/packages/core/src/components/toggle/readme.md
+++ b/packages/core/src/components/toggle/readme.md
@@ -7,15 +7,16 @@
 
 ## Properties
 
-| Property   | Attribute   | Description                                                                 | Type           | Default              |
-| ---------- | ----------- | --------------------------------------------------------------------------- | -------------- | -------------------- |
-| `checked`  | `checked`   | Sets the Toggle as checked                                                  | `boolean`      | `false`              |
-| `disabled` | `disabled`  | Sets the Toggle in a disabled state                                         | `boolean`      | `false`              |
-| `headline` | `headline`  | Headline for the Toggle                                                     | `string`       | `undefined`          |
-| `name`     | `name`      | Name of the toggle's input element                                          | `string`       | `undefined`          |
-| `required` | `required`  | Make the Toggle required                                                    | `boolean`      | `false`              |
-| `size`     | `size`      | Size of the Toggle                                                          | `"lg" \| "sm"` | `'lg'`               |
-| `toggleId` | `toggle-id` | ID of the Toggle's input element, if not specified, it's randomly generated | `string`       | `generateUniqueId()` |
+| Property       | Attribute        | Description                                                                 | Type           | Default              |
+| -------------- | ---------------- | --------------------------------------------------------------------------- | -------------- | -------------------- |
+| `checked`      | `checked`        | Sets the Toggle as checked                                                  | `boolean`      | `false`              |
+| `disabled`     | `disabled`       | Sets the Toggle in a disabled state                                         | `boolean`      | `false`              |
+| `headline`     | `headline`       | Headline for the Toggle                                                     | `string`       | `undefined`          |
+| `name`         | `name`           | Name of the toggle's input element                                          | `string`       | `undefined`          |
+| `required`     | `required`       | Make the Toggle required                                                    | `boolean`      | `false`              |
+| `size`         | `size`           | Size of the Toggle                                                          | `"lg" \| "sm"` | `'lg'`               |
+| `tdsAriaLabel` | `tds-aria-label` | Defines aria-label attribute for input                                      | `string`       | `undefined`          |
+| `toggleId`     | `toggle-id`      | ID of the Toggle's input element, if not specified, it's randomly generated | `string`       | `generateUniqueId()` |
 
 
 ## Events

--- a/packages/core/src/components/toggle/test/default/toggle.axe.ts
+++ b/packages/core/src/components/toggle/test/default/toggle.axe.ts
@@ -2,7 +2,7 @@ import { test } from 'stencil-playwright';
 import { expect } from '@playwright/test';
 import { tegelAnalyze } from '../../../../utils/axeHelpers';
 
-const componentTestPath = 'src/components/banner/test/default/index.html';
+const componentTestPath = 'src/components/toggle/test/default/index.html';
 
 test.describe.parallel('Toggle accessibility test', () => {
   test('Should render without detected accessibility issues', async ({ page }) => {

--- a/packages/core/src/components/toggle/test/default/toggle.axe.ts
+++ b/packages/core/src/components/toggle/test/default/toggle.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/banner/test/default/index.html';
+
+test.describe.parallel('Toggle accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/core/src/components/toggle/toggle.stories.tsx
+++ b/packages/core/src/components/toggle/toggle.stories.tsx
@@ -83,7 +83,7 @@ const Template = ({ size, headline, label, checked, disabled }) =>
         ${disabled ? 'disabled' : ''}
         ${headline ? `headline="${headline}"` : ''}
         size="${size === 'Large' ? 'lg' : 'sm'}">
-        <div slot="label">${label}</div>
+        ${label && `<div slot="label">${label}</div>`}
     </tds-toggle>
 
     <!-- Script tag with eventlistener for demo purposes. -->

--- a/packages/core/src/components/toggle/toggle.stories.tsx
+++ b/packages/core/src/components/toggle/toggle.stories.tsx
@@ -79,6 +79,7 @@ export default {
 const Template = ({ size, headline, label, checked, disabled }) =>
   formatHtmlPreview(`
       <tds-toggle
+        ${label && `tds-aria-label="${label}"`}
         ${checked ? 'checked' : ''}
         ${disabled ? 'disabled' : ''}
         ${headline ? `headline="${headline}"` : ''}

--- a/packages/core/src/components/toggle/toggle.tsx
+++ b/packages/core/src/components/toggle/toggle.tsx
@@ -34,6 +34,11 @@ export class TdsToggle {
   /** ID of the Toggle's input element, if not specified, it's randomly generated */
   @Prop() toggleId: string = generateUniqueId();
 
+  /** Defines aria-label attribute for input */
+  @Prop() tdsAriaLabel: string;
+
+  private labelSlot: HTMLElement;
+
   /** Toggles the Toggle. */
   @Method()
   async toggle() {
@@ -64,6 +69,10 @@ export class TdsToggle {
     });
   };
 
+  componentWillLoad() {
+    this.labelSlot = this.host.querySelector("[slot='label']");
+  }
+
   render() {
     return (
       <div class="tds-toggle">
@@ -78,6 +87,7 @@ export class TdsToggle {
           </div>
         )}
         <input
+          aria-label={this.tdsAriaLabel}
           aria-describedby={this.host.getAttribute('aria-describedby')}
           aria-labelledby={this.host.getAttribute('aria-labelledby')}
           aria-checked={this.checked}
@@ -92,9 +102,11 @@ export class TdsToggle {
           id={this.toggleId}
           role="switch"
         />
-        <label class={{ disabled: this.disabled }} htmlFor={this.toggleId}>
-          <slot name="label"></slot>
-        </label>
+        {this.labelSlot && (
+          <label class={{ disabled: this.disabled }} htmlFor={this.toggleId}>
+            <slot name="label"></slot>
+          </label>
+        )}
       </div>
     );
   }

--- a/packages/core/src/components/toggle/toggle.tsx
+++ b/packages/core/src/components/toggle/toggle.tsx
@@ -73,6 +73,12 @@ export class TdsToggle {
     this.labelSlot = this.host.querySelector("[slot='label']");
   }
 
+  connectedCallback() {
+    if (!this.tdsAriaLabel) {
+      console.warn('Tegel Toggle component: tdsAriaLabel prop is missing');
+    }
+  }
+
   render() {
     return (
       <div class="tds-toggle">


### PR DESCRIPTION
## **Describe pull-request**  
Added accessibility test and `aria-label`.
Removed lingering label object in dom if no label slot is provided.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [[CDEP-430](https://jira.scania.com/browse/CDEP-)](https://jira.scania.com/browse/CDEP-430)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to amplify link
2. Navigate to toggle component
3. Change label text in controls should change `aria-label` & remove text in controls should remove label object in dom

## **Checklist before submission**
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors


## **Additional context**  
Do think we can skip refactoring the focus state, this is good enough in my opinion but will of course run this by designers even if we merge this PR as is.
![Screenshot 2025-03-14 at 11 03 39](https://github.com/user-attachments/assets/c9b1833c-0951-48fa-a1b3-b75903dab2d4)

![Screenshot 2025-03-14 at 11 03 46](https://github.com/user-attachments/assets/2be4cdd6-ee95-4c19-9b62-eede3e29fa94)
