### PR TITLE
fix(dropdown): tdsOnChange only on user emit

### DIFF
--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -101,7 +101,7 @@ export class TdsDropdown {
 
     // Only update if actually changed
     if (this.hasValueChanged(normalizedValue, this.selectedOptions)) {
-      this.updateDropdownState(normalizedValue);
+      this.updateDropdownStateFromUser(normalizedValue);
     }
   }
 
@@ -128,7 +128,15 @@ export class TdsDropdown {
     return newValue.some((val) => !currentValue.includes(val));
   }
 
-  private updateDropdownState(values: string[]) {
+  private updateDropdownStateInternal(values: string[]) {
+    this.updateDropdownState(values, false);
+  }
+
+  private updateDropdownStateFromUser(values: string[]) {
+    this.updateDropdownState(values, true);
+  }
+
+  private updateDropdownState(values: string[], userEmitted: boolean = false) {
     // Update internal state
     this.selectedOptions = [...this.validateValues(values)]; // Force new array reference
 
@@ -144,11 +152,11 @@ export class TdsDropdown {
     // Update display value
     this.updateDisplayValue();
 
-    // Emit change event
-    this.emitChange();
-
     // Update value attribute
     this.setValueAttribute();
+
+    // Only emit change if it is an user emitted event
+    if (userEmitted) this.emitChange();
   }
 
   private validateValues(values: string[]): string[] {
@@ -195,7 +203,7 @@ export class TdsDropdown {
     } else {
       normalizedValue = [convertToString(value)];
     }
-    this.updateDropdownState(normalizedValue);
+    this.updateDropdownStateFromUser(normalizedValue);
     return this.getSelectedChildren().map((element: HTMLTdsDropdownOptionElement) => ({
       value: element.value,
       label: element.textContent.trim(),
@@ -204,13 +212,13 @@ export class TdsDropdown {
 
   @Method()
   async reset() {
-    this.updateDropdownState([]);
+    this.updateDropdownStateFromUser([]);
   }
 
   @Method()
   async removeValue(oldValue: string) {
     const newValues = this.selectedOptions.filter((v) => v !== oldValue);
-    this.updateDropdownState(newValues);
+    this.updateDropdownStateFromUser(newValues);
   }
 
   /** Method that forces focus on the input element. */
@@ -356,7 +364,7 @@ export class TdsDropdown {
       const initialValue = this.multiselect
         ? defaultValueStr.split(',').map(convertToString)
         : [convertToString(this.defaultValue)];
-      this.updateDropdownState(initialValue);
+      this.updateDropdownStateInternal(initialValue);
     }
   }
 
@@ -377,7 +385,7 @@ export class TdsDropdown {
         ? this.internalDefaultValue.split(',')
         : [this.internalDefaultValue];
 
-      this.updateDropdownState(defaultValues);
+      this.updateDropdownStateInternal(defaultValues);
     }
   };
 
@@ -508,9 +516,9 @@ export class TdsDropdown {
   @Method()
   async appendValue(value: string) {
     if (this.multiselect) {
-      this.updateDropdownState([...this.selectedOptions, value]);
+      this.updateDropdownStateFromUser([...this.selectedOptions, value]);
     } else {
-      this.updateDropdownState([value]);
+      this.updateDropdownStateFromUser([value]);
     }
   }
 

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -106,21 +106,27 @@ export class TdsDropdown {
   }
 
   private normalizeValue(value: string | number | (string | number)[] | null): string[] {
-    if (!value || value === '') return []; // Handle both null and empty string
+    if (!value || value === '') return [];
 
-    // For multiselect, keep array. For single select, wrap in array
-    if (this.multiselect) {
+    // For single select, ensure we handle both string and array inputs
+    if (!this.multiselect) {
+      // If array is passed to single select, take first value
       if (Array.isArray(value)) {
-        return convertArrayToStrings(value);
+        return [convertToString(value[0])];
       }
-      return value
-        .toString()
-        .split(',')
-        .filter((v) => v !== '');
+      return [convertToString(value)];
     }
 
-    // Single select - convert to string array
-    return Array.isArray(value) ? convertArrayToStrings(value) : [convertToString(value)];
+    // For multiselect
+    if (Array.isArray(value)) {
+      return convertArrayToStrings(value);
+    }
+
+    // Handle comma-separated string for multiselect
+    return value
+      .toString()
+      .split(',')
+      .filter((v) => v !== '');
   }
 
   private hasValueChanged(newValue: string[], currentValue: string[]): boolean {
@@ -137,13 +143,19 @@ export class TdsDropdown {
   }
 
   private updateDropdownState(values: string[], userEmitted: boolean = false) {
+    // Validate the values first
+    const validValues = this.validateValues(values);
+
     // Update internal state
     this.selectedOptions = [...this.validateValues(values)]; // Force new array reference
 
-    // Then update the value prop to match
+    // Update internal state
+    this.selectedOptions = [...validValues];
+
+    // Update the value prop
     this.value = this.multiselect ? this.selectedOptions : this.selectedOptions[0] || null;
 
-    // Force update of internal value
+    // Update internal value for display
     this.internalValue = this.getValue();
 
     // Update DOM
@@ -160,8 +172,17 @@ export class TdsDropdown {
   }
 
   private validateValues(values: string[]): string[] {
+    // Make sure we have children before validation
+    const children = this.getChildren();
+    if (!children || children.length === 0) {
+      console.warn('No dropdown options found');
+      return values; // Return original values if no children yet
+    }
+
     return values.filter((val) => {
-      const isValid = this.getChildren()?.some((element) => element.value === val);
+      const isValid = children.some(
+        (element) => convertToString(element.value) === convertToString(val),
+      );
       if (!isValid) {
         console.warn(`Option with value "${val}" does not exist`);
       }
@@ -358,8 +379,15 @@ export class TdsDropdown {
   }
 
   componentWillLoad() {
-    if (this.defaultValue && !this.value) {
-      // Convert defaultValue to string before splitting
+    // First handle the value prop if it exists
+    if (this.value !== null && this.value !== undefined) {
+      const normalizedValue = this.normalizeValue(this.value);
+      this.updateDropdownStateInternal(normalizedValue);
+      return; // Exit early if we handled the value prop
+    }
+
+    // Only use defaultValue if no value prop was provided
+    if (this.defaultValue !== null && this.defaultValue !== undefined) {
       const defaultValueStr = convertToString(this.defaultValue);
       const initialValue = this.multiselect
         ? defaultValueStr.split(',').map(convertToString)
@@ -393,9 +421,12 @@ export class TdsDropdown {
     const tdsDropdownOptions = Array.from(this.host.children).filter(
       (element) => element.tagName === 'TDS-DROPDOWN-OPTION',
     ) as Array<HTMLTdsDropdownOptionElement>;
+
     if (tdsDropdownOptions.length === 0) {
-      console.warn('TDS DROPDOWN: Data missing. Disregard if loading data asynchronously.');
-    } else return tdsDropdownOptions;
+      console.warn('TDS DROPDOWN: No options found. Disregard if loading data asynchronously.');
+    }
+
+    return tdsDropdownOptions;
   };
 
   private getSelectedChildren = () => {


### PR DESCRIPTION
## **Describe pull-request**  
This PR is based on: [Tims PR](https://github.com/scania-digital-design-system/tegel/pull/1088)

Small refactor that splits the updateDropdownState into two functionalities,
This let's handle either internal or user changes seperatly.

## **Issue Linking:**  
- **GitHub:** https://github.com/scania-digital-design-system/tegel/issues/1094

## **Additional context**  
Please double check in code if some of the methods using updateDropdownStateFromUser should be changed to updateDropdownStateInternal or vice versa
