### PR TITLE
feat: multibrand development and storybook control

### DIFF
--- a/color/_traton-usage-tokens.scss
+++ b/color/_traton-usage-tokens.scss
@@ -1,6 +1,7 @@
 /* Traton Brand Usage Tokens */
 
 /* Light mode tokens (applied to .traton .tds-mode-light) */
+.traton,
 .traton .tds-mode-light {
   /* Foreground - Text */
   --foreground-text-strong: var(--traton-transparent-950);

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -210,23 +210,25 @@ export const parameters = {
   globals: {
     brand: 'scania',
   },
-  globalTypes: {
-    brand: {
-      name: 'Brand',
-      description: 'Select brand',
-      defaultValue: 'scania',
-      toolbar: {
-        icon: 'circlehollow',
-        items: [
-          { value: 'scania', title: 'Scania', icon: 'circlehollow' },
-          { value: 'traton', title: 'Traton', icon: 'circlehollow' },
-        ],
-        showName: true,
-        dynamicTitle: true,
-        onChange: updateBrandClasses,
+  ...(process.env.STORYBOOK_ENV === 'dev' && {
+    globalTypes: {
+      brand: {
+        name: 'Brand',
+        description: 'Select brand',
+        defaultValue: 'scania',
+        toolbar: {
+          icon: 'circlehollow',
+          items: [
+            { value: 'scania', title: 'Scania', icon: 'circlehollow' },
+            { value: 'traton', title: 'Traton', icon: 'circlehollow' },
+          ],
+          showName: true,
+          dynamicTitle: true,
+          onChange: updateBrandClasses,
+        },
       },
     },
-  },
+  }),
 };
 
 // Below is some hacky code that changes selected background when the theme changes

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -70,6 +70,39 @@ const customViewports = {
   },
 };
 
+// Add brand switcher functionality
+const BRAND_CHANGED = 'BRAND_CHANGED';
+
+// Initialize brand state
+if (typeof window !== 'undefined') {
+  window.TDS_BRAND = 'scania';
+  document.documentElement.classList.add('scania');
+}
+
+// Function to update brand classes
+const updateBrandClasses = (brand) => {
+  if (typeof window !== 'undefined') {
+    document.documentElement.classList.remove('scania', 'traton');
+    document.documentElement.classList.add(brand);
+    window.TDS_BRAND = brand;
+
+    // Emit event for other parts of the application
+    addons.getChannel().emit(BRAND_CHANGED, brand);
+  }
+};
+
+// Add decorator for brand classes
+export const decorators = [
+  (Story, context) => {
+    const brand = context.globals.brand;
+    if (typeof window !== 'undefined') {
+      document.documentElement.classList.remove('scania', 'traton');
+      document.documentElement.classList.add(brand);
+    }
+    return Story();
+  },
+];
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
@@ -172,6 +205,26 @@ export const parameters = {
       'color': '#ffffff',
       'border-radius': '16px',
       'padding': '4px 12px',
+    },
+  },
+  globals: {
+    brand: 'scania',
+  },
+  globalTypes: {
+    brand: {
+      name: 'Brand',
+      description: 'Select brand',
+      defaultValue: 'scania',
+      toolbar: {
+        icon: 'circlehollow',
+        items: [
+          { value: 'scania', title: 'Scania', icon: 'circlehollow' },
+          { value: 'traton', title: 'Traton', icon: 'circlehollow' },
+        ],
+        showName: true,
+        dynamicTitle: true,
+        onChange: updateBrandClasses,
+      },
     },
   },
 };

--- a/packages/core/src/global/global.scss
+++ b/packages/core/src/global/global.scss
@@ -2,11 +2,17 @@
 // https://stenciljs.com/docs/styling#global-styles
 // https://stenciljs.com/docs/config#globalstyle
 
-/* Multibrand tokens */
+/* Multibrand tokens: Scania colors */
 @import '../../../../color/scania-color-primitives';
 @import '../../../../color/scania-brand-usage';
 
+/* Multibrand tokens: Scania typography */
 @import '../../../../typography/tokens/typography-scania';
+
+/* Multibrand tokens: Scania spacing */
+@import '../../../../spacing/units';
+@import '../../../../spacing/radius';
+@import '../../../../spacing/scania-units';
 
 // Motion
 @import '../../../../motion/';

--- a/packages/core/src/global/multibrand-development.scss
+++ b/packages/core/src/global/multibrand-development.scss
@@ -1,0 +1,9 @@
+/*
+ * This file is used to test the multibrand tokens in a development environment.
+ * It imports the global styles and the traton styles.
+ * It is used to test the multibrand tokens in a development environment.
+ * It is not used in the production environment.
+ */
+
+@import 'global';
+@import 'traton';

