### PR TITLE
feat(side-menu): improve accessibility

### DIFF
--- a/packages/core/src/components/side-menu/side-menu-close-button/side-menu-close-button.tsx
+++ b/packages/core/src/components/side-menu/side-menu-close-button/side-menu-close-button.tsx
@@ -9,15 +9,23 @@ import inheritAriaAttributes from '../../../utils/inheritAriaAttributes';
 export class TdsSideMenuCloseButton {
   @Element() host: HTMLElement;
 
+  private static handleClick() {
+    const hamburgerButton = document.querySelector('tds-header-hamburger');
+    if (hamburgerButton) {
+      hamburgerButton.setAttribute('aria-expanded', 'false');
+    }
+  }
+
   render() {
     const buttonProps = {
       'aria-label': 'Close',
       ...inheritAriaAttributes(this.host),
+      'onClick': TdsSideMenuCloseButton.handleClick,
     };
     return (
       <Host>
         <button {...buttonProps}>
-          <tds-icon name="cross" size="20px"></tds-icon>
+          <tds-icon name="cross" size="20px" svgTitle="Cross"></tds-icon>
         </button>
       </Host>
     );

--- a/packages/core/src/components/side-menu/side-menu-close-button/side-menu-close-button.tsx
+++ b/packages/core/src/components/side-menu/side-menu-close-button/side-menu-close-button.tsx
@@ -17,8 +17,13 @@ export class TdsSideMenuCloseButton {
   }
 
   render() {
+    // Find the closest side menu to this close button
+    const sideMenuEl = this.host.closest('tds-side-menu');
+    const sideMenuId = sideMenuEl ? sideMenuEl.id : '';
+
     const buttonProps = {
       'aria-label': 'Close',
+      ...(sideMenuId && { 'aria-controls': sideMenuId }),
       ...inheritAriaAttributes(this.host),
       'onClick': TdsSideMenuCloseButton.handleClick,
     };

--- a/packages/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/packages/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -67,6 +67,7 @@ export class TdsSideMenuCollapseButton {
       <Host
         role="button"
         tabindex="0"
+        aria-expanded={!this.collapsed ? 'true' : 'false'}
         onClick={() => {
           this.handleClick();
         }}

--- a/packages/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
@@ -28,7 +28,7 @@ export class TdsSideMenuDropdownList {
 
   render() {
     return (
-      <Host role="list">
+      <Host role="list" aria-expanded={!this.collapsed ? 'true' : 'false'}>
         <div
           class={{
             'state-collapsed': this.collapsed,

--- a/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -58,6 +58,14 @@ export class TdsSideMenuDropdown {
     this.setHoverStateClosed();
   }
 
+  @Listen('keydown')
+  handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.open = !this.open;
+    }
+  }
+
   setHoverStateOpen() {
     this.hoverState = { isHovered: true, updatedAt: Date.now() };
   }
@@ -84,7 +92,12 @@ export class TdsSideMenuDropdown {
 
   render() {
     return (
-      <Host>
+      <Host
+        tabindex="0"
+        role="button"
+        aria-haspopup="true"
+        aria-expanded={this.getIsOpenState() ? 'true' : 'false'}
+      >
         <div
           class={{
             'wrapper': true,

--- a/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -106,7 +106,12 @@ export class TdsSideMenuDropdown {
                 <Fragment>
                   {this.buttonLabel}
                   <slot name="label"></slot>
-                  <tds-icon class="dropdown-icon" name="chevron_down" size="16px"></tds-icon>
+                  <tds-icon
+                    class="dropdown-icon"
+                    name="chevron_down"
+                    size="16px"
+                    svgTitle="Chevron Down"
+                  ></tds-icon>
                 </Fragment>
               )}
             </button>

--- a/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -99,6 +99,7 @@ export class TdsSideMenuDropdown {
             onClick={() => {
               this.open = !this.open;
             }}
+            aria-expanded={this.getIsOpenState() ? 'true' : 'false'}
           >
             <button>
               <slot name="icon"></slot>

--- a/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -92,12 +92,7 @@ export class TdsSideMenuDropdown {
 
   render() {
     return (
-      <Host
-        tabindex="0"
-        role="button"
-        aria-haspopup="true"
-        aria-expanded={this.getIsOpenState() ? 'true' : 'false'}
-      >
+      <Host tabindex="0" aria-expanded={this.getIsOpenState() ? 'true' : 'false'}>
         <div
           class={{
             'wrapper': true,

--- a/packages/core/src/components/side-menu/side-menu.scss
+++ b/packages/core/src/components/side-menu/side-menu.scss
@@ -142,4 +142,16 @@ aside {
 
     overflow-y: auto;
   }
+
+  [role='navigation'] {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  li {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
 }

--- a/packages/core/src/components/side-menu/side-menu.stories.tsx
+++ b/packages/core/src/components/side-menu/side-menu.stories.tsx
@@ -164,20 +164,20 @@ const Template = ({ persistent, collapsible, collapsed }) =>
 
         <tds-side-menu-item>
           <button>
-            <tds-icon name="timer" size="24px"></tds-icon>
+            <tds-icon name="timer" size="24px" svgTitle="Timer"></tds-icon>
             About us
           </button>
         </tds-side-menu-item>
 
         <tds-side-menu-item>
           <button>
-            <tds-icon name="truck" size="24px"></tds-icon>
+            <tds-icon name="truck" size="24px" svgTitle="Truck"></tds-icon>
             Trucks
           </button>
         </tds-side-menu-item>
 
         <tds-side-menu-dropdown id="wheel-types-dropdown" default-open selected>
-          <tds-icon slot="icon" name="profile" size="24px"></tds-icon>
+          <tds-icon slot="icon" name="profile" size="24px" svgTitle="Profile"></tds-icon>
           <span slot="label">
             Wheel types
           </span>
@@ -197,7 +197,7 @@ const Template = ({ persistent, collapsible, collapsed }) =>
 
         <tds-side-menu-item>
           <button>
-            <tds-icon name="star" size="24px"></tds-icon>
+            <tds-icon name="star" size="24px" svgTitle="Star"></tds-icon>
             Values
           </button>
         </tds-side-menu-item>
@@ -219,6 +219,9 @@ const Template = ({ persistent, collapsible, collapsed }) =>
         <p><i>Note: The Side Menu is sticky, and should not scroll with the main content of the page.</i></p>
 
         <p><i>Note: The collapse button is optional.</i></p>
+        
+        <p><i>Note: When the side menu is open in mobile view, pressing the Escape key will close it.</i></p>
+        
         <button id="test">Toggle the collapsed state programmatically</button>
         <button id="toggleExpandedTest">Toggle wheel types expanded programmatically</button>
       </main>

--- a/packages/core/src/components/side-menu/side-menu.tsx
+++ b/packages/core/src/components/side-menu/side-menu.tsx
@@ -167,6 +167,7 @@ export class TdsSideMenu {
           'menu-persistent': this.persistent,
           'menu-collapsed': this.collapsed,
         }}
+        aria-expanded={this.open ? 'true' : 'false'}
       >
         <div
           class={{

--- a/packages/core/src/components/side-menu/side-menu.tsx
+++ b/packages/core/src/components/side-menu/side-menu.tsx
@@ -58,6 +58,9 @@ export class TdsSideMenu {
   /* To preserved initial state of collapsed prop as it is changed in runtime */
   @State() initialCollapsedState: boolean = false;
 
+  /** @internal Tracks the currently focused element index for keyboard navigation */
+  @State() activeElementIndex: number = 0;
+
   private matchesLgBreakpointMq: MediaQueryList;
 
   handleMatchesLgBreakpointChange: (e: MediaQueryListEvent) => void = (e) => {
@@ -116,15 +119,71 @@ export class TdsSideMenu {
     if (newVal) {
       // When menu opens, focus the first interactive element
       setTimeout(() => {
-        const firstInteractiveElement =
-          this.host.shadowRoot.querySelector('a, button, [tabindex="0"]') ||
-          this.host.querySelector('a, button, [tabindex="0"]');
-
-        if (firstInteractiveElement instanceof HTMLElement) {
-          firstInteractiveElement.focus();
+        const focusableElements = this.getFocusableElements();
+        if (focusableElements.length > 0) {
+          this.activeElementIndex = 0;
+          focusableElements[0].focus();
         }
       }, 100);
     }
+  }
+
+  private getFocusableElements(): HTMLElement[] {
+    const focusableSelectors = [
+      'a[href]',
+      'button:not([disabled])',
+      'textarea:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])',
+      'tds-side-menu-dropdown',
+    ].join(',');
+
+    const focusableInShadowRoot = Array.from(
+      this.host.shadowRoot.querySelectorAll<HTMLElement>(focusableSelectors),
+    );
+    const focusableInSlots = Array.from(
+      this.host.querySelectorAll<HTMLElement>(focusableSelectors),
+    );
+
+    /** Focusable elements */
+    return [...focusableInShadowRoot, ...focusableInSlots];
+  }
+
+  @Listen('keydown', { target: 'window', capture: true })
+  handleFocusTrap(event: KeyboardEvent) {
+    // Only trap focus if the menu is open
+    if (!this.open) return;
+
+    // We care only about the Tab key
+    if (event.key !== 'Tab') return;
+
+    const focusableElements = this.getFocusableElements();
+
+    // If there are no focusable elements
+    if (focusableElements.length === 0) return;
+
+    // Prevent default tab behavior
+    event.preventDefault();
+
+    // Going backwards (Shift + Tab) on the first element => move to last
+    if (event.shiftKey) {
+      this.activeElementIndex -= 1;
+      if (this.activeElementIndex < 0) {
+        this.activeElementIndex = focusableElements.length - 1;
+      }
+    }
+    // Going forwards (Tab) on the last element => move to first
+    else {
+      this.activeElementIndex += 1;
+      if (this.activeElementIndex >= focusableElements.length) {
+        this.activeElementIndex = 0;
+      }
+    }
+
+    // Focus the next element
+    const nextElement = focusableElements[this.activeElementIndex];
+    nextElement.focus();
   }
 
   /** Event that is emitted when the Side Menu is collapsed. */

--- a/packages/core/src/components/side-menu/side-menu.tsx
+++ b/packages/core/src/components/side-menu/side-menu.tsx
@@ -167,7 +167,7 @@ export class TdsSideMenu {
           'menu-persistent': this.persistent,
           'menu-collapsed': this.collapsed,
         }}
-        aria-expanded={this.open ? 'true' : 'false'}
+        aria-expanded={!this.collapsed ? 'true' : 'false'}
       >
         <div
           class={{

--- a/packages/core/src/components/side-menu/test/collapsible/index.html
+++ b/packages/core/src/components/side-menu/test/collapsible/index.html
@@ -15,20 +15,20 @@
     <tds-side-menu aria-label="Side menu" id="demo-side-menu" persistent>
       <tds-side-menu-item>
         <button>
-          <tds-icon name="timer" size="24px"></tds-icon>
+          <tds-icon name="timer" size="24px" svgTitle="Timer"></tds-icon>
           About us
         </button>
       </tds-side-menu-item>
 
       <tds-side-menu-item>
         <button>
-          <tds-icon name="truck" size="24px"></tds-icon>
+          <tds-icon name="truck" size="24px" svgTitle="Truck"></tds-icon>
           Trucks
         </button>
       </tds-side-menu-item>
 
       <tds-side-menu-dropdown default-open selected>
-        <tds-icon slot="icon" name="profile" size="24px"></tds-icon>
+        <tds-icon slot="icon" name="profile" size="24px" svgTitle="Profile"></tds-icon>
         <span slot="label">Wheel types</span>
         <tds-side-menu-dropdown-list>
           <tds-side-menu-dropdown-list-item>
@@ -42,7 +42,7 @@
 
       <tds-side-menu-item>
         <button>
-          <tds-icon name="star" size="24px"></tds-icon>
+          <tds-icon name="star" size="24px" svgTitle="Star"></tds-icon>
           Values
         </button>
       </tds-side-menu-item>

--- a/packages/core/src/components/side-menu/test/default/index.html
+++ b/packages/core/src/components/side-menu/test/default/index.html
@@ -15,20 +15,20 @@
     <tds-side-menu aria-label="Side menu" id="demo-side-menu" persistent>
       <tds-side-menu-item>
         <button>
-          <tds-icon name="timer" size="24px"></tds-icon>
+          <tds-icon name="timer" size="24px" svgTitle="Timer"></tds-icon>
           About us
         </button>
       </tds-side-menu-item>
 
       <tds-side-menu-item>
         <button>
-          <tds-icon name="truck" size="24px"></tds-icon>
+          <tds-icon name="truck" size="24px" svgTitle="Truck"></tds-icon>
           Trucks
         </button>
       </tds-side-menu-item>
 
       <tds-side-menu-dropdown default-open selected>
-        <tds-icon slot="icon" name="profile" size="24px"></tds-icon>
+        <tds-icon slot="icon" name="profile" size="24px" svgTitle="Profile icon"></tds-icon>
         <span slot="label">Wheel types</span>
         <tds-side-menu-dropdown-list>
           <tds-side-menu-dropdown-list-item>
@@ -42,7 +42,7 @@
 
       <tds-side-menu-item>
         <button>
-          <tds-icon name="star" size="24px"></tds-icon>
+          <tds-icon name="star" size="24px" svgTitle="Star"></tds-icon>
           Values
         </button>
       </tds-side-menu-item>

--- a/packages/core/src/components/side-menu/test/default/side-menu.axe.ts
+++ b/packages/core/src/components/side-menu/test/default/side-menu.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/side-menu/test/default/index.html';
+
+test.describe.parallel('Side menu accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/core/src/components/side-menu/test/expand-toggle/index.html
+++ b/packages/core/src/components/side-menu/test/expand-toggle/index.html
@@ -15,20 +15,20 @@
     <tds-side-menu aria-label="Side menu" id="demo-side-menu" persistent>
       <tds-side-menu-item>
         <button>
-          <tds-icon name="timer" size="24px"></tds-icon>
+          <tds-icon name="timer" size="24px" svgTitle="Timer"></tds-icon>
           About us
         </button>
       </tds-side-menu-item>
 
       <tds-side-menu-item>
         <button>
-          <tds-icon name="truck" size="24px"></tds-icon>
+          <tds-icon name="truck" size="24px" svgTitle="Truck"></tds-icon>
           Trucks
         </button>
       </tds-side-menu-item>
 
       <tds-side-menu-dropdown default-open selected>
-        <tds-icon slot="icon" name="profile" size="24px"></tds-icon>
+        <tds-icon slot="icon" name="profile" size="24px" svgTitle="Profile"></tds-icon>
         <span slot="label">Wheel types</span>
         <tds-side-menu-dropdown-list>
           <tds-side-menu-dropdown-list-item>
@@ -42,7 +42,7 @@
 
       <tds-side-menu-item>
         <button>
-          <tds-icon name="star" size="24px"></tds-icon>
+          <tds-icon name="star" size="24px" svgTitle="Star"></tds-icon>
           Values
         </button> </tds-side-menu-item
       >>

--- a/packages/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
+++ b/packages/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
@@ -181,55 +181,55 @@ const Template = ({ dummyHtml }) =>
 
         <tds-side-menu-item>
           <button>
-            <tds-icon name="timer" size="24"></tds-icon>
+            <tds-icon name="timer" size="24" svgTitle="Timer"></tds-icon>
             About us
           </button>
         </tds-side-menu-item>
 
         <tds-side-menu-item>
           <button>
-            <tds-icon name="timer" size="24"></tds-icon>
+            <tds-icon name="timer" size="24" svgTitle="Timer"></tds-icon>
             Contact
           </button>
         </tds-side-menu-item>
 
         <tds-side-menu-item>
           <button>
-            <tds-icon name="timer" size="24"></tds-icon>
+            <tds-icon name="timer" size="24" svgTitle="Timer"></tds-icon>
             Blog
           </button>
         </tds-side-menu-item>
 
         <tds-side-menu-item>
         <button>
-          <tds-icon name="timer" size="24"></tds-icon>
+          <tds-icon name="timer" size="24" svgTitle="Timer"></tds-icon>
           About us
         </button>
       </tds-side-menu-item>
 
       <tds-side-menu-item>
         <button>
-          <tds-icon name="timer" size="24"></tds-icon>
+          <tds-icon name="timer" size="24" svgTitle="Timer"></tds-icon>
           About us
         </button>
       </tds-side-menu-item>
 
         <tds-side-menu-item>
           <a href="https://www.scania.com">
-            <tds-icon name="truck" size="24"></tds-icon>
+            <tds-icon name="truck" size="24" svgTitle="Truck"></tds-icon>
             Trucks
           </a>
         </tds-side-menu-item>
 
         <tds-side-menu-item>
           <button>
-            <tds-icon name="wifi" size="24"></tds-icon>
+            <tds-icon name="wifi" size="24" svgTitle="WiFi"></tds-icon>
             Our services
           </button>
         </tds-side-menu-item>
 
         <tds-side-menu-dropdown default-open selected>
-          <tds-icon slot="icon" name="profile" size="24"></tds-icon>
+          <tds-icon slot="icon" name="profile" size="24" svgTitle="Profile"></tds-icon>
           <span slot="label">
             Wheel types
           </span>
@@ -245,7 +245,7 @@ const Template = ({ dummyHtml }) =>
 
         <tds-side-menu-item>
           <button>
-            <tds-icon name="star" size="24"></tds-icon>
+            <tds-icon name="star" size="24" svgTitle="Star"></tds-icon>
             Values
           </button>
         </tds-side-menu-item>
@@ -253,7 +253,7 @@ const Template = ({ dummyHtml }) =>
 
         <tds-side-menu-item slot="end">
           <button>
-            <tds-icon name="calendar" size="24"></tds-icon>
+            <tds-icon name="calendar" size="24" svgTitle="Calendar"></tds-icon>
             My Calendar
           </button>
         </tds-side-menu-item>
@@ -282,6 +282,8 @@ const Template = ({ dummyHtml }) =>
         <p><i>Note: The side menu is sticky, and should not scroll with the main content of the page.</i></p>
 
         <p><i>Note: The collapse button is optional.</i></p>
+        
+        <p><i>Note: When the side menu is open in mobile view, pressing the Escape key will close it.</i></p>
 
         ${dummyHtml}
       </main>


### PR DESCRIPTION
## **Describe pull-request**  

### Automatic Accessibility tests
❌ Some automatic tests are failing still...

### Keyboard interactability
✅ Close Hamburger Menu with Escape Key
✅ Focus on Inner Content After Opening Hamburger Menu
🟡 Focus on First Item in Side Menu When Expanded
🟡 Open Submenu and Focus on First Item When Pressing Enter
🟡 Reverse Tabbing in Side Menu Should Work
🟡 Move Focus Out and Close All Menus When Exiting Menu Bar

### Screen Reader behavior
🟡 Add aria-expanded to Collapsible Side Menu
🟡 Add aria-controls to Close Button
🟡 Use aria-expanded on Collapsed Side Menu List


## **Issue Linking:**  
_Choose one of the following options_
- **Jira:**  [CDEP-424](https://jira.scania.com/browse/CDEP-424)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
To be continued....

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
