### PR TITLE
feat(modal): accessibility improvements

### DIFF
--- a/packages/core/src/components/modal/modal.stories.tsx
+++ b/packages/core/src/components/modal/modal.stories.tsx
@@ -82,6 +82,17 @@ export default {
         defaultValue: { summary: true },
       },
     },
+    tdsAlertDialog: {
+      name: 'Alert Dialog Role',
+      description: 'Sets the ARIA role of the message component.',
+      control: {
+        type: 'radio',
+      },
+      options: ['dialog', 'alertdialog'],
+      table: {
+        defaultValue: { summary: 'dialog' },
+      },
+    },
   },
   args: {
     actionsPosition: 'Static',
@@ -92,6 +103,7 @@ export default {
     showModal: true,
     prevent: false,
     closable: true,
+    tdsAlertDialog: 'dialog',
   },
 };
 
@@ -110,6 +122,7 @@ const ModalTemplate = ({
   showModal,
   prevent,
   closable,
+  tdsAlertDialog,
 }) =>
   formatHtmlPreview(`
     <!-- The button below is just for demo purposes -->
@@ -123,6 +136,7 @@ const ModalTemplate = ({
       actions-position="${actionsPosition.toLowerCase()}"
       prevent="${prevent}"
       closable="${closable ? 'true' : 'false'}"
+      tds-alert-dialog="${tdsAlertDialog}"
     >
       <span slot="body">
         ${bodyContent}

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -276,7 +276,7 @@ export class TdsModal {
     return (
       <Host
         role={this.tdsAlertDialog}
-        aria-modal={this.isShown}
+        aria-modal="true"
         aria-describedby={bodyId}
         aria-labelledby={headerId}
         class={{
@@ -287,7 +287,7 @@ export class TdsModal {
       >
         <div class="tds-modal-backdrop" />
         <div class={`tds-modal tds-modal__actions-${this.actionsPosition} tds-modal-${this.size}`}>
-          <div class="header">
+          <div id={headerId} class="header">
             {this.header && <div class="header-text">{this.header}</div>}
             {usesHeaderSlot && <slot name="header" />}
 

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -8,8 +8,10 @@ import {
   State,
   Event,
   EventEmitter,
+  Listen,
 } from '@stencil/core';
 import hasSlot from '../../utils/hasSlot';
+import generateUniqueId from '../../utils/generateUniqueId';
 
 /**
  * @slot header - Slot for header text
@@ -49,6 +51,9 @@ export class TdsModal {
   /** Shows or hides the close [X] button. */
   @Prop() closable: boolean = true;
 
+  /** Role of the modal component. Can be either 'alertdialog' for important messages that require immediate attention, or 'dialog' for regular messages. */
+  @Prop() tdsAlertDialog: 'alertdialog' | 'dialog' = 'dialog';
+
   // State that keeps track of show/closed state for the Modal.
   @State() isShown: boolean = false;
 
@@ -72,6 +77,13 @@ export class TdsModal {
     bubbles: true,
   })
   tdsClose: EventEmitter<any>;
+
+  @Listen('keydown', { target: 'window' })
+  handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Escape' && this.isShown && !this.prevent) {
+      this.handleClose(event)
+    }
+  }
 
   connectedCallback() {
     if (this.closable === undefined) {
@@ -179,8 +191,15 @@ export class TdsModal {
     const usesHeaderSlot = hasSlot('header', this.host);
     const usesActionsSlot = hasSlot('actions', this.host);
 
+    const headerId = this.header ? `tds-modal-header-${generateUniqueId()}` : undefined
+    const bodyId = `tds-modal-body-${generateUniqueId()}`
+
     return (
       <Host
+        role={this.tdsAlertDialog}
+        aria-modal={this.isShown}
+        aria-describedby={bodyId}
+        aria-labelledby={headerId}
         class={{
           show: this.isShown,
           hide: !this.isShown,
@@ -204,7 +223,7 @@ export class TdsModal {
             )}
           </div>
 
-          <div class="body">
+          <div id={bodyId} class="body">
             <slot name="body" />
           </div>
 

--- a/packages/core/src/components/modal/readme.md
+++ b/packages/core/src/components/modal/readme.md
@@ -44,6 +44,7 @@ use the `referenceEl` prop rather than the `selector` the referenced element can
 | `selector`        | `selector`         | CSS selector for the element that will show the Modal.                                                                                                      | `string`                       | `undefined` |
 | `show`            | `show`             | Controls whether the Modal is shown or not. If this is set hiding and showing will be decided by this prop and will need to be controlled from the outside. | `boolean`                      | `undefined` |
 | `size`            | `size`             | Size of Modal                                                                                                                                               | `"lg" \| "md" \| "sm" \| "xs"` | `'md'`      |
+| `tdsAlertDialog`  | `tds-alert-dialog` | Role of the modal component. Can be either 'alertdialog' for important messages that require immediate attention, or 'dialog' for regular messages.         | `"alertdialog" \| "dialog"`    | `'dialog'`  |
 
 
 ## Events

--- a/packages/core/src/components/modal/test/default/modal.axe.ts
+++ b/packages/core/src/components/modal/test/default/modal.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/divider/test/horizontal/index.html';
+
+test.describe.parallel('Modal accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## **Describe pull-request**  
Improved accessibility for modal component.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-419](https://jira.scania.com/browse/CDEP-419)
- **GitHub:** Include issue link  
- **No issue:** Describe the problem being solved.  

## **How to test**  
**Feature: Ensure component responsiveness**
Given the component is rendered in Storybook 
When viewport changes width 
Then the component should adjust its size accordingly without layout breaks 
And it should maintain a clear and consistent UI

_Seems to be working already, please resize window and look at container and text behavior._

### Feature: Keyboard interactability

**Scenario: Moving Focus to the First Tabbable Element Inside the Dialog**
Given a dialog is open and the focus is on the last tabbable element inside the dialog
 When the user presses Tab to navigate further
 Then the focus should move to the first tabbable element inside the dialog
 And this ensures a circular focus loop within the dialog
 But if the dialog has no tabbable elements, focus should not shift unexpectedly

_This is achieved by trapping the tab-keydown-event and taking control over it, tab-focus a interactable element inside the modal you should be in a circular tab behavior, using `tab` and `shift-tab`._

**Scenario: Closing the Modal with the Escape Key**
Given a modal or dialog is open
 When the user presses the Escape key
 Then the modal should close
 And focus should return to the element that triggered the modal
 But if the modal is not closable, the Escape key should have no effect

_Added listener for escape on keydown_


**Scenario: Ensuring Dialog Is Not Closable When closable Is False**
Given the closable property of the dialog is set to false
 When the user tries to close the dialog
 Then it should not be possible to close the dialog
 And the dialog should remain open regardless of user interaction
 But if closable is true, the dialog should be closable with the Escape key or a close button

_Listener for escape should only trigger `handleClose()` when `prevent` prop is false._

**Scenario: Returning Focus to the Invoking Element After Closing the Dialog**
Given a dialog is closed
 When the modal is closed
 Then the focus should return to the element that invoked the dialog
 And this ensures continuity of the user's navigation
 But if the dialog was triggered by a non-focusable element, focus may return to the document body or another appropriate location

_Finding referenced element or passed selector for reference element, if that element is a custom element we dig deeper for interactive element, test by closing modal with close button or escape and focus should return to tds button and open on direct enter click_

### Feature: Component compliant with screen reader behavior

**Scenario: Adding role="dialog" to tds-modal**
Given a modal component tds-modal is displayed
 When the modal is rendered
 Then the tds-modal element should have the role="dialog" attribute
 And this helps screen readers identify it as a dialog
 But if the modal serves as an alert or other specific function, a more appropriate role, like role="alertdialog", should be used instead

_Added prop for this, inspect to see that role is applied_

**Scenario: Adding aria-modal="true" to tds-modal**
Given the modal component tds-modal is displayed
 When the modal is opened
 Then the tds-modal element should have the aria-modal="true" attribute
 And this will inform assistive technologies that the modal is modal and blocks interaction with other content
 But if the dialog is not truly modal (e.g., it allows interaction with background content), this attribute should not be added

_Added attribute, inspect to confirm that attribute is there_

**Scenario: Adding aria-labelledby for the Header in tds-modal**
Given a tds-modal with a header section
 When the modal is rendered
 Then the modal should have the aria-labelledby attribute
 And the attribute should reference the ID of the header element to provide a clear label for the dialog
 But if the modal lacks a header or title, the aria-labelledby attribute should be omitted

_Added dynamic id for header, inspect that header id is the correct id used in `aria-labelledby`_

**Scenario: Adding aria-describedby for the Body in tds-modal**
Given a tds-modal with a body section containing content
 When the modal is rendered
 Then the modal should have the aria-describedby attribute
 And the attribute should reference the ID of the body content to describe the purpose or details of the modal
 But if the body contains no essential information or is empty, the aria-describedby attribute may be omitted

_Added dynamic id for body, inspect that body-slot-wrapper id is the correct id used in `aria-describedby`_

## **Checklist before submission**
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

