### PR TITLE
feat(typography): woff2 as additional format

### DIFF
--- a/typography/_scania-fonts.scss
+++ b/typography/_scania-fonts.scss
@@ -5,7 +5,8 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
   font-family: 'Scania Sans';
   font-weight: bold;
   unicode-range: U+0400-04FF;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Bold.woff') format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Bold.woff2') format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Bold.woff') format('woff'),
     url('./assets/fonts/cyrillic/ScaniaSansCY-Bold.woff') format('woff');
 }
 
@@ -13,14 +14,16 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
   font-family: 'Scania Sans';
   font-style: italic;
   unicode-range: U+0400-04FF;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Italic.woff') format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Italic.woff2') format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Italic.woff') format('woff'),
     url('./assets/fonts/cyrillic/ScaniaSansCY-Italic.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Scania Sans';
   unicode-range: U+0400-04FF;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Regular.woff') format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Regular.woff2') format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Regular.woff') format('woff'),
     url('./assets/fonts/cyrillic/ScaniaSansCY-Regular.woff') format('woff');
 }
 
@@ -28,8 +31,9 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
   font-family: 'Scania Sans Condensed';
   font-weight: bold;
   unicode-range: U+0400-04FF;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYCondensed-Bold.woff')
-    format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYCondensed-Bold.woff2')
+    format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYCondensed-Bold.woff') format('woff'),
     url('./assets/fonts/cyrillic/ScaniaSansCYCondensed-Bold.woff') format('woff');
 }
 
@@ -37,15 +41,18 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
   font-family: 'Scania Sans Condensed';
   font-style: italic;
   unicode-range: U+0400-04FF;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYCondensed-Italic.woff')
-    format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYCondensed-Italic.woff2')
+    format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYCondensed-Italic.woff') format('woff'),
     url('./assets/fonts/cyrillic/ScaniaSansCYCondensed-Italic.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Scania Sans Condensed';
   unicode-range: U+0400-04FF;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYCondensed-Regular.woff')
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYCondensed-Regular.woff2')
+    format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYCondensed-Regular.woff')
     format('woff'),
     url('./assets/fonts/cyrillic/ScaniaSansCYCondensed-Regular.woff') format('woff');
 }
@@ -54,15 +61,18 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
   font-family: 'Scania Sans Headline';
   font-weight: bold;
   unicode-range: U+0400-04FF;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYHeadline-Bold.woff') format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYHeadline-Bold.woff2')
+    format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYHeadline-Bold.woff') format('woff'),
     url('./assets/fonts/cyrillic/ScaniaSansCYHeadline-Bold.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Scania Sans Headline';
   unicode-range: U+0400-04FF;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYHeadline-Regular.woff')
-    format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYHeadline-Regular.woff2')
+    format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYHeadline-Regular.woff') format('woff'),
     url('./assets/fonts/cyrillic/ScaniaSansCYHeadline-Regular.woff') format('woff');
 }
 
@@ -70,7 +80,9 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
   font-family: 'Scania Sans Semi Condensed';
   font-weight: bold;
   unicode-range: U+0400-04FF;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Bold.woff')
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Bold.woff2')
+    format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Bold.woff')
     format('woff'),
     url('./assets/fonts/cyrillic/ScaniaSansCYSemiCondensed-Bold.woff') format('woff');
 }
@@ -79,7 +91,9 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
   font-family: 'Scania Sans Semi Condensed';
   font-style: italic;
   unicode-range: U+0400-04FF;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Italic.woff')
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Italic.woff2')
+    format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Italic.woff')
     format('woff'),
     url('./assets/fonts/cyrillic/ScaniaSansCYSemiCondensed-Italic.woff') format('woff');
 }
@@ -87,7 +101,9 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans Semi Condensed';
   unicode-range: U+0400-04FF;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Regular.woff')
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Regular.woff2')
+    format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Regular.woff')
     format('woff'),
     url('./assets/fonts/cyrillic/ScaniaSansCYSemiCondensed-Regular.woff') format('woff');
 }
@@ -95,74 +111,87 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans';
   font-weight: bold;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Bold.woff') format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Bold.woff2') format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Bold.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSans-Bold.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Scania Sans';
   font-style: italic;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Italic.woff') format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Italic.woff2') format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Italic.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSans-Italic.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Scania Sans';
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Regular.woff') format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Regular.woff2') format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Regular.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSans-Regular.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Scania Sans Condensed';
   font-weight: bold;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Bold.woff') format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Bold.woff2') format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Bold.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSansCondensed-Bold.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Scania Sans Condensed';
   font-style: italic;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Italic.woff') format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Italic.woff2') format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Italic.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSansCondensed-Italic.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Scania Sans Condensed';
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Regular.woff') format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Regular.woff2')
+    format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Regular.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSansCondensed-Regular.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Scania Sans Headline';
   font-weight: bold;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansHeadline-Bold.woff') format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansHeadline-Bold.woff2') format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansHeadline-Bold.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSansHeadline-Bold.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Scania Sans Headline';
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansHeadline-Regular.woff') format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansHeadline-Regular.woff2') format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansHeadline-Regular.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSansHeadline-Regular.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Scania Sans Semi Condensed';
   font-weight: bold;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Bold.woff') format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Bold.woff2')
+    format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Bold.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSansSemiCondensed-Bold.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Scania Sans Semi Condensed';
   font-style: italic;
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Italic.woff')
-    format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Italic.woff2')
+    format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Italic.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSansSemiCondensed-Italic.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Scania Sans Semi Condensed';
-  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Regular.woff')
-    format('woff'),
+  src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Regular.woff2')
+    format('woff2'),
+    url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Regular.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSansSemiCondensed-Regular.woff') format('woff');
 }


### PR DESCRIPTION
### Describe pull-request
Added WOFF2 format support to all Scania Sans font declarations to improve font loading performance. The WOFF2 format is now the primary format, with WOFF as a fallback, and local assets as the final fallback.

### Issue Linking:
Jira: https://jira.scania.com/browse/CDEP-202

This is a performance optimization to leverage modern font formats. WOFF2 offers better compression than WOFF, resulting in faster font loading times and reduced bandwidth usage.

### How to test
Go to any page using Scania Sans fonts
Check in browser dev tools (Network tab) that fonts are being loaded in WOFF2 format
Verify that fonts still display correctly in all browsers
Test fallback behavior by temporarily disabling WOFF2 support in browser

### Checklist before submission

- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] npm run build:all without errors

### Suggested test steps

- [x] Browser testing (Chrome, Safari, Firefox)
- [ ]  Keyboard operability
- [ ] Interactive elements have labels
- [ ]  Storybook controls
- [ ]  Design/controls/props is aligned with other components
- [ ] Dark/light mode and variants
- [ ] Input fields – values should be displayed properly
- [ ] Events

### Screenshots
No UI changes - this is a performance optimization that doesn't affect visual appearance.

### Additional context

#### The changes maintain backward compatibility while improving performance:
- Added WOFF2 as primary format for all font declarations
- Kept WOFF as secondary format for broader browser support
- Maintained local assets as final fallback
- No visual changes, only performance improvements
- All font families (Regular, Bold, Italic, Condensed, Semi Condensed, Headline) and both Latin and Cyrillic variants are updated
- The changes follow best practices for font loading optimization and maintain the existing font loading strategy while adding support for the more efficient WOFF2 format.

Files are uploaded to AWS bucket: https://digitaldesign-assets.s3.eu-west-1.amazonaws.com/fonts/scania-sans/1.0.0/scania-sans