### PR TITLE
feat(radio-button): improved accessibility

### DIFF
--- a/packages/core/src/components/radio-button/radio-button.stories.tsx
+++ b/packages/core/src/components/radio-button/radio-button.stories.tsx
@@ -64,6 +64,7 @@ const Template = ({ label, disabled }) =>
     required=false
     ${disabled ? 'disabled' : ''}
     checked="true" 
+    tds-tab-index="0"
   >
     <div slot="label">
       ${label} 1

--- a/packages/core/src/components/radio-button/radio-button.tsx
+++ b/packages/core/src/components/radio-button/radio-button.tsx
@@ -31,6 +31,12 @@ export class TdsRadioButton {
   /** Decides if the Radio Button is disabled or not. */
   @Prop() disabled: boolean = false;
 
+  /** Provides an accessible name for the component */
+  @Prop() tdsAriaLabel: string;
+
+  /** Provides a tabindex used when radio buttons are grouped */
+  @Prop() tdsTabIndex: number;
+
   /** Sends unique Radio Button identifier and status when it is checked.
    * If no ID is specified, a random one will be generated.
    * To use this listener, don't use the randomized ID, use a specific one of your choosing. */
@@ -56,8 +62,10 @@ export class TdsRadioButton {
     return (
       <div class="tds-radio-button">
         <input
+          aria-label={this.tdsAriaLabel}
           class="tds-form-input"
           type="radio"
+          role="radio"
           name={this.name}
           id={this.radioId}
           value={this.value}
@@ -66,6 +74,7 @@ export class TdsRadioButton {
           required={this.required}
           disabled={this.disabled}
           onChange={() => this.handleChange()}
+          tabIndex={this.tdsTabIndex}
         />
         <label htmlFor={this.radioId}>
           <slot name="label"></slot>

--- a/packages/core/src/components/radio-button/readme.md
+++ b/packages/core/src/components/radio-button/readme.md
@@ -7,14 +7,16 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                                     | Type      | Default              |
-| ---------- | ---------- | ----------------------------------------------- | --------- | -------------------- |
-| `checked`  | `checked`  | Decides if the Radio Button is checked or not.  | `boolean` | `false`              |
-| `disabled` | `disabled` | Decides if the Radio Button is disabled or not. | `boolean` | `false`              |
-| `name`     | `name`     | Name of Radio Button, used for reference.       | `string`  | `undefined`          |
-| `radioId`  | `radio-id` | Unique Radio Button identifier.                 | `string`  | `generateUniqueId()` |
-| `required` | `required` | Decides if the Radio Button is required or not. | `boolean` | `false`              |
-| `value`    | `value`    | Value of input.                                 | `string`  | `undefined`          |
+| Property       | Attribute        | Description                                             | Type      | Default              |
+| -------------- | ---------------- | ------------------------------------------------------- | --------- | -------------------- |
+| `checked`      | `checked`        | Decides if the Radio Button is checked or not.          | `boolean` | `false`              |
+| `disabled`     | `disabled`       | Decides if the Radio Button is disabled or not.         | `boolean` | `false`              |
+| `name`         | `name`           | Name of Radio Button, used for reference.               | `string`  | `undefined`          |
+| `radioId`      | `radio-id`       | Unique Radio Button identifier.                         | `string`  | `generateUniqueId()` |
+| `required`     | `required`       | Decides if the Radio Button is required or not.         | `boolean` | `false`              |
+| `tdsAriaLabel` | `tds-aria-label` | Provides an accessible name for the component           | `string`  | `undefined`          |
+| `tdsTabIndex`  | `tds-tab-index`  | Provides a tabindex used when radio buttons are grouped | `number`  | `undefined`          |
+| `value`        | `value`          | Value of input.                                         | `string`  | `undefined`          |
 
 
 ## Events

--- a/packages/core/src/components/radio-button/test/default/radio-button.axe.ts
+++ b/packages/core/src/components/radio-button/test/default/radio-button.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/radio-button/test/default/index.html';
+
+test.describe.parallel('Radio-Button accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## **Describe pull-request**  
Improved accessibility for radio-button component.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-422](https://jira.scania.com/browse/CDEP-422)

## **How to test**  

### Feature: Keyboard interactability
**Scenario: Navigating Between Radio Buttons Using Tab & Shift+Tab**
 Given a user is navigating a form with radio buttons
 When the user presses the Tab or Shift+Tab keys
 Then the focus should move between radio buttons correctly

_This only applies for radio buttons in groups, which we do not facilitate. Added a `tdsTabIndex` -prop which can be used to control tabindex if radio-button is used in groups_

### Feature: Component compliant with screen reader behavior

**Scenario: Ensuring Proper Labeling for Accessibility**
Given a radio button component is rendered
When the component receives a tds-aria-label prop
Then it should correctly set the aria-label attributes on the input element

_Added both `role` and `tdsAriaLabel` -prop_

## **Checklist before submission**
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors
