### PR TITLE
feat(typography): add typography files for Traton and fallback fonts

### DIFF
--- a/typography/_scania-fonts.scss
+++ b/typography/_scania-fonts.scss
@@ -4,6 +4,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans';
   font-weight: bold;
+  font-display: swap;
   unicode-range: U+0400-04FF;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Bold.woff2') format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Bold.woff') format('woff'),
@@ -13,6 +14,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans';
   font-style: italic;
+  font-display: swap;
   unicode-range: U+0400-04FF;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Italic.woff2') format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Italic.woff') format('woff'),
@@ -22,6 +24,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans';
   unicode-range: U+0400-04FF;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Regular.woff2') format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCY-Regular.woff') format('woff'),
     url('./assets/fonts/cyrillic/ScaniaSansCY-Regular.woff') format('woff');
@@ -30,6 +33,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans Condensed';
   font-weight: bold;
+  font-display: swap;
   unicode-range: U+0400-04FF;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYCondensed-Bold.woff2')
     format('woff2'),
@@ -40,6 +44,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans Condensed';
   font-style: italic;
+  font-display: swap;
   unicode-range: U+0400-04FF;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYCondensed-Italic.woff2')
     format('woff2'),
@@ -50,6 +55,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans Condensed';
   unicode-range: U+0400-04FF;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYCondensed-Regular.woff2')
     format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYCondensed-Regular.woff')
@@ -61,6 +67,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
   font-family: 'Scania Sans Headline';
   font-weight: bold;
   unicode-range: U+0400-04FF;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYHeadline-Bold.woff2')
     format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYHeadline-Bold.woff') format('woff'),
@@ -70,6 +77,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans Headline';
   unicode-range: U+0400-04FF;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYHeadline-Regular.woff2')
     format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYHeadline-Regular.woff') format('woff'),
@@ -80,6 +88,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
   font-family: 'Scania Sans Semi Condensed';
   font-weight: bold;
   unicode-range: U+0400-04FF;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Bold.woff2')
     format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Bold.woff')
@@ -91,6 +100,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
   font-family: 'Scania Sans Semi Condensed';
   font-style: italic;
   unicode-range: U+0400-04FF;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Italic.woff2')
     format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Italic.woff')
@@ -101,6 +111,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans Semi Condensed';
   unicode-range: U+0400-04FF;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Regular.woff2')
     format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/cyrillic/ScaniaSansCYSemiCondensed-Regular.woff')
@@ -111,6 +122,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans';
   font-weight: bold;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Bold.woff2') format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Bold.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSans-Bold.woff') format('woff');
@@ -119,6 +131,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans';
   font-style: italic;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Italic.woff2') format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Italic.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSans-Italic.woff') format('woff');
@@ -126,6 +139,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 
 @font-face {
   font-family: 'Scania Sans';
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Regular.woff2') format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSans-Regular.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSans-Regular.woff') format('woff');
@@ -134,6 +148,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans Condensed';
   font-weight: bold;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Bold.woff2') format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Bold.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSansCondensed-Bold.woff') format('woff');
@@ -142,6 +157,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans Condensed';
   font-style: italic;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Italic.woff2') format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Italic.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSansCondensed-Italic.woff') format('woff');
@@ -149,6 +165,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 
 @font-face {
   font-family: 'Scania Sans Condensed';
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Regular.woff2')
     format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansCondensed-Regular.woff') format('woff'),
@@ -158,6 +175,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans Headline';
   font-weight: bold;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansHeadline-Bold.woff2') format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansHeadline-Bold.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSansHeadline-Bold.woff') format('woff');
@@ -165,6 +183,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 
 @font-face {
   font-family: 'Scania Sans Headline';
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansHeadline-Regular.woff2') format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansHeadline-Regular.woff') format('woff'),
     url('./assets/fonts/latin/ScaniaSansHeadline-Regular.woff') format('woff');
@@ -173,6 +192,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans Semi Condensed';
   font-weight: bold;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Bold.woff2')
     format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Bold.woff') format('woff'),
@@ -182,6 +202,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 @font-face {
   font-family: 'Scania Sans Semi Condensed';
   font-style: italic;
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Italic.woff2')
     format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Italic.woff') format('woff'),
@@ -190,6 +211,7 @@ $cdn: 'https://cdn.digitaldesign.scania.com';
 
 @font-face {
   font-family: 'Scania Sans Semi Condensed';
+  font-display: swap;
   src: url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Regular.woff2')
     format('woff2'),
     url('#{$cdn}/fonts/scania-sans/1.0.0/latin/ScaniaSansSemiCondensed-Regular.woff') format('woff'),

--- a/typography/_traton-fonts.scss
+++ b/typography/_traton-fonts.scss
@@ -1,0 +1,93 @@
+$cdn: 'https://cdn.digitaldesign.scania.com';
+
+/* === TRATON Type Display === */
+@font-face {
+  font-family: 'TRATON Type Display';
+  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-display-medium.woff2') format('woff2'),
+    url('traton-type-display-medium.woff') format('woff');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'TRATON Type Display';
+  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-display-bold.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-display-bold.woff') format('woff');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* === TRATON Type Text === */
+@font-face {
+  font-family: 'TRATON Type Text';
+  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-regular.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-regular.woff') format('woff');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'TRATON Type Text';
+  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-italic.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-italic.woff') format('woff');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'TRATON Type Text';
+  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-medium.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-medium.woff') format('woff');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'TRATON Type Text';
+  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-medium-italic.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-medium-italic.woff') format('woff');
+  font-weight: 500;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'TRATON Type Text';
+  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-semibold.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-semibold.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'TRATON Type Text';
+  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-semibold-italic.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-semibold-italic.woff') format('woff');
+  font-weight: 600;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'TRATON Type Text';
+  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-bold.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-bold.woff') format('woff');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'TRATON Type Text';
+  src: url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-bold-italic.woff2') format('woff2'),
+    url('#{$cdn}/fonts/traton-type/1.0.0/traton-type-text-bold-italic.woff') format('woff');
+  font-weight: 700;
+  font-style: italic;
+  font-display: swap;
+}

--- a/typography/tokens/_typography-scania.scss
+++ b/typography/tokens/_typography-scania.scss
@@ -57,31 +57,31 @@
   --detail-07-line-height: 8px;
 
   /* Font family tokens */
-  --super-type-01-font-family: 'Scania Sans Headline';
-  --super-type-02-font-family: 'Scania Sans Headline';
-  --super-type-03-font-family: 'Scania Sans Headline';
-  --expressive-headline-01-font-family: 'Scania Sans Headline';
-  --expressive-headline-02-font-family: 'Scania Sans Headline';
-  --headline-01-font-family: 'Scania Sans Headline';
-  --headline-02-font-family: 'Scania Sans';
-  --headline-03-font-family: 'Scania Sans';
-  --headline-04-font-family: 'Scania Sans';
-  --headline-05-font-family: 'Scania Sans';
-  --headline-06-font-family: 'Scania Sans';
-  --headline-07-font-family: 'Scania Sans Semi Condensed';
-  --paragraph-01-font-family: 'Scania Sans';
-  --paragraph-02-font-family: 'Scania Sans';
-  --body-01-font-family: 'Scania Sans';
-  --body-02-font-family: 'Scania Sans';
-  --body-link-01-font-family: 'Scania Sans';
-  --body-link-02-font-family: 'Scania Sans';
-  --detail-01-font-family: 'Scania Sans Semi Condensed';
-  --detail-02-font-family: 'Scania Sans Semi Condensed';
-  --detail-03-font-family: 'Scania Sans Semi Condensed';
-  --detail-04-font-family: 'Scania Sans';
-  --detail-05-font-family: 'Scania Sans Semi Condensed';
-  --detail-06-font-family: 'Scania Sans';
-  --detail-07-font-family: 'Scania Sans Semi Condensed';
+  --super-type-01-font-family: 'Scania Sans Headline', arial, 'Helvetica Neue';
+  --super-type-02-font-family: 'Scania Sans Headline', arial, 'Helvetica Neue';
+  --super-type-03-font-family: 'Scania Sans Headline', arial, 'Helvetica Neue';
+  --expressive-headline-01-font-family: 'Scania Sans Headline', arial, 'Helvetica Neue';
+  --expressive-headline-02-font-family: 'Scania Sans Headline', arial, 'Helvetica Neue';
+  --headline-01-font-family: 'Scania Sans Headline', arial, 'Helvetica Neue';
+  --headline-02-font-family: 'Scania Sans', arial, 'Helvetica Neue';
+  --headline-03-font-family: 'Scania Sans', arial, 'Helvetica Neue';
+  --headline-04-font-family: 'Scania Sans', arial, 'Helvetica Neue';
+  --headline-05-font-family: 'Scania Sans', arial, 'Helvetica Neue';
+  --headline-06-font-family: 'Scania Sans', arial, 'Helvetica Neue';
+  --headline-07-font-family: 'Scania Sans Semi Condensed', arial, 'Helvetica Neue';
+  --paragraph-01-font-family: 'Scania Sans', arial, 'Helvetica Neue';
+  --paragraph-02-font-family: 'Scania Sans', arial, 'Helvetica Neue';
+  --body-01-font-family: 'Scania Sans', arial, 'Helvetica Neue';
+  --body-02-font-family: 'Scania Sans', arial, 'Helvetica Neue';
+  --body-link-01-font-family: 'Scania Sans', arial, 'Helvetica Neue';
+  --body-link-02-font-family: 'Scania Sans', arial, 'Helvetica Neue';
+  --detail-01-font-family: 'Scania Sans Semi Condensed', arial, 'Helvetica Neue';
+  --detail-02-font-family: 'Scania Sans Semi Condensed', arial, 'Helvetica Neue';
+  --detail-03-font-family: 'Scania Sans Semi Condensed', arial, 'Helvetica Neue';
+  --detail-04-font-family: 'Scania Sans', arial, 'Helvetica Neue';
+  --detail-05-font-family: 'Scania Sans Semi Condensed', arial, 'Helvetica Neue';
+  --detail-06-font-family: 'Scania Sans', arial, 'Helvetica Neue';
+  --detail-07-font-family: 'Scania Sans Semi Condensed', arial, 'Helvetica Neue';
 
   /* Font weight tokens */
   --super-type-01-font-weight: bold;

--- a/typography/tokens/_typography-traton.scss
+++ b/typography/tokens/_typography-traton.scss
@@ -55,31 +55,31 @@
   --detail-07-line-height: 14px;
 
   /* Typography Font Family Tokens */
-  --super-type-01-font-family: 'TRATON Type Display';
-  --super-type-02-font-family: 'TRATON Type Display';
-  --super-type-03-font-family: 'TRATON Type Display';
-  --expressive-headline-01-font-family: 'TRATON Type Display';
-  --expressive-headline-02-font-family: 'TRATON Type Display';
-  --headline-01-font-family: 'TRATON Type Display';
-  --headline-02-font-family: 'TRATON Type Display';
-  --headline-03-font-family: 'TRATON Type Display';
-  --headline-04-font-family: 'TRATON Type Display';
-  --headline-05-font-family: 'TRATON Type Text';
-  --headline-06-font-family: 'TRATON Type Text';
-  --headline-07-font-family: 'TRATON Type Text';
-  --paragraph-01-font-family: 'TRATON Type Display';
-  --paragraph-02-font-family: 'TRATON Type Display';
-  --body-01-font-family: 'TRATON Type Text';
-  --body-02-font-family: 'TRATON Type Text';
-  --body-link-01-font-family: 'TRATON Type Text';
-  --body-link-02-font-family: 'TRATON Type Text';
-  --detail-01-font-family: 'TRATON Type Text';
-  --detail-02-font-family: 'TRATON Type Text';
-  --detail-03-font-family: 'TRATON Type Text';
-  --detail-04-font-family: 'TRATON Type Text';
-  --detail-05-font-family: 'TRATON Type Text';
-  --detail-06-font-family: 'TRATON Type Text';
-  --detail-07-font-family: 'TRATON Type Text';
+  --super-type-01-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
+  --super-type-02-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
+  --super-type-03-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
+  --expressive-headline-01-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
+  --expressive-headline-02-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
+  --headline-01-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
+  --headline-02-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
+  --headline-03-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
+  --headline-04-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
+  --headline-05-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --headline-06-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --headline-07-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --paragraph-01-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
+  --paragraph-02-font-family: 'TRATON Type Display', arial, 'Helvetica Neue', verdana;
+  --body-01-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --body-02-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --body-link-01-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --body-link-02-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --detail-01-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --detail-02-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --detail-03-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --detail-04-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --detail-05-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --detail-06-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
+  --detail-07-font-family: 'TRATON Type Text', arial, 'Helvetica Neue', verdana;
 
   /* Typography Font Weight Tokens */
   --super-type-01-font-weight: normal;


### PR DESCRIPTION
## **Describe pull-request**  
Adding font-face declarations for traton and fallback fonts for both Traton and Scania

## **Issue Linking:**  
- **Jira:** [CDEP-570](https://jira.scania.com/browse/CDEP-570)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Login into AWS and verify the [uploaded font files](https://eu-west-1.console.aws.amazon.com/s3/buckets/digitaldesign-assets?region=eu-west-1&bucketType=general&prefix=fonts%2Ftraton%2F1.0.0%2F&tab=objects) and paths looks correct compared to the _traton-fonts-scss.

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