--- a/packages/core/src/global/traton.scss
+++ b/packages/core/src/global/traton.scss
@@ -1,46 +1,9 @@
-// Motion
-@import '../../../../motion/';
-
-// Colors - TRATON specific
+/* Colors */
 @import '../../../../color/traton-color-primitives';
 @import '../../../../color/_traton-usage-tokens';
 
-// Grid (Deprecated - will be removed in version 2.0)
-@import '../../../../grid-deprecated/grid-deprecated';
+/* Spacing */
+@import '../../../../spacing/traton-units';
 
-// Grid new
-@import '../../../../grid/grid';
-
-// Typography
-@import '../../../../typography/scania-fonts';
-@import '../../../../typography/scania-fonts-vars';
-@import '../../../../typography/scania-fonts-selectors';
-
-// Logos
-@import '../../../../logotype/logotype';
-
-// Vars
-@import '_variables';
-@import 'scrollbar-vars';
-
-// Utility classes
-@import '_utility-classes';
-
-// Web component theme variables
-@import '../components/accordion/accordion-vars';
-@import '../components/banner/banner-vars';
-@import '../components/block/block-vars';
-@import '../components/breadcrumbs/breadcrumbs-vars';
-
-// ... (rest of component imports)
-
-body {
-  font-family: 'Scania Sans Semi Condensed', 'Scania Sans Condensed', Arial, Helvetica, sans-serif;
-  font-size: 14px;
-  margin: 0;
-  flex: 1;
-}
-
-// Include the rest of the global styles but with TRATON tokens
-
-@import 'shame';
+/* Typography */
+@import '../../../../typography/tokens/typography-traton';

--- a/packages/core/src/global/traton.scss
+++ b/packages/core/src/global/traton.scss
@@ -6,4 +6,5 @@
 @import '../../../../spacing/traton-units';
 
 /* Typography */
+@import '../../../../typography/traton-fonts';
 @import '../../../../typography/tokens/typography-traton';

--- a/packages/core/src/global/traton.scss
+++ b/packages/core/src/global/traton.scss
@@ -1,0 +1,46 @@
+// Motion
+@import '../../../../motion/';
+
+// Colors - TRATON specific
+@import '../../../../color/traton-color-primitives';
+@import '../../../../color/_traton-usage-tokens';
+
+// Grid (Deprecated - will be removed in version 2.0)
+@import '../../../../grid-deprecated/grid-deprecated';
+
+// Grid new
+@import '../../../../grid/grid';
+
+// Typography
+@import '../../../../typography/scania-fonts';
+@import '../../../../typography/scania-fonts-vars';
+@import '../../../../typography/scania-fonts-selectors';
+
+// Logos
+@import '../../../../logotype/logotype';
+
+// Vars
+@import '_variables';
+@import 'scrollbar-vars';
+
+// Utility classes
+@import '_utility-classes';
+
+// Web component theme variables
+@import '../components/accordion/accordion-vars';
+@import '../components/banner/banner-vars';
+@import '../components/block/block-vars';
+@import '../components/breadcrumbs/breadcrumbs-vars';
+
+// ... (rest of component imports)
+
+body {
+  font-family: 'Scania Sans Semi Condensed', 'Scania Sans Condensed', Arial, Helvetica, sans-serif;
+  font-size: 14px;
+  margin: 0;
+  flex: 1;
+}
+
+// Include the rest of the global styles but with TRATON tokens
+
+@import 'shame';

--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -10,6 +10,13 @@ function getTsConfigFile() {
   return 'tsconfig.prod.json';
 }
 
