### PR TITLE
feat(table): improve accessibility 

### DIFF
--- a/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
+++ b/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
@@ -128,6 +128,7 @@ export class TdsTableBodyCell {
           'tds-table--no-min-width': this.noMinWidth,
         }}
         style={dynamicStyles}
+        role="cell"
       >
         {this.cellValue}
         <slot />

--- a/packages/core/src/components/table/table-body-input-wrapper/table-body-input-wrapper.tsx
+++ b/packages/core/src/components/table/table-body-input-wrapper/table-body-input-wrapper.tsx
@@ -79,6 +79,30 @@ export class TdsTableBodyInputWrapper {
       input.addEventListener('blur', () => {
         this.inputFocused = false;
       });
+
+      // Handle Enter key event
+      input.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          this.moveToNextEditableCell();
+        }
+      });
+    }
+  }
+
+  private moveToNextEditableCell() {
+    const allEditableCells = Array.from(
+      document.querySelectorAll('tds-table-body-input-wrapper'),
+    ) as HTMLTdsTableBodyInputWrapperElement[];
+
+    const currentIndex = allEditableCells.indexOf(this.host as HTMLTdsTableBodyInputWrapperElement);
+
+    if (currentIndex !== -1 && currentIndex < allEditableCells.length - 1) {
+      const nextCell = allEditableCells[currentIndex + 1];
+      const nextInput = nextCell.querySelector('input') as HTMLInputElement;
+      if (nextInput) {
+        nextInput.focus();
+      }
     }
   }
 

--- a/packages/core/src/components/table/table-body-row-expandable/readme.md
+++ b/packages/core/src/components/table/table-body-row-expandable/readme.md
@@ -53,13 +53,14 @@ We recommend fitting your content within the table’s natural size whenever pos
 
 ## Properties
 
-| Property       | Attribute       | Description                                                                                                                               | Type                              | Default              |
-| -------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | -------------------- |
-| `autoCollapse` | `auto-collapse` | Enables auto-collapse of other expandable rows when one row is expanded                                                                   | `boolean`                         | `false`              |
-| `colSpan`      | `col-span`      | In case that automatic count of columns does not work, user can manually set this one. Take in mind that expandable control is column too | `number`                          | `null`               |
-| `expanded`     | `expanded`      | Sets isExpanded state to true or false externally                                                                                         | `boolean`                         | `undefined`          |
-| `overflow`     | `overflow`      | Controls the overflow behavior of the expandable row content                                                                              | `"auto" \| "hidden" \| "visible"` | `'auto'`             |
-| `rowId`        | `row-id`        | ID for the table row. Randomly generated if not specified.                                                                                | `string`                          | `generateUniqueId()` |
+| Property                   | Attribute                      | Description                                                                                                                               | Type                              | Default              |
+| -------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | -------------------- |
+| `autoCollapse`             | `auto-collapse`                | Enables auto-collapse of other expandable rows when one row is expanded                                                                   | `boolean`                         | `false`              |
+| `colSpan`                  | `col-span`                     | In case that automatic count of columns does not work, user can manually set this one. Take in mind that expandable control is column too | `number`                          | `null`               |
+| `expanded`                 | `expanded`                     | Sets isExpanded state to true or false externally                                                                                         | `boolean`                         | `undefined`          |
+| `overflow`                 | `overflow`                     | Controls the overflow behavior of the expandable row content                                                                              | `"auto" \| "hidden" \| "visible"` | `'auto'`             |
+| `rowId`                    | `row-id`                       | ID for the table row. Randomly generated if not specified.                                                                                | `string`                          | `generateUniqueId()` |
+| `tdsAriaLabelExpandButton` | `tds-aria-label-expand-button` | Aria label for the expand button, providing an accessible description                                                                     | `string`                          | `''`                 |
 
 
 ## Events

--- a/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -201,6 +201,7 @@ export class TdsTableBodyRowExpandable {
             'tds-table__row--expanded': this.isExpanded,
           }}
           part="row"
