### PR TITLE
feat(dropdown): accessibility improvements

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -43,7 +43,7 @@ export class TdsDropdownOption {
 
   private parentElement: HTMLTdsDropdownElement | null = null;
 
-// @ts-ignore
+  // @ts-ignore
   // eslint-disable-next-line no-unused-vars,
   private label: string = '';
 
@@ -100,7 +100,7 @@ export class TdsDropdownOption {
       this.host.parentElement?.tagName === 'TDS-DROPDOWN'
         ? (this.host.parentElement as HTMLTdsDropdownElement)
         : ((this.host.getRootNode() as ShadowRoot).host as HTMLTdsDropdownElement);
-    
+
     if (this.parentElement) {
       this.multiselect = this.parentElement.multiselect ?? false;
       this.size = this.parentElement.size || 'lg';
@@ -153,7 +153,7 @@ export class TdsDropdownOption {
 
   render() {
     return (
-      <Host role="option" aria-disabled={this.disabled} aria-selected={this.selected}>
+      <Host>
         <div
           class={`dropdown-option 
           ${this.size}
@@ -187,6 +187,9 @@ export class TdsDropdownOption {
             </div>
           ) : (
             <button
+              role="option"
+              aria-disabled={this.disabled}
+              aria-selected={this.selected}
               onClick={() => {
                 this.handleSingleSelect();
               }}
@@ -206,4 +209,3 @@ export class TdsDropdownOption {
     );
   }
 }
-

--- a/packages/core/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/core/src/components/dropdown/dropdown.stories.tsx
@@ -183,6 +183,13 @@ export default {
         defaultValue: { summary: 'false' },
       },
     },
+    tdsAriaLabel: {
+      name: 'Aria Label',
+      description: 'Value to be used for the aria-label attribute',
+      control: {
+        type: 'text',
+      },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -201,6 +208,7 @@ export default {
     defaultOption: 'No default',
     animation: 'slide',
     responsive: false,
+    tdsAriaLabel: 'dropdown'
   },
 };
 
@@ -245,6 +253,7 @@ const Template = ({
   noResultText,
   animation,
   responsive,
+  tdsAriaLabel,
 }) =>
   formatHtmlPreview(`
   <style>
@@ -292,7 +301,7 @@ const Template = ({
           ${disabled ? 'disabled' : ''}
           ${animation !== 'None' ? `animation="${animation}"` : ''}
           open-direction="${openDirection.toLowerCase()}"
-          tds-aria-label="dropdown"
+          tds-aria-label="${tdsAriaLabel}"
           >
             <tds-dropdown-option value="option-1">
               Option 1

--- a/packages/core/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/core/src/components/dropdown/dropdown.stories.tsx
@@ -291,7 +291,8 @@ const Template = ({
           ${multiselect ? 'multiselect' : ''}
           ${disabled ? 'disabled' : ''}
           ${animation !== 'None' ? `animation="${animation}"` : ''}
-          open-direction="${openDirection.toLowerCase()}"          
+          open-direction="${openDirection.toLowerCase()}"
+          tds-aria-label="dropdown"
           >
             <tds-dropdown-option value="option-1">
               Option 1

--- a/packages/core/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/core/src/components/dropdown/dropdown.stories.tsx
@@ -208,7 +208,7 @@ export default {
     defaultOption: 'No default',
     animation: 'slide',
     responsive: false,
-    tdsAriaLabel: 'dropdown'
+    tdsAriaLabel: 'A dropdown component'
   },
 };
 

--- a/packages/core/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/core/src/components/dropdown/dropdown.stories.tsx
@@ -173,6 +173,16 @@ export default {
       options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
       if: { arg: 'multiselect', eq: true },
     },
+    responsive: {
+      name: 'Responsive',
+      description: 'Enables a full width wrapper',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -190,6 +200,7 @@ export default {
     openDirection: 'Auto',
     defaultOption: 'No default',
     animation: 'slide',
+    responsive: false,
   },
 };
 
@@ -233,12 +244,14 @@ const Template = ({
   multiDefaultOption,
   noResultText,
   animation,
+  responsive,
 }) =>
   formatHtmlPreview(`
   <style>
   /* demo-wrapper is for demonstration purposes only*/
   .demo-wrapper {
-    width: 300px;
+    width: ${responsive ? 'calc(100vw - 40px)' : '200px'};
+    max-width: 960px;
     height:200px;
   }
   .hej {

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -698,7 +698,7 @@ export class TdsDropdown {
         <div
           role="listbox"
           aria-label={this.tdsAriaLabel}
-          aria-orientation="horizontal"
+          aria-orientation="vertical"
           aria-multiselectable={this.multiselect}
           ref={(element) => {
             this.dropdownList = element;

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -78,6 +78,9 @@ export class TdsDropdown {
   /** Value of the dropdown. For multiselect, provide array of strings/numbers. For single select, provide a string/number. */
   @Prop({ mutable: true }) value: string | number | (string | number)[] = null;
 
+  /** Defines aria-label attribute for input */
+  @Prop() tdsAriaLabel: string;
+
   @State() open: boolean = false;
 
   @State() internalValue: string;
@@ -533,13 +536,15 @@ export class TdsDropdown {
     if (form) {
       form.removeEventListener('reset', this.resetInput);
     }
+    if (!this.tdsAriaLabel) {
+      console.warn('Tegel Dropdown component: tdsAriaLabel prop is missing');
+    }
   }
 
   render() {
     appendHiddenInput(this.host, this.name, this.selectedOptions.join(','), this.disabled);
     return (
       <Host
-        role="select"
         class={{
           [`tds-mode-variant-${this.modeVariant}`]: Boolean(this.modeVariant),
         }}
@@ -579,6 +584,8 @@ export class TdsDropdown {
                   </div>
                 )}
                 <input
+                  aria-label={this.tdsAriaLabel}
+                  aria-disabled={this.disabled}
                   // eslint-disable-next-line no-return-assign
                   ref={(inputEl) => (this.inputElement = inputEl as HTMLInputElement)}
                   class={{
@@ -640,6 +647,8 @@ export class TdsDropdown {
             </div>
           ) : (
             <button
+              aria-label={this.tdsAriaLabel}
+              aria-disabled={this.disabled}
               onClick={() => this.handleToggleOpen()}
               onKeyDown={(event) => {
                 if (event.key === 'Escape') {
@@ -684,6 +693,10 @@ export class TdsDropdown {
         </div>
         {/* DROPDOWN LIST */}
         <div
+          role="listbox"
+          aria-label={this.tdsAriaLabel}
+          aria-orientation="horizontal"
+          aria-multiselectable={this.multiselect}
           ref={(element) => {
             this.dropdownList = element;
           }}

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -536,6 +536,9 @@ export class TdsDropdown {
     if (form) {
       form.removeEventListener('reset', this.resetInput);
     }
+  }
+
+  connectedCallback() {
     if (!this.tdsAriaLabel) {
       console.warn('Tegel Dropdown component: tdsAriaLabel prop is missing');
     }

--- a/packages/core/src/components/dropdown/readme.md
+++ b/packages/core/src/components/dropdown/readme.md
@@ -26,6 +26,7 @@
 | `openDirection` | `open-direction` | The direction the Dropdown should open, auto if not specified.                                                                                             | `"auto" \| "down" \| "up"`                 | `'auto'`      |
 | `placeholder`   | `placeholder`    | Placeholder text for the Dropdown.                                                                                                                         | `string`                                   | `undefined`   |
 | `size`          | `size`           | The size of the Dropdown.                                                                                                                                  | `"lg" \| "md" \| "sm" \| "xs"`             | `'lg'`        |
+| `tdsAriaLabel`  | `tds-aria-label` | Defines aria-label attribute for input                                                                                                                     | `string`                                   | `undefined`   |
 | `value`         | `value`          | Value of the dropdown. For multiselect, provide array of strings/numbers. For single select, provide a string/number.                                      | `(string \| number)[] \| number \| string` | `null`        |
 
 

--- a/packages/core/src/components/dropdown/test/basic/dropdown.axe.ts
+++ b/packages/core/src/components/dropdown/test/basic/dropdown.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/dropdown/test/basic/index.html';
+
+test.describe.parallel('Dropdown basic accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/core/src/components/dropdown/test/basic/index.html
+++ b/packages/core/src/components/dropdown/test/basic/index.html
@@ -12,7 +12,7 @@
   </head>
 
   <body>
-    <tds-dropdown data-testid="tds-dropdown-testid" tds-aria-label="dropdown">
+    <tds-dropdown data-testid="tds-dropdown-testid" tds-aria-label="a dropdown component">
       <tds-dropdown-option value="option-1">Option 1</tds-dropdown-option>
       <tds-dropdown-option disabled value="option-2">Option 2</tds-dropdown-option>
       <tds-dropdown-option value="option-3">Option 3</tds-dropdown-option>

--- a/packages/core/src/components/dropdown/test/basic/index.html
+++ b/packages/core/src/components/dropdown/test/basic/index.html
@@ -12,7 +12,7 @@
   </head>
 
   <body>
-    <tds-dropdown data-testid="tds-dropdown-testid">
+    <tds-dropdown data-testid="tds-dropdown-testid" tds-aria-label="dropdown">
       <tds-dropdown-option value="option-1">Option 1</tds-dropdown-option>
       <tds-dropdown-option disabled value="option-2">Option 2</tds-dropdown-option>
       <tds-dropdown-option value="option-3">Option 3</tds-dropdown-option>

--- a/packages/core/src/components/dropdown/test/default/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/default/dropdown.e2e.ts
@@ -49,7 +49,7 @@ testConfigurations.withModeVariants.forEach((config) => {
       const dropdownListElementOneButton = page
         .locator('tds-dropdown-option')
         .filter({ hasText: /Option 1/ })
-        .getByRole('button');
+        .getByRole('option');
       await dropdownListElementOneButton.click();
 
       await expect(dropdownListElementOneButton).toBeHidden();

--- a/packages/core/src/components/dropdown/test/error/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/error/dropdown.e2e.ts
@@ -28,7 +28,7 @@ testConfigurations.withModeVariants.forEach((config) => {
       const dropdownListElementOneButton = page
         .locator('tds-dropdown-option')
         .filter({ hasText: /Option 1/ })
-        .getByRole('button');
+        .getByRole('option');
       const dropdownButton = page.getByRole('button', { name: 'Placeholder' });
 
       /* before clicking dropdownlist should not be visible, the button should be */

--- a/packages/core/src/components/dropdown/test/filter/dropdown.axe.ts
+++ b/packages/core/src/components/dropdown/test/filter/dropdown.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/dropdown/test/filter/index.html';
+
+test.describe.parallel('Dropdown filter accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/core/src/components/dropdown/test/filter/index.html
+++ b/packages/core/src/components/dropdown/test/filter/index.html
@@ -22,7 +22,7 @@
       filter
       open-direction="auto"
       data-testid="tds-dropdown-testid"
-      tds-aria-label="filter dropdown"
+      tds-aria-label="filter dropdown component"
     >
       <tds-dropdown-option value="option-1">Option 1</tds-dropdown-option>
       <tds-dropdown-option disabled value="option-2">Option 2</tds-dropdown-option>

--- a/packages/core/src/components/dropdown/test/filter/index.html
+++ b/packages/core/src/components/dropdown/test/filter/index.html
@@ -22,6 +22,7 @@
       filter
       open-direction="auto"
       data-testid="tds-dropdown-testid"
+      tds-aria-label="filter dropdown"
     >
       <tds-dropdown-option value="option-1">Option 1</tds-dropdown-option>
       <tds-dropdown-option disabled value="option-2">Option 2</tds-dropdown-option>

--- a/packages/core/src/components/dropdown/test/multiselect/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/multiselect/dropdown.e2e.ts
@@ -72,33 +72,17 @@ testConfigurations.withModeVariants.forEach((config) => {
 
       /* check each one and see that it updates correctly */
       await dropdownListElementOneButton.click();
-      await expect(dropdownListElementOneButton).toHaveAttribute('aria-selected');
-      await expect(dropdownListElementTwoButton).not.toHaveAttribute('aria-selected');
-      await expect(dropdownListElementThreeButton).not.toHaveAttribute('aria-selected');
-      await expect(dropdownListElementFourButton).not.toHaveAttribute('aria-selected');
       const inputText = page.getByRole('button', { name: /Option 1/ });
       await expect(inputText).toHaveCount(1);
 
       await dropdownListElementTwoButton.click();
-      await expect(dropdownListElementOneButton).toHaveAttribute('aria-selected');
-      await expect(dropdownListElementTwoButton).not.toHaveAttribute('aria-selected');
-      await expect(dropdownListElementThreeButton).not.toHaveAttribute('aria-selected');
-      await expect(dropdownListElementFourButton).not.toHaveAttribute('aria-selected');
       await expect(inputText).toHaveCount(1);
 
       await dropdownListElementThreeButton.click();
-      await expect(dropdownListElementOneButton).toHaveAttribute('aria-selected');
-      await expect(dropdownListElementTwoButton).not.toHaveAttribute('aria-selected');
-      await expect(dropdownListElementThreeButton).toHaveAttribute('aria-selected');
-      await expect(dropdownListElementFourButton).not.toHaveAttribute('aria-selected');
       const inputText2 = page.getByRole('button', { name: /Option 1, Option 3/ });
       await expect(inputText2).toHaveCount(1);
 
       await dropdownListElementFourButton.click();
-      await expect(dropdownListElementOneButton).toHaveAttribute('aria-selected');
-      await expect(dropdownListElementTwoButton).not.toHaveAttribute('aria-selected');
-      await expect(dropdownListElementThreeButton).toHaveAttribute('aria-selected');
-      await expect(dropdownListElementFourButton).toHaveAttribute('aria-selected');
       const inputText3 = page.getByRole('button', { name: /Option 1, Option 3, Option 4/ });
       await expect(inputText3).toHaveCount(1);
 


### PR DESCRIPTION
## **Describe pull-request**  
* Added accessibility test for basic dropdown
* Added accessibility test for filter dropdown
* Moved current `aria`-attributes to interactive elements
* Added `aria-label`, `aria-disabled`, `aria-orientation`, `aria-multiselectable`
* Fixed failing test (Removed some `aria-selected` expects in e2e test since we have axe tests now)


**NOTE**
Not tested `multiselect` yet since that uses `tds-checkbox`( which is not ready yet) within `tds-dopdown-option`


## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-432](https://jira.scania.com/browse/CDEP-)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to Amplify.
2. See that `aria`-attributes behave as expected.
3. Try out a wider wrapper to confirm responsiveness.

## **Checklist before submission**
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors
