### PR TITLE
feat(header): accessibility improvements

### DIFF
--- a/packages/core/src/components/header/header-brand-symbol/header-brand-symbol.tsx
+++ b/packages/core/src/components/header/header-brand-symbol/header-brand-symbol.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, h, Host } from '@stencil/core';
 
 /**
- * @slot <default> - <b>Unnamed slot.</b> For a link.
+ * @slot <default> - <b>Unnamed slot.</b> For a link. When using an <a> tag, use the aria-label attribute for accessibility.
  */
 @Component({
   tag: 'tds-header-brand-symbol',
@@ -12,6 +12,14 @@ export class TdsHeaderBrandSymbol {
   @Element() host: HTMLElement;
 
   render() {
+    const aTag = this.host.querySelector('a');
+
+    if (!aTag.hasAttribute('aria-label')) {
+      console.warn(
+        'Tegel Header Brand Symbol component: missing aria-label attribute for <a> tag inside slot',
+      );
+    }
+
     return (
       <Host>
         <tds-header-item>

--- a/packages/core/src/components/header/header-brand-symbol/readme.md
+++ b/packages/core/src/components/header/header-brand-symbol/readme.md
@@ -7,9 +7,9 @@
 
 ## Slots
 
-| Slot          | Description                      |
-| ------------- | -------------------------------- |
-| `"<default>"` | <b>Unnamed slot.</b> For a link. |
+| Slot          | Description                                                                                             |
+| ------------- | ------------------------------------------------------------------------------------------------------- |
+| `"<default>"` | <b>Unnamed slot.</b> For a link. When using an <a> tag, use the aria-label attribute for accessibility. |
 
 
 ## Dependencies

--- a/packages/core/src/components/header/header-dropdown/header-dropdown.tsx
+++ b/packages/core/src/components/header/header-dropdown/header-dropdown.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, h, Host, Listen, Prop, State } from '@stencil/core';
 import generateUniqueId from '../../../utils/generateUniqueId';
+import hasSlot from '../../../utils/hasSlot';
 
 /**
  * @slot <default> - <b>Unnamed slot.</b> For injecting a dropdown list.
@@ -24,6 +25,9 @@ export class TdsHeaderDropdown {
   /** If the button that opens the dropdown should appear selected. */
   @Prop() selected: boolean = false;
 
+  /** Value to be used by the aria-label attribute */
+  @Prop() tdsAriaLabel: string;
+
   @State() open: boolean = false;
 
   @State() buttonEl?: HTMLButtonElement;
@@ -39,8 +43,30 @@ export class TdsHeaderDropdown {
     }
   }
 
+  @Listen('keydown', { target: 'window' })
+  handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Escape' && this.open) {
+      this.open = false;
+      this.buttonEl.focus();
+    }
+  }
+
   toggleDropdown() {
     this.open = !this.open;
+    console.log('toglleDropdown');
+
+    if (this.open) {
+      requestAnimationFrame(() => {
+        const selectors = "a, [tabindex='0']";
+
+        const firstFocusableElement =
+          this.host.shadowRoot.querySelector(selectors) || this.host.querySelector(selectors);
+
+        if (firstFocusableElement instanceof HTMLElement) {
+          firstFocusableElement.focus();
+        }
+      });
+    }
   }
 
   handleSlottedItemClick = (event: MouseEvent | KeyboardEvent) => {
@@ -49,6 +75,14 @@ export class TdsHeaderDropdown {
       this.open = false;
     }
   };
+
+  connectedCallback() {
+    const hasLabelSlot = hasSlot('label', this.host);
+
+    if (!this.tdsAriaLabel && !hasLabelSlot) {
+      console.warn('Tegel Header Dropdown component: use label slot or specify tdsAriaLabel prop');
+    }
+  }
 
   render() {
     return (
@@ -69,6 +103,7 @@ export class TdsHeaderDropdown {
               onClick={() => {
                 this.toggleDropdown();
               }}
+              aria-label={this.tdsAriaLabel}
             >
               <slot name="icon"></slot>
               {this.label}

--- a/packages/core/src/components/header/header-dropdown/header-dropdown.tsx
+++ b/packages/core/src/components/header/header-dropdown/header-dropdown.tsx
@@ -53,7 +53,6 @@ export class TdsHeaderDropdown {
 
   toggleDropdown() {
     this.open = !this.open;
-    console.log('toglleDropdown');
 
     if (this.open) {
       requestAnimationFrame(() => {

--- a/packages/core/src/components/header/header-dropdown/header-dropdown.tsx
+++ b/packages/core/src/components/header/header-dropdown/header-dropdown.tsx
@@ -109,7 +109,12 @@ export class TdsHeaderDropdown {
               {this.label}
               <slot name="label"></slot>
               {!this.noDropdownIcon && (
-                <tds-icon class="dropdown-icon" name="chevron_down" size="16px"></tds-icon>
+                <tds-icon
+                  class="dropdown-icon"
+                  name="chevron_down"
+                  size="16px"
+                  svgTitle="Dropdown icon"
+                ></tds-icon>
               )}
             </button>
           </tds-header-item>

--- a/packages/core/src/components/header/header-dropdown/readme.md
+++ b/packages/core/src/components/header/header-dropdown/readme.md
@@ -12,6 +12,7 @@
 | `label`          | `label`            | The label of the button that opens the dropdown. This is an alternative to the label slot. | `string`  | `undefined` |
 | `noDropdownIcon` | `no-dropdown-icon` | If the dropdown icon (downwards chevron) should be hidden.                                 | `boolean` | `false`     |
 | `selected`       | `selected`         | If the button that opens the dropdown should appear selected.                              | `boolean` | `false`     |
+| `tdsAriaLabel`   | `tds-aria-label`   | Value to be used by the aria-label attribute                                               | `string`  | `undefined` |
 
 
 ## Slots

--- a/packages/core/src/components/header/header-hamburger/header-hamburger.tsx
+++ b/packages/core/src/components/header/header-hamburger/header-hamburger.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, Host } from '@stencil/core';
+import { Component, Element, h, Host, Prop } from '@stencil/core';
 import inheritAriaAttributes from '../../../utils/inheritAriaAttributes';
 
 @Component({
@@ -9,6 +9,15 @@ import inheritAriaAttributes from '../../../utils/inheritAriaAttributes';
 export class TdsHeaderHamburger {
   @Element() host: HTMLElement;
 
+  /** Value to be used by the aria-label attribute */
+  @Prop() tdsAriaLabel: string;
+
+  connectedCallback() {
+    if (!this.tdsAriaLabel) {
+      console.warn('Tegel Header Hamburger component: missing tdsAriaLabel prop');
+    }
+  }
+
   render() {
     const inheritedButtonProps = {
       ...inheritAriaAttributes(this.host),
@@ -17,7 +26,7 @@ export class TdsHeaderHamburger {
     return (
       <Host>
         <tds-header-item>
-          <button {...inheritedButtonProps}>
+          <button {...inheritedButtonProps} aria-label={this.tdsAriaLabel}>
             <tds-icon class="icon" name="burger" size="20px"></tds-icon>
           </button>
         </tds-header-item>

--- a/packages/core/src/components/header/header-hamburger/readme.md
+++ b/packages/core/src/components/header/header-hamburger/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property       | Attribute        | Description                                  | Type     | Default     |
+| -------------- | ---------------- | -------------------------------------------- | -------- | ----------- |
+| `tdsAriaLabel` | `tds-aria-label` | Value to be used by the aria-label attribute | `string` | `undefined` |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/core/src/components/header/header-launcher-button/header-launcher-button.tsx
+++ b/packages/core/src/components/header/header-launcher-button/header-launcher-button.tsx
@@ -14,6 +14,9 @@ export class TdsHeaderLauncherButton {
    * triggering a dropdown, and the dropdown is open, for example. */
   @Prop() active = false;
 
+  /** Value to be used by the aria-label attribute */
+  @Prop() tdsAriaLabel: string;
+
   private ariaAttributes: Attributes;
 
   render() {
@@ -25,8 +28,13 @@ export class TdsHeaderLauncherButton {
     return (
       <Host>
         <tds-header-item active={this.active}>
-          <button {...buttonProps}>
-            <tds-icon class="icon" name="bento" size="20px"></tds-icon>
+          <button {...buttonProps} aria-label={this.tdsAriaLabel}>
+            <tds-icon
+              class="icon"
+              name="bento"
+              size="20px"
+              svg-title={this.tdsAriaLabel}
+            ></tds-icon>
           </button>
         </tds-header-item>
       </Host>

--- a/packages/core/src/components/header/header-launcher-button/readme.md
+++ b/packages/core/src/components/header/header-launcher-button/readme.md
@@ -7,9 +7,10 @@
 
 ## Properties
 
-| Property | Attribute | Description                                                                                                                      | Type      | Default |
-| -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- | --------- | ------- |
-| `active` | `active`  | If the button should appear active. Can be used when the button is triggering a dropdown, and the dropdown is open, for example. | `boolean` | `false` |
+| Property       | Attribute        | Description                                                                                                                      | Type      | Default     |
+| -------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `active`       | `active`         | If the button should appear active. Can be used when the button is triggering a dropdown, and the dropdown is open, for example. | `boolean` | `false`     |
+| `tdsAriaLabel` | `tds-aria-label` | Value to be used by the aria-label attribute                                                                                     | `string`  | `undefined` |
 
 
 ## Dependencies

--- a/packages/core/src/components/header/header-launcher/readme.md
+++ b/packages/core/src/components/header/header-launcher/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property       | Attribute        | Description                                                         | Type     | Default     |
+| -------------- | ---------------- | ------------------------------------------------------------------- | -------- | ----------- |
+| `tdsAriaLabel` | `tds-aria-label` | Value to be used by the aria-label attribute of the launcher button | `string` | `undefined` |
+
+
 ## Slots
 
 | Slot          | Description                                                 |

--- a/packages/core/src/components/header/header.stories.tsx
+++ b/packages/core/src/components/header/header.stories.tsx
@@ -57,7 +57,7 @@ const Template = () =>
       Example: default
     </tds-header-title>
 
-    <tds-header-launcher slot="end">
+    <tds-header-launcher slot="end" tds-aria-label="Example launcher menu">
       <tds-header-launcher-list-title>Cool apps</tds-header-launcher-list-title>
       <tds-header-launcher-list>
         <tds-header-launcher-list-item>
@@ -74,7 +74,7 @@ const Template = () =>
 
 
     <tds-header-brand-symbol slot="end">
-      <a aria-label="Scania - red gryphon on blue shield" href="https://scania.com"></a>
+      <a href="https://scania.com" aria-label="Scania website"></a>
     </tds-header-brand-symbol>
 
   </tds-header>

--- a/packages/core/src/components/header/test/default/header.axe.ts
+++ b/packages/core/src/components/header/test/default/header.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/header/test/default/index.html';
+
+test.describe.parallel('Header accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/core/src/components/header/test/default/index.html
+++ b/packages/core/src/components/header/test/default/index.html
@@ -15,7 +15,7 @@
     <tds-header>
       <tds-header-title>Example: default</tds-header-title>
 
-      <tds-header-launcher slot="end">
+      <tds-header-launcher slot="end" tds-aria-label="Example launcher menu">
         <tds-header-launcher-list-title>Cool apps</tds-header-launcher-list-title>
         <tds-header-launcher-list>
           <tds-header-launcher-list-item>
@@ -31,7 +31,7 @@
       </tds-header-launcher>
 
       <tds-header-brand-symbol slot="end">
-        <a aria-label="Scania - red gryphon on blue shield" href="https://scania.com"></a>
+        <a href="https://scania.com" aria-label="Scania - red gryphon on blue shield"></a>
       </tds-header-brand-symbol>
     </tds-header>
   </body>

--- a/packages/core/src/components/side-menu/side-menu.stories.tsx
+++ b/packages/core/src/components/side-menu/side-menu.stories.tsx
@@ -140,7 +140,7 @@ const Template = ({ persistent, collapsible, collapsed }) =>
 
   <div class="demo-layout">
     <tds-header class="demo-header">
-      <tds-header-hamburger onclick="demoSideMenu.open = true;" aria-expanded="false" aria-label="Open application drawer" aria-haspopup="true"></tds-header-hamburger>
+      <tds-header-hamburger onclick="demoSideMenu.open = true;" aria-expanded="false" tds-aria-label="Open application drawer" aria-haspopup="true"></tds-header-hamburger>
 
       <tds-header-title>
         My Application
@@ -149,7 +149,7 @@ const Template = ({ persistent, collapsible, collapsed }) =>
       <i style="color:white">Header items omitted for brevity. See patterns/navigation</i>
 
       <tds-header-brand-symbol slot="end">
-        <a aria-label="Scania - red gryphon on blue shield" href="https://scania.com"></a>
+        <a href="https://scania.com" aria-label="Scania website"></a>
       </tds-header-brand-symbol>
     </tds-header>
 

--- a/packages/core/src/stories/patterns/navigation/navigation-basic.stories.tsx
+++ b/packages/core/src/stories/patterns/navigation/navigation-basic.stories.tsx
@@ -38,7 +38,7 @@ const Template = () =>
     <tds-header-title>
       Example: default
     </tds-header-title>
-    <tds-header-launcher slot="end" aria-label="Application launcher">
+    <tds-header-launcher slot="end" tds-aria-label="Example launcher menu">
       <tds-header-launcher-list-title>Cool apps</tds-header-launcher-list-title>
       <tds-header-launcher-list>
         <tds-header-launcher-list-item>
@@ -78,7 +78,7 @@ const Template = () =>
     </tds-header-launcher>
   
     <tds-header-brand-symbol slot="end">
-      <a aria-label="Scania - red gryphon on blue shield" href="https://scania.com"></a>
+      <a href="https://scania.com" aria-label="Scania website"></a>
     </tds-header-brand-symbol>
 
   </tds-header>

--- a/packages/core/src/stories/patterns/navigation/navigation-fewitems.stories.tsx
+++ b/packages/core/src/stories/patterns/navigation/navigation-fewitems.stories.tsx
@@ -80,7 +80,7 @@ const Template = () =>
       <tds-header>
         <!-- TODO setting aria-expanded="true" on the hamburger button does not work, as it is not
           copied to the button element -->
-        <tds-header-hamburger id="demo-hamburger" onclick="demoSideMenu.open = true;demoHamburger.setAttribute('aria-expanded', true);" aria-label="Open application drawer" aria-haspopup="true" aria-expanded="false"></tds-header-hamburger>
+        <tds-header-hamburger id="demo-hamburger" onclick="demoSideMenu.open = true;demoHamburger.setAttribute('aria-expanded', true);" tds-aria-label="Open application drawer" aria-haspopup="true" aria-expanded="false"></tds-header-hamburger>
 
         <tds-header-title>
           Example: Few items
@@ -112,11 +112,11 @@ const Template = () =>
 
         <tds-header-item slot="end">
           <button onclick="alert('Calendar button clicked')">
-            <tds-icon name="calendar" size="20px"></tds-icon>
+            <tds-icon name="calendar" size="20px" svg-title="Calendar"></tds-icon>
           </button>
         </tds-header-item>
 
-        <tds-header-launcher slot="end" aria-label="Application launcher">
+        <tds-header-launcher slot="end" tds-aria-label="Example launcher menu">
           <tds-header-launcher-grid-title>Operations and Logistics</tds-header-launcher-grid-title>
           <tds-header-launcher-grid>
             <tds-header-launcher-grid-item>
@@ -168,7 +168,7 @@ const Template = () =>
 
         </tds-header-launcher>
 
-        <tds-header-dropdown slot="end" placement="end" no-dropdown-icon class="demo-hide demo-lg-show" selected>
+        <tds-header-dropdown tds-aria-label="Example dropdown menu" slot="end" placement="end" no-dropdown-icon class="demo-hide demo-lg-show" selected>
           <img slot="icon" src="https://www.svgrepo.com/show/384676/account-avatar-profile-user-6.svg" alt="User menu."/>
           <tds-header-dropdown-list size="lg">
             <tds-header-dropdown-list-user
@@ -185,7 +185,7 @@ const Template = () =>
         </tds-header-dropdown>
 
         <tds-header-brand-symbol slot="end">
-          <a aria-label="Scania - red gryphon on blue shield" href="https://scania.com"></a>
+          <a href="https://scania.com" aria-label="Scania website"></a>
         </tds-header-brand-symbol>
 
       </tds-header>

--- a/packages/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
+++ b/packages/core/src/stories/patterns/navigation/navigation-manyitems.stories.tsx
@@ -101,7 +101,7 @@ const Template = ({ dummyHtml }) =>
 
   <div class="demo-layout">
     <tds-header class="demo-header">
-      <tds-header-hamburger onclick="demoSideMenu.open = true;demoHamburger.setAttribute('aria-expanded', true);" aria-label="Open application drawer" aria-haspopup="true" aria-expanded="false"></tds-header-hamburger>
+      <tds-header-hamburger onclick="demoSideMenu.open = true;demoHamburger.setAttribute('aria-expanded', true);" tds-aria-label="Open application drawer" aria-haspopup="true" aria-expanded="false"></tds-header-hamburger>
 
       <tds-header-title>
         Example: Many items
@@ -109,11 +109,11 @@ const Template = ({ dummyHtml }) =>
 
       <tds-header-item slot="end">
         <button onclick="alert('clicked')">
-          <tds-icon name="calendar" size="20px"></tds-icon>
+          <tds-icon name="calendar" size="20px" svg-title="Calendar"></tds-icon>
         </button>
       </tds-header-item>
 
-      <tds-header-launcher slot="end">
+      <tds-header-launcher slot="end" tds-aria-label="Example launcher menu">
         <tds-header-launcher-list-title>Good</tds-header-launcher-list-title>
         <tds-header-launcher-list>
           <tds-header-launcher-list-item>
@@ -149,7 +149,7 @@ const Template = ({ dummyHtml }) =>
         </tds-header-launcher-list>
       </tds-header-launcher>
       
-      <tds-header-dropdown slot="end" placement="end" no-dropdown-icon class="demo-hide demo-xs-show">
+      <tds-header-dropdown slot="end" placement="end" no-dropdown-icon class="demo-hide demo-xs-show" tds-aria-label="Example dropdown menu">
         <img slot="icon" src="https://www.svgrepo.com/show/384676/account-avatar-profile-user-6.svg" alt="User menu."/>
         <tds-header-dropdown-list size="lg">
           <tds-header-dropdown-list-user
@@ -167,7 +167,7 @@ const Template = ({ dummyHtml }) =>
       
       
       <tds-header-brand-symbol slot="end">
-        <a aria-label="Scania - red gryphon on blue shield" href="https://scania.com"></a>
+        <a href="https://scania.com" aria-label="Scania website"></a>
       </tds-header-brand-symbol>
 
     </tds-header>

--- a/packages/core/src/stories/patterns/navigation/navigation-user-menu.stories.tsx
+++ b/packages/core/src/stories/patterns/navigation/navigation-user-menu.stories.tsx
@@ -69,13 +69,13 @@ const Template = () =>
 
     <div class="demo-layout">
       <tds-header>
-        <tds-header-hamburger class="demo-xs-hide" onclick="demoSideMenu.open = true;demoHamburger.setAttribute('aria-expanded', true);" aria-label="Open application drawer" aria-haspopup="true" aria-expanded="false"></tds-header-hamburger>
+        <tds-header-hamburger class="demo-xs-hide" onclick="demoSideMenu.open = true;demoHamburger.setAttribute('aria-expanded', true);" tds-aria-label="Open application drawer" aria-haspopup="true" aria-expanded="false"></tds-header-hamburger>
 
         <tds-header-title>
           Example: User menu
         </tds-header-title>
 
-        <tds-header-launcher slot="end">
+        <tds-header-launcher slot="end" tds-aria-label="Example launcher menu">
           <tds-header-launcher-list-title>Sustainable tools</tds-header-launcher-list-title>
           <tds-header-launcher-list>
             <tds-header-launcher-list-item>
@@ -87,7 +87,7 @@ const Template = () =>
           </tds-header-launcher-list>
         </tds-header-launcher>
         
-        <tds-header-dropdown slot="end" class="demo-hide demo-xs-show" no-dropdown-icon selected>
+        <tds-header-dropdown slot="end" class="demo-hide demo-xs-show" no-dropdown-icon selected tds-aria-label="Example dropdown menu">
           <img slot="icon" src="https://www.svgrepo.com/show/384676/account-avatar-profile-user-6.svg" alt="User menu."/>
           <tds-header-dropdown-list size="lg">
             <tds-header-dropdown-list-user
@@ -104,7 +104,7 @@ const Template = () =>
         </tds-header-dropdown>
 
         <tds-header-brand-symbol slot="end">
-          <a aria-label="Scania - red gryphon on blue shield" href="https://scania.com"></a>
+          <a href="https://scania.com" aria-label="Scania website"></a>
         </tds-header-brand-symbol>
 
       </tds-header>


### PR DESCRIPTION
## **Describe pull-request**  
Improves accessibility for the Header component.

## **Issue Linking:**  
- **Jira:** [CDEP-416](https://jira.scania.com/browse/CDEP-416)

## **How to test**  

### Feature: Keyboard interactability

#### Scenario 1 

> Scenario: Closing the Right-Side Menu with the Escape Key 
> Given the right-side menu is open  
> When the user presses the Escape key  
> Then the right-side menu should close  
> And focus should return to the previously focused element

This has been fixed for header-launcher and header-dropdown, see Scenario 4.

#### Scenario 2

See Additional context.

#### Scenario 3

> Scenario: Focusing on Sidebar Content When Opening the Left-Side Menu 
> Given the left-side menu is opened  
> When the menu becomes visible  
> Then the focus should directly move to the first interactive element within the sidebar  
> And keyboard users should be able to navigate seamlessly

This has been fixed for header-launcher and header-dropdown.

How to test:
1. Go to https://pr-1118.d3fazya28914g3.amplifyapp.com/?path=/story/patterns-navigation--few-navigation-items
2. Open any of the header-dropdowns (the button with "Wheel types" or the button to the left of the Scania logo) **by tabbing to it and pressing the enter key**
3. Make sure that the focus is moved to the first focusable element in the menu
4. Open the header-launcher (the button with the icon that has 9 dots) **by tabbing to it and pressing the enter key**
5. Repeat step 3

#### Scenario 4

> Scenario: Closing Any Open Menu with the Escape Key 
> Given any menu (left-side or right-side) is open  
> When the user presses the Escape key  
> Then the menu should close  
> And focus should return to the appropriate previous element  
> But if no menu is open, pressing Escape should not have any effect

This has been fixed for header-launcher and header-dropdown.

How to test:
1. Go to https://pr-1118.d3fazya28914g3.amplifyapp.com/?path=/story/patterns-navigation--few-navigation-items
2. Open any of the header-dropdowns (the button with "Wheel types" or the button to the left of the Scania logo) 
3. Press the esc key and verify that the menu is closed and the focus is moved to the button you clicked to open it
4. Open the header-launcher (the button with the icon that has 9 dots)
5. Repeat step 3

### Feature: Component compliant with screen reader behavior

#### Scenario 5

> Scenario: Providing Descriptive Text for Icons in the Header 
> Given an icon is displayed in the header  
> When the screen reader encounters the icon  
> Then it should read out a descriptive label instead of just saying "image"  
> And the label should describe the purpose or function of the icon or link (e.g., "menu", "search", etc.)  
> But if the icon is purely decorative, it should have aria-hidden="true"

How to test:
1. Go to https://pr-1118.d3fazya28914g3.amplifyapp.com/?path=/story/patterns-navigation--few-navigation-items
2. Activate your screen reader
3. Tab to the header-dropdown located to the left of the Scania logo
4. Verify that it announces "Example dropdown menu" (which is the specified aria-label) and not "image"
5. Tab to the header-launcher (the button with the icon that has 9 dots)
6. Verify that it announces "Example launcher menu" (which is the specified aria-label) and not "image"

#### Scenario 6

> Scenario: Announcing Collapsible Item State to Screen Reader 
> Given a collapsible item (e.g., a dropdown or accordion)  
> When the item is expanded or collapsed  
> Then the screen reader should announce whether the item is "expanded" or "collapsed"  
> And it should dynamically update the state for the user  
> But if the item is in its default state (collapsed), it should announce it as "collapsed" without requiring additional interaction

This was already fixed, with aria-expanded attribute in header-dropdown and header-launcher.

How to test:
1. Go to https://pr-1118.d3fazya28914g3.amplifyapp.com/?path=/story/patterns-navigation--few-navigation-items
2. Activate your screen reader
7. Tab to any of the header-dropdowns (the button with "Wheel types" or the button to the left of the Scania logo)
8. Verify that the screen reader announces that that the menu is collapsed
9. Press enter. The focus will move to the first focusable element in the menu
10. Tab backwards to the button that you opened the menu with
11. Verify that the screen reader announces that the menu is expanded
12. Tab to the the header-launcher (the button with the icon that has 9 dots)
13. Repeat steps 4-7


## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  

### Regarding Scenario 2

> Scenario: Closing the Left-Side Menu with the Escape Key 
> Given the left-side menu is open  
> When the user presses the Escape key  
> Then the left-side menu should close  
> And focus should return to the previously focused element

This has not been fixed, and should be fixed separately for the left-side menu on https://pr-1118.d3fazya28914g3.amplifyapp.com/?path=/story/patterns-navigation--many-navigation-items (visible with narrow screens), when addressing the accessibility for the side-menu component.