+          aria-expanded={this.isExpanded}
         >
           <td
             class={{

--- a/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -53,6 +53,9 @@ export class TdsTableBodyRowExpandable {
   /** Enables auto-collapse of other expandable rows when one row is expanded */
   @Prop() autoCollapse: boolean = false;
 
+  /** Aria label for the expand button, providing an accessible description */
+  @Prop({ reflect: true }) tdsAriaLabelExpandButton: string = '';
+
   /** Sets isExpanded state to true or fals internally */
   @State() isExpanded: boolean = false;
 
@@ -212,6 +215,7 @@ export class TdsTableBodyRowExpandable {
                 checked={this.isExpanded}
                 aria-expanded={this.isExpanded ? 'true' : 'false'}
                 aria-controls={`expandable-content-${this.rowId}`}
+                aria-label={this.tdsAriaLabelExpandButton}
               />
               <span class="tds-expendable-row-icon">
                 <svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">

--- a/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -192,12 +192,12 @@ export class TdsTableBodyRowExpandable {
         }}
       >
         <tr
+          id={`expandable-content-${this.rowId}`}
           class={{
             'tds-table__row': true,
             'tds-table__row--expanded': this.isExpanded,
           }}
           part="row"
-          aria-expanded={this.isExpanded}
         >
           <td
             class={{
@@ -210,6 +210,8 @@ export class TdsTableBodyRowExpandable {
                 type="checkbox"
                 onChange={(event) => this.onChangeHandler(event)}
                 checked={this.isExpanded}
+                aria-expanded={this.isExpanded ? 'true' : 'false'}
+                aria-controls={`expandable-content-${this.rowId}`}
               />
               <span class="tds-expendable-row-icon">
                 <svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">

--- a/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -197,6 +197,7 @@ export class TdsTableBodyRowExpandable {
             'tds-table__row--expanded': this.isExpanded,
           }}
           part="row"
+          aria-expanded={this.isExpanded}
         >
           <td
             class={{

--- a/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/packages/core/src/components/table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -201,7 +201,6 @@ export class TdsTableBodyRowExpandable {
             'tds-table__row--expanded': this.isExpanded,
           }}
           part="row"
-          aria-expanded={this.isExpanded}
         >
           <td
             class={{

--- a/packages/core/src/components/table/table-body-row/table-body-row.tsx
+++ b/packages/core/src/components/table/table-body-row/table-body-row.tsx
@@ -145,6 +145,7 @@ export class TdsTableBodyRow {
         }}
         onClick={(e) => this.handleRowClick(e)}
         onKeyDown={(e) => this.handleKeyDown(e)}
+        role="row"
       >
         {this.multiselect && (
           <td class="tds-table__body-cell tds-table__body-cell--checkbox tds-form-label tds-form-label--table">

--- a/packages/core/src/components/table/table-component-editable-cells.stories.tsx
+++ b/packages/core/src/components/table/table-component-editable-cells.stories.tsx
@@ -195,258 +195,274 @@ const EditableCellsTemplate = ({
   column4Width,
 }) =>
   formatHtmlPreview(`
-  <tds-table
-      vertical-dividers="${verticalDivider}"
-      compact-design="${compactDesign}"
-      responsive="${responsiveDesign}"
-      ${noMinWidth ? 'no-min-width' : ''}
-      ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}
-      ${horizontalScrollWidth ? `horizontal-scroll-width="${horizontalScrollWidth}"` : ''}
-    >
-      <tds-table-header >
-          <tds-header-cell cell-key='truck' cell-value='Truck type' disable-padding="${disableHeaderPadding}" ${
+
+  <div>
+    <style>
+      label {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        border: 0;
+      }
+    </style>
+    <tds-table
+  vertical-dividers="${verticalDivider}"
+  compact-design="${compactDesign}"
+  responsive="${responsiveDesign}"
+  ${noMinWidth ? 'no-min-width' : ''}
+  ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}
+  ${horizontalScrollWidth ? `horizontal-scroll-width="${horizontalScrollWidth}"` : ''}
+>
+  <tds-table-header>
+    <tds-header-cell cell-key="truck" cell-value="Truck type" disable-padding="${disableHeaderPadding}" ${
     column1Width ? `custom-width="${column1Width}"` : ''
   } text-align="${headerTextAlignment}"></tds-header-cell>
-          <tds-header-cell cell-key='driver' cell-value='Driver name' disable-padding="${disableHeaderPadding}" ${
+    <tds-header-cell cell-key="driver" cell-value="Driver name" disable-padding="${disableHeaderPadding}" ${
     column2Width ? `custom-width="${column2Width}"` : ''
   } text-align="${headerTextAlignment}"></tds-header-cell>
-          <tds-header-cell cell-key='country' cell-value='Country' disable-padding="${disableHeaderPadding}" ${
+    <tds-header-cell cell-key="country" cell-value="Country" disable-padding="${disableHeaderPadding}" ${
     column3Width ? `custom-width="${column3Width}"` : ''
   } text-align="${headerTextAlignment}"></tds-header-cell>
-          <tds-header-cell cell-key='mileage' cell-value='Mileage' disable-padding="${disableHeaderPadding}" ${
+    <tds-header-cell cell-key="mileage" cell-value="Mileage" disable-padding="${disableHeaderPadding}" ${
     column4Width ? `custom-width="${column4Width}"` : ''
   } text-align="${headerTextAlignment}"></tds-header-cell>
-      </tds-table-header>
-      <tds-table-body>
-          <tds-table-body-row>
-              <tds-body-cell cell-key="truck" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 1"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="driver" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 2"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="country" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 3"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="mileage" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 4"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-          </tds-table-body-row>
-          <tds-table-body-row>
-              <tds-body-cell cell-key="truck" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 5"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="driver" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 6"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="country" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 7"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="mileage" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 8"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-          </tds-table-body-row>
-          <tds-table-body-row>
-              <tds-body-cell cell-key="truck" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 1"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="driver" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 2"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="country" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 3"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="mileage" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 4"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-          </tds-table-body-row>
-          <tds-table-body-row>
-              <tds-body-cell cell-key="truck" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 5"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="driver" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 6"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="country" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 7"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="mileage" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 8"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-          </tds-table-body-row>
-          <tds-table-body-row>
-              <tds-body-cell cell-key="truck" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 1"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="driver" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 2"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="country" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 3"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="mileage" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 4"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-          </tds-table-body-row>
-          <tds-table-body-row>
-              <tds-body-cell cell-key="truck" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 5"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="driver" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 6"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="country" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 7"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-              <tds-body-cell cell-key="mileage" disable-padding="true" ${
-                cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }> <tds-table-body-input-wrapper>
-      <input
-        type="text"
-        value="Test value 8"
-      />
-    </tds-table-body-input-wrapper>
-  </tds-body-cell>
-          </tds-table-body-row>
-      </tds-table-body>
-  </tds-table>`);
+  </tds-table-header>
+
+  <tds-table-body>
+    <tds-table-body-row>
+      <tds-body-cell cell-key="truck" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="truck-input-1">Truck type</label>
+          <input id="truck-input-1" type="text" value="Test value 1" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="driver" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="driver-input-1">Driver name</label>
+          <input id="driver-input-1" type="text" value="Test value 2" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="country" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="country-input-1">Country</label>
+          <input id="country-input-1" type="text" value="Test value 3" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="mileage" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="mileage-input-1">Mileage</label>
+          <input id="mileage-input-1" type="text" value="Test value 4" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+    </tds-table-body-row>
+
+    <tds-table-body-row>
+      <tds-body-cell cell-key="truck" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="truck-input-2">Truck type</label>
+          <input id="truck-input-2" type="text" value="Test value 5" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="driver" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="driver-input-2">Driver name</label>
+          <input id="driver-input-2" type="text" value="Test value 6" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="country" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="country-input-2">Country</label>
+          <input id="country-input-2" type="text" value="Test value 7" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="mileage" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="mileage-input-2">Mileage</label>
+          <input id="mileage-input-2" type="text" value="Test value 8" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+    </tds-table-body-row>
+
+    <tds-table-body-row>
+      <tds-body-cell cell-key="truck" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="truck-input-3">Truck type</label>
+          <input id="truck-input-3" type="text" value="Test value 1" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="driver" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="driver-input-3">Driver name</label>
+          <input id="driver-input-3" type="text" value="Test value 2" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="country" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="country-input-3">Country</label>
+          <input id="country-input-3" type="text" value="Test value 3" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="mileage" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="mileage-input-3">Mileage</label>
+          <input id="mileage-input-3" type="text" value="Test value 4" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+    </tds-table-body-row>
+
+    <tds-table-body-row>
+      <tds-body-cell cell-key="truck" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="truck-input-4">Truck type</label>
+          <input id="truck-input-4" type="text" value="Test value 5" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="driver" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="driver-input-4">Driver name</label>
+          <input id="driver-input-4" type="text" value="Test value 6" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="country" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="country-input-4">Country</label>
+          <input id="country-input-4" type="text" value="Test value 7" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="mileage" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="mileage-input-4">Mileage</label>
+          <input id="mileage-input-4" type="text" value="Test value 8" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+    </tds-table-body-row>
+
+    <tds-table-body-row>
+      <tds-body-cell cell-key="truck" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="truck-input-5">Truck type</label>
+          <input id="truck-input-5" type="text" value="Test value 1" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="driver" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="driver-input-5">Driver name</label>
+          <input id="driver-input-5" type="text" value="Test value 2" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="country" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="country-input-5">Country</label>
+          <input id="country-input-5" type="text" value="Test value 3" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="mileage" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="mileage-input-5">Mileage</label>
+          <input id="mileage-input-5" type="text" value="Test value 4" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+    </tds-table-body-row>
+
+    <tds-table-body-row>
+      <tds-body-cell cell-key="truck" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="truck-input-6">Truck type</label>
+          <input id="truck-input-6" type="text" value="Test value 5" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="driver" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="driver-input-6">Driver name</label>
+          <input id="driver-input-6" type="text" value="Test value 6" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="country" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="country-input-6">Country</label>
+          <input id="country-input-6" type="text" value="Test value 7" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+
+      <tds-body-cell cell-key="mileage" disable-padding="true" ${
+        cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
+      }>
+        <tds-table-body-input-wrapper>
+          <label for="mileage-input-6">Mileage</label>
+          <input id="mileage-input-6" type="text" value="Test value 8" />
+        </tds-table-body-input-wrapper>
+      </tds-body-cell>
+    </tds-table-body-row>
+  </tds-table-body>
+</tds-table>
+  </div>  
+  `);
 
 export const EditableCells = EditableCellsTemplate.bind({});

--- a/packages/core/src/components/table/table-component-filtering.stories.tsx
+++ b/packages/core/src/components/table/table-component-filtering.stories.tsx
@@ -150,7 +150,7 @@ const FilteringTemplate = ({
       ${noMinWidth ? 'no-min-width' : ''}
       ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}
   >
-          <tds-table-toolbar table-title="Filter" filter></tds-table-toolbar>
+          <tds-table-toolbar table-title="Filter" tds-search-aria-label="Input for filtering" filter></tds-table-toolbar>
           <tds-table-header>
               <tds-header-cell cell-key='truck' cell-value='Truck type' ${
                 column1Width ? `custom-width="${column1Width}"` : ''

--- a/packages/core/src/components/table/table-component-filtering.stories.tsx
+++ b/packages/core/src/components/table/table-component-filtering.stories.tsx
@@ -208,14 +208,18 @@ const FilteringTemplate = ({
   </tds-table>
   <!-- Note: Code below is just for demo purposes -->
   <div class="tds-u-mt1" style="width: 500px; background-color: lightblue; padding: 16px;">
-  <p class="tds-u-mt0">Note: This box works only in "Canvas" tab.</p>
+    <p class="tds-u-mt0">Note: This box works only in "Canvas" tab.</p>
     <h5 class="tds-u-mt0 tds-u-mb0">Event test box</h5>
+
     <h6 class="tds-u-mt1 tds-u-mb0">Event name:</h6>
+    <label for="event-name-textarea" class="tds-u-visually-hidden">Event Name</label>
     <textarea id="event-name-textarea" rows="1" cols="50" readonly></textarea>
+
     <h6 class="tds-u-mt0 tds-u-mb0">Events value (aka detail)</h6>
-    <br>
+    <label for="event-value-textarea" class="tds-u-visually-hidden">Event Value</label>
     <textarea id="event-value-textarea" rows="4" cols="50" readonly></textarea>
   </div>
+
   
   <script>  
   

--- a/packages/core/src/components/table/table-component-horizontal-scroll.stories.tsx
+++ b/packages/core/src/components/table/table-component-horizontal-scroll.stories.tsx
@@ -229,14 +229,18 @@ const HorizontalScrollTemplate = ({
   </tds-table>
   <!-- Note: Code below is just for demo purposes -->
   <div class="tds-u-mt1" style="width: 500px; background-color: lightblue; padding: 16px;">
-  <p class="tds-u-mt0">Note: This box works only in "Canvas" tab.</p>
+    <p class="tds-u-mt0">Note: This box works only in "Canvas" tab.</p>
     <h5 class="tds-u-mt0 tds-u-mb0">Event test box</h5>
+
     <h6 class="tds-u-mt1 tds-u-mb0">Event name:</h6>
+    <label for="event-name-textarea" class="sr-only">Event name</label>
     <textarea id="event-name-textarea" rows="1" cols="50" readonly></textarea>
+
     <h6 class="tds-u-mt0 tds-u-mb0">Events value (aka detail)</h6>
-    <br>
+    <label for="event-value-textarea" class="sr-only">Event value</label>
     <textarea id="event-value-textarea" rows="4" cols="50" readonly></textarea>
   </div>
+
   
 
   <script>

--- a/packages/core/src/components/table/table-component-multiselect.stories.tsx
+++ b/packages/core/src/components/table/table-component-multiselect.stories.tsx
@@ -228,17 +228,26 @@ const MultiselectTemplate = ({
   </tds-table>
   <!-- Note: Code below is just for demo purposes -->
   <div class="tds-u-mt1" style="width: 500px; background-color: lightblue; padding: 16px;">
-  <p class="tds-u-mt0">Note: This box works only in "Canvas" tab.</p>
+    <p class="tds-u-mt0">Note: This box works only in "Canvas" tab.</p>
     <h5 class="tds-u-mt0 tds-u-mb0">Event test box</h5>
+
     <h6 class="tds-u-mt1 tds-u-mb0">Event name:</h6>
+    <label for="event-name-textarea" class="sr-only">Event Name</label>
     <textarea id="event-name-textarea" rows="1" cols="50" readonly></textarea>
+
     <br><br>
-    <h6 class="tds-u-mt0 tds-u-mb0">Events value (aka detail)</h6>
+
+    <h6 class="tds-u-mt0 tds-u-mb0">Events value (aka detail):</h6>
+    <label for="event-value-textarea" class="sr-only">Event Value</label>
     <textarea id="event-value-textarea" rows="4" cols="50" readonly></textarea>
+
     <br><br>
-    <h6 class="tds-u-mt0 tds-u-mb0">Selected rows</h6>
-    <textarea  id="selected-rows-textarea" rows="4" cols="50" readonly></textarea>
+
+    <h6 class="tds-u-mt0 tds-u-mb0">Selected rows:</h6>
+    <label for="selected-rows-textarea" class="sr-only">Selected Rows</label>
+    <textarea id="selected-rows-textarea" rows="4" cols="50" readonly></textarea>
   </div>  
+
   <script>
   // Note: Script here is only for demo purposes
 

--- a/packages/core/src/components/table/table-component-pagination.stories.tsx
+++ b/packages/core/src/components/table/table-component-pagination.stories.tsx
@@ -240,14 +240,18 @@ const PaginationTemplate = ({
   </tds-table>
   <!-- Note: Code below is just for demo purposes -->
   <div class="tds-u-mt1" style="width: 500px; background-color: lightblue; padding: 16px;">
-  <p class="tds-u-mt0">Note: This box works only in "Canvas" tab.</p>
+    <p class="tds-u-mt0">Note: This box works only in "Canvas" tab.</p>
     <h5 class="tds-u-mt0 tds-u-mb0">Event test box</h5>
+
     <h6 class="tds-u-mt1 tds-u-mb0">Event name:</h6>
+    <label for="event-name-textarea" class="sr-only">Event Name</label>
     <textarea id="event-name-textarea" rows="1" cols="50" readonly></textarea>
+
     <h6 class="tds-u-mt0 tds-u-mb0">Events value (aka detail)</h6>
-    <br>
+    <label for="event-value-textarea" class="sr-only">Event Value</label>
     <textarea id="event-value-textarea" rows="4" cols="50" readonly></textarea>
   </div>
+
   
 
   <script>

--- a/packages/core/src/components/table/table-component-sorting.stories.tsx
+++ b/packages/core/src/components/table/table-component-sorting.stories.tsx
@@ -269,14 +269,20 @@ const SortingTemplate = ({
   </tds-table>
   <!-- Note: Code below is just for demo purposes -->
   <div class="tds-u-mt1" style="width: 500px; background-color: lightblue; padding: 16px;">
-  <p class="tds-u-mt0">Note: This box works only in "Canvas" tab.</p>
+    <p class="tds-u-mt0">Note: This box works only in "Canvas" tab.</p>
     <h5 class="tds-u-mt0 tds-u-mb0">Event test box</h5>
-    <h6 class="tds-u-mt1 tds-u-mb0">Event name:</h6>
+
+    <label for="event-name-textarea" class="tds-u-mt1 tds-u-mb0">
+      <h6 class="tds-u-mt1 tds-u-mb0">Event name:</h6>
+    </label>
     <textarea id="event-name-textarea" rows="1" cols="50" readonly></textarea>
-    <h6 class="tds-u-mt0 tds-u-mb0">Events value (aka detail)</h6>
-    <br>
+
+    <label for="event-value-textarea" class="tds-u-mt0 tds-u-mb0">
+      <h6 class="tds-u-mt0 tds-u-mb0">Events value (aka detail)</h6>
+    </label>
     <textarea id="event-value-textarea" rows="4" cols="50" readonly></textarea>
   </div>
+
   
   
   <script>    

--- a/packages/core/src/components/table/table-component-sorting.stories.tsx
+++ b/packages/core/src/components/table/table-component-sorting.stories.tsx
@@ -157,18 +157,6 @@ export default {
       },
       if: { arg: 'noMinWidth', eq: true },
     },
-    tdsAriaSort: {
-      name: 'Aria Sort Value',
-      description:
-        'Aria sort value, default is "none". Other accepted values are "ascending" or "descending".',
-      control: {
-        type: 'select',
-      },
-      options: ['none', 'ascending', 'descending'],
-      table: {
-        defaultValue: { summary: 'none' },
-      },
-    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -184,7 +172,6 @@ export default {
     column2Width: '',
     column3Width: '',
     column4Width: '',
-    tdsAriaSort: 'none',
   },
 };
 
@@ -202,7 +189,6 @@ const SortingTemplate = ({
   column2Width,
   column3Width,
   column4Width,
-  tdsAriaSort,
 }) =>
   formatHtmlPreview(`
     <tds-table
@@ -217,16 +203,16 @@ const SortingTemplate = ({
           <tds-table-header>
               <tds-header-cell cell-key='truck' cell-value='Truck type' sortable="${column1sortable}" ${
     column1Width ? `custom-width="${column1Width}"` : ''
-  } tds-aria-sort="${tdsAriaSort}"></tds-header-cell>
+  }></tds-header-cell>
               <tds-header-cell cell-key='driver' cell-value='Driver name' sortable="${column2sortable}" ${
     column2Width ? `custom-width="${column2Width}"` : ''
-  } tds-aria-sort="${tdsAriaSort}"></tds-header-cell>
+  }></tds-header-cell>
               <tds-header-cell cell-key='country' cell-value='Country' sortable="${column3sortable}" ${
     column3Width ? `custom-width="${column3Width}"` : ''
-  } tds-aria-sort="${tdsAriaSort}"></tds-header-cell>
+  }></tds-header-cell>
               <tds-header-cell cell-key='mileage' cell-value='Mileage' sortable="${column4sortable}" text-align='right' ${
     column4Width ? `custom-width="${column4Width}"` : ''
-  } tds-aria-sort="${tdsAriaSort}"></tds-header-cell>
+  }></tds-header-cell>
           </tds-table-header>
           <tds-table-body>
             <tds-table-body-row>

--- a/packages/core/src/components/table/table-component-sorting.stories.tsx
+++ b/packages/core/src/components/table/table-component-sorting.stories.tsx
@@ -157,6 +157,18 @@ export default {
       },
       if: { arg: 'noMinWidth', eq: true },
     },
+    tdsAriaSort: {
+      name: 'Aria Sort Value',
+      description:
+        'Aria sort value, default is "none". Other accepted values are "ascending" or "descending".',
+      control: {
+        type: 'select',
+      },
+      options: ['none', 'ascending', 'descending'],
+      table: {
+        defaultValue: { summary: 'none' },
+      },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -172,6 +184,7 @@ export default {
     column2Width: '',
     column3Width: '',
     column4Width: '',
+    tdsAriaSort: 'none',
   },
 };
 
@@ -189,6 +202,7 @@ const SortingTemplate = ({
   column2Width,
   column3Width,
   column4Width,
+  tdsAriaSort,
 }) =>
   formatHtmlPreview(`
     <tds-table
@@ -203,16 +217,16 @@ const SortingTemplate = ({
           <tds-table-header>
               <tds-header-cell cell-key='truck' cell-value='Truck type' sortable="${column1sortable}" ${
     column1Width ? `custom-width="${column1Width}"` : ''
-  }></tds-header-cell>
+  } tds-aria-sort="${tdsAriaSort}"></tds-header-cell>
               <tds-header-cell cell-key='driver' cell-value='Driver name' sortable="${column2sortable}" ${
     column2Width ? `custom-width="${column2Width}"` : ''
-  }></tds-header-cell>
+  } tds-aria-sort="${tdsAriaSort}"></tds-header-cell>
               <tds-header-cell cell-key='country' cell-value='Country' sortable="${column3sortable}" ${
     column3Width ? `custom-width="${column3Width}"` : ''
-  }></tds-header-cell>
+  } tds-aria-sort="${tdsAriaSort}"></tds-header-cell>
               <tds-header-cell cell-key='mileage' cell-value='Mileage' sortable="${column4sortable}" text-align='right' ${
     column4Width ? `custom-width="${column4Width}"` : ''
-  }></tds-header-cell>
+  } tds-aria-sort="${tdsAriaSort}"></tds-header-cell>
           </tds-table-header>
           <tds-table-body>
             <tds-table-body-row>

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -14,6 +14,7 @@
 | `customWidth`    | `custom-width`    | In case noMinWidth is set, the user has to specify the width value for each column.                     | `string`                                            | `undefined` |
 | `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                | `boolean`                                           | `false`     |
 | `sortable`       | `sortable`        | Enables sorting on that column                                                                          | `boolean`                                           | `false`     |
+| `tdsAriaSort`    | `tds-aria-sort`   | Aria sort value, default is "none". Other accepted values are "ascending" or "descending".              | `"ascending" \| "descending" \| "none"`             | `'none'`    |
 | `textAlign`      | `text-align`      | Setting for text align, default is "left". Other accepted values are "left", "start", "right" or "end". | `"center" \| "end" \| "left" \| "right" \| "start"` | `'left'`    |
 
 

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -15,7 +15,6 @@
 | `disablePadding`         | `disable-padding`            | Disables internal padding. Useful when passing other components to cell.                                | `boolean`                                           | `false`     |
 | `sortable`               | `sortable`                   | Enables sorting on that column                                                                          | `boolean`                                           | `false`     |
 | `tdsAriaLabelSortButton` | `tds-aria-label-sort-button` | Aria label for the sort button, providing an accessible description                                     | `string`                                            | `''`        |
-| `tdsAriaSort`            | `tds-aria-sort`              | Aria sort value, default is "none". Other accepted values are "ascending" or "descending".              | `"ascending" \| "descending" \| "none"`             | `'none'`    |
 | `textAlign`              | `text-align`                 | Setting for text align, default is "left". Other accepted values are "left", "start", "right" or "end". | `"center" \| "end" \| "left" \| "right" \| "start"` | `'left'`    |
 
 

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -7,15 +7,16 @@
 
 ## Properties
 
-| Property         | Attribute         | Description                                                                                             | Type                                                | Default     |
-| ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------- |
-| `cellKey`        | `cell-key`        | The value of column key, usually comes from JSON, needed for sorting                                    | `string`                                            | `undefined` |
-| `cellValue`      | `cell-value`      | Text that displays in column cell                                                                       | `string`                                            | `undefined` |
-| `customWidth`    | `custom-width`    | In case noMinWidth is set, the user has to specify the width value for each column.                     | `string`                                            | `undefined` |
-| `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                | `boolean`                                           | `false`     |
-| `sortable`       | `sortable`        | Enables sorting on that column                                                                          | `boolean`                                           | `false`     |
-| `tdsAriaSort`    | `tds-aria-sort`   | Aria sort value, default is "none". Other accepted values are "ascending" or "descending".              | `"ascending" \| "descending" \| "none"`             | `'none'`    |
-| `textAlign`      | `text-align`      | Setting for text align, default is "left". Other accepted values are "left", "start", "right" or "end". | `"center" \| "end" \| "left" \| "right" \| "start"` | `'left'`    |
+| Property                 | Attribute                    | Description                                                                                             | Type                                                | Default     |
+| ------------------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------- |
+| `cellKey`                | `cell-key`                   | The value of column key, usually comes from JSON, needed for sorting                                    | `string`                                            | `undefined` |
+| `cellValue`              | `cell-value`                 | Text that displays in column cell                                                                       | `string`                                            | `undefined` |
+| `customWidth`            | `custom-width`               | In case noMinWidth is set, the user has to specify the width value for each column.                     | `string`                                            | `undefined` |
+| `disablePadding`         | `disable-padding`            | Disables internal padding. Useful when passing other components to cell.                                | `boolean`                                           | `false`     |
+| `sortable`               | `sortable`                   | Enables sorting on that column                                                                          | `boolean`                                           | `false`     |
+| `tdsAriaLabelSortButton` | `tds-aria-label-sort-button` | Aria label for the sort button, providing an accessible description                                     | `string`                                            | `''`        |
+| `tdsAriaSort`            | `tds-aria-sort`              | Aria sort value, default is "none". Other accepted values are "ascending" or "descending".              | `"ascending" \| "descending" \| "none"`             | `'none'`    |
+| `textAlign`              | `text-align`                 | Setting for text align, default is "left". Other accepted values are "left", "start", "right" or "end". | `"center" \| "end" \| "left" \| "right" \| "start"` | `'left'`    |
 
 
 ## Events

--- a/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
+++ b/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
@@ -50,6 +50,9 @@ export class TdsTableHeaderCell {
   /** Aria sort value, default is "none". Other accepted values are "ascending" or "descending". */
   @Prop({ reflect: true }) tdsAriaSort?: 'ascending' | 'descending' | 'none' = 'none';
 
+  /** Aria label for the sort button, providing an accessible description */
+  @Prop({ reflect: true }) tdsAriaLabelSortButton?: string = '';
+
   @State() textAlignState: string;
 
   @State() sortingDirection: 'asc' | 'desc' | undefined;
@@ -207,6 +210,7 @@ export class TdsTableHeaderCell {
           class="tds-table__header-button"
           onClick={() => this.sortButtonClick()}
           style={{ justifyContent: this.textAlignState }}
+          aria-label={this.tdsAriaLabelSortButton}
         >
           <span class="tds-table__header-button-text">
             {this.cellValue}
@@ -214,10 +218,16 @@ export class TdsTableHeaderCell {
           </span>
 
           {this.sortingDirection === undefined && (
-            <tds-icon class="tds-table__header-button-icon" name="sorting" size="16px"></tds-icon>
+            <tds-icon
+              svgTitle="sorting"
+              class="tds-table__header-button-icon"
+              name="sorting"
+              size="16px"
+            ></tds-icon>
           )}
           {this.sortingDirection && ['asc', 'desc'].includes(this.sortingDirection) && (
             <tds-icon
+              svgTitle="arrow down"
               class={`tds-table__header-button-icon ${
                 this.sortingDirection === 'asc' ? 'tds-table__header-button-icon--rotate' : ''
               }`}

--- a/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
+++ b/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
@@ -47,6 +47,9 @@ export class TdsTableHeaderCell {
   /** Disables internal padding. Useful when passing other components to cell. */
   @Prop({ reflect: true }) disablePadding: boolean = false;
 
+  /** Aria sort value, default is "none". Other accepted values are "ascending" or "descending". */
+  @Prop({ reflect: true }) tdsAriaSort?: 'ascending' | 'descending' | 'none' = 'none';
+
   @State() textAlignState: string;
 
   @State() sortingDirection: 'asc' | 'desc' | undefined;
@@ -265,6 +268,7 @@ export class TdsTableHeaderCell {
         onMouseOver={() => this.onHeadCellHover(this.cellKey)}
         onMouseLeave={() => this.onHeadCellHover('')}
         role="columnheader"
+        aria-sort={this.tdsAriaSort}
       >
         {this.headerCellContent()}
       </Host>

--- a/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
+++ b/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
@@ -47,9 +47,6 @@ export class TdsTableHeaderCell {
   /** Disables internal padding. Useful when passing other components to cell. */
   @Prop({ reflect: true }) disablePadding: boolean = false;
 
-  /** Aria sort value, default is "none". Other accepted values are "ascending" or "descending". */
-  @Prop({ reflect: true }) tdsAriaSort?: 'ascending' | 'descending' | 'none' = 'none';
-
   /** Aria label for the sort button, providing an accessible description */
   @Prop({ reflect: true }) tdsAriaLabelSortButton?: string = '';
 
@@ -259,6 +256,12 @@ export class TdsTableHeaderCell {
     });
   };
 
+  private getAriaSort(): 'ascending' | 'descending' | 'none' {
+    if (this.sortingDirection === 'asc') return 'ascending';
+    if (this.sortingDirection === 'desc') return 'descending';
+    return 'none';
+  }
+
   render() {
     return (
       <Host
@@ -278,7 +281,7 @@ export class TdsTableHeaderCell {
         onMouseOver={() => this.onHeadCellHover(this.cellKey)}
         onMouseLeave={() => this.onHeadCellHover('')}
         role="columnheader"
-        aria-sort={this.tdsAriaSort}
+        aria-sort={this.getAriaSort()}
       >
         {this.headerCellContent()}
       </Host>

--- a/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
+++ b/packages/core/src/components/table/table-header-cell/table-header-cell.tsx
@@ -264,6 +264,7 @@ export class TdsTableHeaderCell {
         style={{ minWidth: this.customWidth }}
         onMouseOver={() => this.onHeadCellHover(this.cellKey)}
         onMouseLeave={() => this.onHeadCellHover('')}
+        role="columnheader"
       >
         {this.headerCellContent()}
       </Host>

--- a/packages/core/src/components/table/table-header-input-wrapper/table-header-input-wrapper.tsx
+++ b/packages/core/src/components/table/table-header-input-wrapper/table-header-input-wrapper.tsx
@@ -94,7 +94,13 @@ export class TdsTableHeaderInputWrapper {
       >
         {this.renderSlot ? <slot onSlotchange={() => this.handleSlotChange()} /> : null}
         {this.showIcon ? (
-          <tds-icon class="search-icon" slot="icon" size="16px" name="search"></tds-icon>
+          <tds-icon
+            svgTitle="search"
+            class="search-icon"
+            slot="icon"
+            size="16px"
+            name="search"
+          ></tds-icon>
         ) : null}
       </Host>
     );

--- a/packages/core/src/components/table/table-toolbar/readme.md
+++ b/packages/core/src/components/table/table-toolbar/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property     | Attribute     | Description                  | Type      | Default |
-| ------------ | ------------- | ---------------------------- | --------- | ------- |
-| `filter`     | `filter`      | Enables preview of searchbar | `boolean` | `false` |
-| `tableTitle` | `table-title` | Adds title to the Table      | `string`  | `''`    |
+| Property             | Attribute               | Description                                                          | Type      | Default |
+| -------------------- | ----------------------- | -------------------------------------------------------------------- | --------- | ------- |
+| `filter`             | `filter`                | Enables preview of searchbar                                         | `boolean` | `false` |
+| `tableTitle`         | `table-title`           | Adds title to the Table                                              | `string`  | `''`    |
+| `tdsSearchAriaLabel` | `tds-search-aria-label` | Aria label for the search input, providing an accessible description | `string`  | `''`    |
 
 
 ## Events

--- a/packages/core/src/components/table/table-toolbar/table-toolbar.tsx
+++ b/packages/core/src/components/table/table-toolbar/table-toolbar.tsx
@@ -140,7 +140,7 @@ export class TdsTableToolbar {
                   class="tds-table__searchbar-input"
                   type="text"
                   onKeyUp={(event) => this.handleSearch(event)}
-                  aria-label={`Type here to filter table content`}
+                  aria-label={this.tdsSearchAriaLabel}
                 />
                 <span class="tds-table__searchbar-icon">
                   <tds-icon name="search" size="20px"></tds-icon>

--- a/packages/core/src/components/table/table-toolbar/table-toolbar.tsx
+++ b/packages/core/src/components/table/table-toolbar/table-toolbar.tsx
@@ -33,6 +33,9 @@ export class TdsTableToolbar {
   /** Enables preview of searchbar */
   @Prop({ reflect: true }) filter: boolean = false;
 
+  /** Aria label for the search input, providing an accessible description */
+  @Prop() tdsSearchAriaLabel: string = '';
+
   @State() verticalDividers: boolean = false;
 
   @State() compactDesign: boolean = false;
@@ -79,6 +82,10 @@ export class TdsTableToolbar {
   connectedCallback() {
     this.tableEl = this.host.closest('tds-table');
     this.tableId = this.tableEl.tableId;
+
+    if (!this.tdsSearchAriaLabel) {
+      console.warn('tds-table-toolbar: tdsSearchAriaLabel is highly recommended for accessibility');
+    }
   }
 
   componentWillLoad() {
@@ -120,9 +127,12 @@ export class TdsTableToolbar {
           'toolbar__horizontal-scroll': !!this.horizontalScrollWidth,
         }}
         style={this.getStyles()}
+        aria-labelledby="table-toolbar-title"
       >
         <div class="tds-table__upper-bar-flex">
-          <caption class="tds-table__title">{this.tableTitle}</caption>
+          <caption id="table-toolbar-title" class="tds-table__title">
+            {this.tableTitle}
+          </caption>
           <div class="tds-table__actionbar">
             {this.filter && (
               <div class="tds-table__searchbar">
@@ -130,6 +140,7 @@ export class TdsTableToolbar {
                   class="tds-table__searchbar-input"
                   type="text"
                   onKeyUp={(event) => this.handleSearch(event)}
+                  aria-label={`Type here to filter table content`}
                 />
                 <span class="tds-table__searchbar-icon">
                   <tds-icon name="search" size="20px"></tds-icon>

--- a/packages/core/src/components/table/table/test/default/table.axe.ts
+++ b/packages/core/src/components/table/table/test/default/table.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/table/table/test/default/index.html';
+
+test.describe.parallel('Table accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/core/src/components/table/table/test/expandable-row/interaction-1.e2e.ts
+++ b/packages/core/src/components/table/table/test/expandable-row/interaction-1.e2e.ts
@@ -17,13 +17,19 @@ testConfigurations.withModeVariants.forEach((config) => {
     });
 
     test('under first row opened expanded row with text "Hello world 1"', async ({ page }) => {
-      const tableBodyRowFirstInput = page.getByRole('cell').nth(1);
-      const tableBodyExpandableRowSlot = page.getByText(/Hello world 1/);
-      await expect(tableBodyRowFirstInput).toHaveCount(1);
+      const tableBodyRowFirstIcon = page
+        .locator('tds-table-body-row-expandable')
+        .first()
+        .locator('.tds-expendable-row-icon');
+      const tableBodyExpandableRowSlot = page
+        .locator('tds-table-body-row-expandable')
+        .first()
+        .locator('div[slot="expand-row"]');
+      await expect(tableBodyRowFirstIcon).toHaveCount(1);
       await expect(tableBodyExpandableRowSlot).toHaveCount(1);
       await expect(tableBodyExpandableRowSlot).toBeHidden();
 
-      await tableBodyRowFirstInput.click();
+      await tableBodyRowFirstIcon.click();
       await expect(tableBodyExpandableRowSlot).toBeVisible();
 
       /* check input screenshot diff */

--- a/packages/core/src/components/table/table/test/expandable-row/interaction-2.e2e.ts
+++ b/packages/core/src/components/table/table/test/expandable-row/interaction-2.e2e.ts
@@ -17,13 +17,19 @@ testConfigurations.withModeVariants.forEach((config) => {
     });
 
     test('under second row opened expanded row with text "Hello to you too"', async ({ page }) => {
-      const tableBodyRowSecondInput = page.getByRole('cell').nth(2);
-      const tableBodyExpandableRowSlot = page.getByText(/Hello to you too/);
-      await expect(tableBodyRowSecondInput).toHaveCount(1);
+      const tableBodyRowSecondIcon = page
+        .locator('tds-table-body-row-expandable')
+        .nth(1)
+        .locator('.tds-expendable-row-icon');
+      const tableBodyExpandableRowSlot = page
+        .locator('tds-table-body-row-expandable')
+        .nth(1)
+        .locator('div[slot="expand-row"]');
+      await expect(tableBodyRowSecondIcon).toHaveCount(1);
       await expect(tableBodyExpandableRowSlot).toHaveCount(1);
       await expect(tableBodyExpandableRowSlot).toBeHidden();
 
-      await tableBodyRowSecondInput.click();
+      await tableBodyRowSecondIcon.click();
       await expect(tableBodyExpandableRowSlot).toBeVisible();
 
       /* check input screenshot diff */

--- a/packages/core/src/components/table/table/test/expandable-row/interaction-3.e2e.ts
+++ b/packages/core/src/components/table/table/test/expandable-row/interaction-3.e2e.ts
@@ -19,13 +19,22 @@ testConfigurations.withModeVariants.forEach((config) => {
     test('under third row opened expanded row with a button with text "Call to action"', async ({
       page,
     }) => {
-      const tableBodyRowThirdInput = page.getByRole('cell').nth(3);
+      const tableBodyRowThirdIcon = page
+        .locator('tds-table-body-row-expandable')
+        .nth(2)
+        .locator('.tds-expendable-row-icon');
+
       const tableBodyRowButton = page.getByText(/Call to action/);
-      await expect(tableBodyRowThirdInput).toHaveCount(1);
+
+      await expect(tableBodyRowThirdIcon).toHaveCount(1);
       await expect(tableBodyRowButton).toHaveCount(1);
       await expect(tableBodyRowButton).toBeHidden();
 
-      await tableBodyRowThirdInput.click();
+      // Click on the expand icon for the third row
+      await tableBodyRowThirdIcon.click();
+
+      // Wait for the button to become visible
+      await tableBodyRowButton.waitFor({ state: 'visible' });
       await expect(tableBodyRowButton).toBeVisible();
 
       /* check input screenshot diff */

--- a/packages/core/src/components/table/table/test/multiselect/default/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/multiselect/default/table.e2e.ts
@@ -25,18 +25,23 @@ testConfigurations.withModeVariants.forEach((config) => {
     });
 
     test('can check every checkbox in the table', async ({ page }) => {
-      const tableCheckboxes = page.getByRole('cell');
-      await expect(tableCheckboxes).toHaveCount(5);
+      // Target the checkbox cells specifically
+      const tableCheckboxCells = page.locator('tds-table-body-row .tds-table__body-cell--checkbox');
+      await expect(tableCheckboxCells).toHaveCount(4);
+
+      // Also get the header checkbox cell
+      const headerCheckboxCell = page.locator('tds-table-header .tds-table__header-cell--checkbox');
+      await expect(headerCheckboxCell).toHaveCount(1);
 
       const myEventSpyAll = await page.spyOnEvent('tdsSelectAll');
       const myEventSpy = await page.spyOnEvent('tdsSelect');
 
       /* Click each one */
-      await tableCheckboxes.first().click();
-      await tableCheckboxes.nth(1).click();
-      await tableCheckboxes.nth(2).click();
-      await tableCheckboxes.nth(3).click();
-      await tableCheckboxes.last().click();
+      await headerCheckboxCell.click(); // This should trigger tdsSelectAll
+      await tableCheckboxCells.first().click();
+      await tableCheckboxCells.nth(1).click();
+      await tableCheckboxCells.nth(2).click();
+      await tableCheckboxCells.last().click();
 
       /* check so correct events have been called */
       expect(myEventSpyAll).toHaveReceivedEventTimes(1);

--- a/packages/core/src/components/table/table/test/multiselect/disabled-rows/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/multiselect/disabled-rows/table.e2e.ts
@@ -25,18 +25,18 @@ testConfigurations.withModeVariants.forEach((config) => {
     });
 
     test('can check enabled checkbox in the table', async ({ page }) => {
-      const tableCheckboxes = page.getByRole('cell');
-      await expect(tableCheckboxes).toHaveCount(5);
+      const tableCheckboxLabels = page.locator(
+        'tds-table-body-row:not([disabled]) tds-checkbox label',
+      );
+      await expect(tableCheckboxLabels).toHaveCount(2);
 
       const myEventSpyAll = await page.spyOnEvent('tdsSelectAll');
       const myEventSpy = await page.spyOnEvent('tdsSelect');
 
       /* Click each one */
-      await tableCheckboxes.first().click();
-      await tableCheckboxes.nth(1).click();
-      await tableCheckboxes.nth(2).click();
-      await tableCheckboxes.nth(3).click();
-      await tableCheckboxes.last().click();
+      for (let i = 0; i < 2; i++) {
+        await tableCheckboxLabels.nth(i).click();
+      }
 
       /* check so correct events have been called */
       expect(myEventSpyAll).toHaveReceivedEventTimes(0);

--- a/packages/core/src/components/table/table/test/sorting/table.e2e.ts
+++ b/packages/core/src/components/table/table/test/sorting/table.e2e.ts
@@ -67,7 +67,10 @@ test.describe.parallel(componentName, () => {
 
   test('table has header "Sorting"', async ({ page }) => {
     /* Search for header by text and see if it exists */
-    const tdsTableToolbarCaption = page.getByText('Sorting');
+    const tdsTableToolbarCaption = page.locator('caption#table-toolbar-title.tds-table__title', {
+      hasText: 'Sorting',
+    });
+
     await expect(tdsTableToolbarCaption).toHaveCount(1);
     await expect(tdsTableToolbarCaption).toBeVisible();
   });


### PR DESCRIPTION
## **Describe pull-request**  
- Editable Table Cells: Pressing Enter after editing a cell saves the value and moves focus to the next cell.
- Semantic Table Structure: The table uses proper semantic elements for screen reader compatibility.
- Sortable Columns: Sorting updates aria-sort dynamically to reflect the current order.
- Expandable Sections: Expanding or collapsing updates aria-expanded and links controls with aria-controls.
- Accessible Toolbar: The toolbar has a proper accessible name via aria-labelledby.
- Descriptive Search Input: The search input includes a clear label using aria-describedby.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-386](https://jira.scania.com/browse/CDEP-386)

## **How to test**  

For each test scenario it requires the tester to open the amplified link and open the Table component.

### Feature: Keyboard Interactivity
_Scenario: Table Editable Cells_
**Given** a table with editable cells
**When** a user edits a cell and presses Enter
**Then** the edited value should be saved
**And** the focus should move to the next editable cell

### Feature: Component Compliance with Screen Reader Behavior

_Scenario: Semantic Table Structure_
**Given** a table component
**When** the screen reader interacts with it
**Then** ensure the table uses semantic elements:
```
<table> or role="table"
<tr> or role="row"
<th> or role="columnheader"
<td> or role="cell"
```
 
_Scenario: Sortable Table Columns_
**Given** a sortable table
**When** a column is sorted
**Then** dynamically update aria-sort to "ascending" or "descending"
 
_Scenario: Expandable Elements_
**Given** an expandable section in the component
**When** it is expanded or collapsed
**Then** update aria-expanded="true | false"
**And** link the control to the expandable content using aria-controls
 
_Scenario: Toolbar and Search Labels_
**Given** a toolbar and search input
**When** the screen reader navigates
**Then** the toolbar should have an accessible name via aria-labelledby
**And** the search input should have a descriptive label via aria-describedby


## **Checklist before submission**
- [x] No accessibility violations in Storybook
- [x] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [x] Keyboard operability
- [x] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
While implementing these accessibility improvements, I encountered some failing tests. However, the failures were not due to my changes breaking the production code but rather because the tests were tightly coupled to the implementation rather than verifying actual behavior. I adjusted the tests in my last commit.

Also I fixed some a11y violations in the table storybook plugin. Not really related to the table. But to the form below table.
