### PR TITLE
fix(dropdown): refactor, only call tdsChange on user emit

### DIFF
--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -101,7 +101,7 @@ export class TdsDropdown {
 
     // Only update if actually changed
     if (this.hasValueChanged(normalizedValue, this.selectedOptions)) {
-      this.updateDropdownState(normalizedValue);
+      this.updateDropdownStateFromUser(normalizedValue);
     }
   }
 
@@ -128,7 +128,15 @@ export class TdsDropdown {
     return newValue.some((val) => !currentValue.includes(val));
   }
 
-  private updateDropdownState(values: string[]) {
+  private updateDropdownStateInternal(values: string[]) {
+    this.updateDropdownState(values, false);
+  }
+
+  private updateDropdownStateFromUser(values: string[]) {
+    this.updateDropdownState(values, true);
+  }
+
+  private updateDropdownState(values: string[], userEmitted: boolean = false) {
     // Update internal state
     this.selectedOptions = [...this.validateValues(values)]; // Force new array reference
 
@@ -144,11 +152,11 @@ export class TdsDropdown {
     // Update display value
     this.updateDisplayValue();
 
-    // Emit change event
-    this.emitChange();
-
     // Update value attribute
     this.setValueAttribute();
+
+    // Only emit change if it is an user emitted event
+    if (userEmitted) this.emitChange();
   }
 
   private validateValues(values: string[]): string[] {
@@ -195,7 +203,7 @@ export class TdsDropdown {
     } else {
       normalizedValue = [convertToString(value)];
     }
-    this.updateDropdownState(normalizedValue);
+    this.updateDropdownStateFromUser(normalizedValue);
     return this.getSelectedChildren().map((element: HTMLTdsDropdownOptionElement) => ({
       value: element.value,
       label: element.textContent.trim(),
@@ -204,13 +212,13 @@ export class TdsDropdown {
 
   @Method()
   async reset() {
-    this.updateDropdownState([]);
+    this.updateDropdownStateFromUser([]);
   }
 
   @Method()
   async removeValue(oldValue: string) {
     const newValues = this.selectedOptions.filter((v) => v !== oldValue);
-    this.updateDropdownState(newValues);
+    this.updateDropdownStateFromUser(newValues);
   }
 
   /** Method that forces focus on the input element. */
@@ -356,7 +364,7 @@ export class TdsDropdown {
       const initialValue = this.multiselect
         ? defaultValueStr.split(',').map(convertToString)
         : [convertToString(this.defaultValue)];
-      this.updateDropdownState(initialValue);
+      this.updateDropdownStateInternal(initialValue);
     }
   }
 
@@ -377,7 +385,7 @@ export class TdsDropdown {
         ? this.internalDefaultValue.split(',')
         : [this.internalDefaultValue];
 
-      this.updateDropdownState(defaultValues);
+      this.updateDropdownStateInternal(defaultValues);
     }
   };
 
@@ -508,9 +516,9 @@ export class TdsDropdown {
   @Method()
   async appendValue(value: string) {
     if (this.multiselect) {
-      this.updateDropdownState([...this.selectedOptions, value]);
+      this.updateDropdownStateFromUser([...this.selectedOptions, value]);
     } else {
-      this.updateDropdownState([value]);
+      this.updateDropdownStateFromUser([value]);
     }
   }
 


### PR DESCRIPTION
## **Describe pull-request**  
Small refactor that splits the updateDropdownState into two functionalities,
This let's handle either internal or user changes seperatly.

## **Issue Linking:**  
- **GitHub:** https://github.com/scania-digital-design-system/tegel/issues/1094

## **Additional context**  
Please double check in code if some of the methods using updateDropdownStateFromUser should be changed to updateDropdownStateInternal or vice versa