+function getGlobalStyleFile() {
+  if (process.env.STORYBOOK_ENV === 'dev') {
+    return 'src/global/multibrand-development.scss';
+  }
+  return 'src/global/global.scss';
+}
+
 const angularValueAccessorBindings: ValueAccessorConfig[] = [
   {
     elementSelectors: ['tds-checkbox', 'tds-chip[type="checkbox"]'],
@@ -47,7 +54,7 @@ const angularValueAccessorBindings: ValueAccessorConfig[] = [
 export const config: Config = {
   tsconfig: getTsConfigFile(),
   namespace: 'tegel',
-  globalStyle: 'src/global/global.scss',
+  globalStyle: getGlobalStyleFile(),
   extras: {
     enableImportInjection: true,
     tagNameTransform: true,
@@ -65,11 +72,6 @@ export const config: Config = {
         {
           src: '../../../assets',
           dest: 'assets/',
-          warn: true,
-        },
-        {
-          src: 'global/traton.scss',
-          dest: 'traton.css',
           warn: true,
         },
       ],

--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -67,6 +67,11 @@ export const config: Config = {
           dest: 'assets/',
           warn: true,
         },
+        {
+          src: 'global/traton.scss',
+          dest: 'traton.css',
+          warn: true,
+        },
       ],
     },
     angularOutputTarget({

--- a/typography/_traton-fonts.scss
+++ b/typography/_traton-fonts.scss
@@ -4,7 +4,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'TRATON Type Display';
   src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-display-medium.woff2') format('woff2'),
-    url('traton-type-display-medium.woff') format('woff');
+    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-display-medium.woff') format('woff');
   font-weight: 500;
   font-style: normal;
   font-display: swap;

--- a/typography/_traton-fonts.scss
+++ b/typography/_traton-fonts.scss
@@ -3,8 +3,8 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 /* === TRATON Type Display === */
 @font-face {
   font-family: 'TRATON Type Display';
-  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-display-medium.woff2') format('woff2'),
-    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-display-medium.woff') format('woff');
+  src: url('#{$cdn}/fonts/traton/1.0.0/traton-type-display-medium.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton/1.0.0/traton-type-display-medium.woff') format('woff');
   font-weight: 500;
   font-style: normal;
   font-display: swap;
@@ -12,8 +12,8 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 
 @font-face {
   font-family: 'TRATON Type Display';
-  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-display-bold.woff2') format('woff2'),
-    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-display-bold.woff') format('woff');
+  src: url('#{$cdn}/fonts/traton/1.0.0/traton-type-display-bold.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton/1.0.0/traton-type-display-bold.woff') format('woff');
   font-weight: 700;
   font-style: normal;
   font-display: swap;
@@ -22,8 +22,8 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 /* === TRATON Type Text === */
 @font-face {
   font-family: 'TRATON Type Text';
-  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-regular.woff2') format('woff2'),
-    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-regular.woff') format('woff');
+  src: url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-regular.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-regular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -31,8 +31,8 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 
 @font-face {
   font-family: 'TRATON Type Text';
-  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-italic.woff2') format('woff2'),
-    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-italic.woff') format('woff');
+  src: url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-italic.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-italic.woff') format('woff');
   font-weight: 400;
   font-style: italic;
   font-display: swap;
@@ -40,8 +40,8 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 
 @font-face {
   font-family: 'TRATON Type Text';
-  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-medium.woff2') format('woff2'),
-    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-medium.woff') format('woff');
+  src: url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-medium.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-medium.woff') format('woff');
   font-weight: 500;
   font-style: normal;
   font-display: swap;
@@ -49,8 +49,8 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 
 @font-face {
   font-family: 'TRATON Type Text';
-  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-medium-italic.woff2') format('woff2'),
-    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-medium-italic.woff') format('woff');
+  src: url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-medium-italic.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-medium-italic.woff') format('woff');
   font-weight: 500;
   font-style: italic;
   font-display: swap;
@@ -58,8 +58,8 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 
 @font-face {
   font-family: 'TRATON Type Text';
-  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-semibold.woff2') format('woff2'),
-    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-semibold.woff') format('woff');
+  src: url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-semibold.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-semibold.woff') format('woff');
   font-weight: 600;
   font-style: normal;
   font-display: swap;
@@ -67,8 +67,8 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 
 @font-face {
   font-family: 'TRATON Type Text';
-  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-semibold-italic.woff2') format('woff2'),
-    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-semibold-italic.woff') format('woff');
+  src: url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-semibold-italic.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-semibold-italic.woff') format('woff');
   font-weight: 600;
   font-style: italic;
   font-display: swap;
@@ -76,8 +76,8 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 
 @font-face {
   font-family: 'TRATON Type Text';
-  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-bold.woff2') format('woff2'),
-    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-bold.woff') format('woff');
+  src: url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-bold.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-bold.woff') format('woff');
   font-weight: 700;
   font-style: normal;
   font-display: swap;
@@ -85,8 +85,8 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 
 @font-face {
   font-family: 'TRATON Type Text';
-  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-bold-italic.woff2') format('woff2'),
-    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-bold-italic.woff') format('woff');
+  src: url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-bold-italic.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton/1.0.0/traton-type-text-bold-italic.woff') format('woff');
   font-weight: 700;
   font-style: italic;
   font-display: swap;

--- a/typography/tokens/_typography-traton.scss
+++ b/typography/tokens/_typography-traton.scss
@@ -1,4 +1,3 @@
-:root,
 .traton {
   /* Font size tokens */
   --super-type-01-font-size: 216px;

--- a/typography/tokens/_typography-traton.scss
+++ b/typography/tokens/_typography-traton.scss
@@ -54,31 +54,31 @@
   --detail-07-line-height: 14px;
 
   /* Typography Font Family Tokens */
-  --super-type-01-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
-  --super-type-02-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
-  --super-type-03-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
-  --expressive-headline-01-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
-  --expressive-headline-02-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
-  --headline-01-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
-  --headline-02-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
-  --headline-03-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
-  --headline-04-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
-  --headline-05-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
-  --headline-06-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
-  --headline-07-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
-  --paragraph-01-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
-  --paragraph-02-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
-  --body-01-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
-  --body-02-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
-  --body-link-01-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
-  --body-link-02-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
-  --detail-01-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
-  --detail-02-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
-  --detail-03-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
-  --detail-04-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
-  --detail-05-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
-  --detail-06-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
-  --detail-07-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --super-type-01-font-family: 'TRATON Type Display', verdana;
+  --super-type-02-font-family: 'TRATON Type Display', verdana;
+  --super-type-03-font-family: 'TRATON Type Display', verdana;
+  --expressive-headline-01-font-family: 'TRATON Type Display', verdana;
+  --expressive-headline-02-font-family: 'TRATON Type Display', verdana;
+  --headline-01-font-family: 'TRATON Type Display', verdana;
+  --headline-02-font-family: 'TRATON Type Display', verdana;
+  --headline-03-font-family: 'TRATON Type Display', verdana;
+  --headline-04-font-family: 'TRATON Type Display', verdana;
+  --headline-05-font-family: 'TRATON Type Text', verdana;
+  --headline-06-font-family: 'TRATON Type Text', verdana;
+  --headline-07-font-family: 'TRATON Type Text', verdana;
+  --paragraph-01-font-family: 'TRATON Type Display', verdana;
+  --paragraph-02-font-family: 'TRATON Type Display', verdana;
+  --body-01-font-family: 'TRATON Type Text', verdana;
+  --body-02-font-family: 'TRATON Type Text', verdana;
+  --body-link-01-font-family: 'TRATON Type Text', verdana;
+  --body-link-02-font-family: 'TRATON Type Text', verdana;
+  --detail-01-font-family: 'TRATON Type Text', verdana;
+  --detail-02-font-family: 'TRATON Type Text', verdana;
+  --detail-03-font-family: 'TRATON Type Text', verdana;
+  --detail-04-font-family: 'TRATON Type Text', verdana;
+  --detail-05-font-family: 'TRATON Type Text', verdana;
+  --detail-06-font-family: 'TRATON Type Text', verdana;
+  --detail-07-font-family: 'TRATON Type Text', verdana;
 
   /* Typography Font Weight Tokens */
   --super-type-01-font-weight: normal;


### PR DESCRIPTION
### Describe pull-request
A proposal on we can test multibrand in the development phase via different CSS files and how to switch brands in Storybook.

### Issue Linking:
Jira: CDEP-399

### How to test

1. Set environment variable STORYBOOK_ENV=dev in your local environment
2. Run Storybook using npm run storybook
3. Look for the brand switcher in the Storybook toolbar
4. Switch between Scania and Traton brands
5. Verify that:
6. The HTML tag's class changes accordingly
7. The window.TDS_BRAND variable updates
8. The BRAND_CHANGED event is emitted
9. Verify that in non-dev environments (when STORYBOOK_ENV=dev is unset):
10. The brand switcher is not visible
11. The brand remains fixed as 'scania'

### Checklist before submission
[x] No accessibility violations in Storybook
[] I have added unit tests for my changes (if applicable)
[x] All existing tests pass
[ ] I have updated the documentation (if applicable)
[x] Not breaking production behavior
[ ] Behavior available in Storybook with documented descriptions (if applicable)
[x] npm run build:all without errors

### Suggested test steps
[x] Browser testing (Chrome, Safari, Firefox)
[ ] Keyboard operability
[ ] Interactive elements have labels
[x] Storybook controls
[ ] Design/controls/props is aligned with other components
[x] Dark/light mode and variants
[ ] Input fields – values should be displayed properly
[ ] Events

### Screenshots Add screenshots showing the brand switcher in the Storybook toolbar and the HTML tag class changes


### Additional context
This implementation:

- Uses Storybook's built-in globals feature for brand switching
- Only shows the brand switcher in development environment
- Maintains brand state in both the window object and HTML tag classes
- Emits events for other parts of the application to react to brand changes
- Keeps the code simple and maintainable

The brand switcher can be used in components by:
Checking the current brand: window.TDS_BRAND
Listening to brand changes: addons.getChannel().on('BRAND_CHANGED', (brand) => {...})
Using CSS selectors: .scania .your-component or .traton .your-component