### PR TITLE
fix(logotypes): differentiate local variable from CDN ones

### DIFF
--- a/logotype/_logotype.scss
+++ b/logotype/_logotype.scss
@@ -12,7 +12,7 @@ html {
   }
 
   // Fallback local assets - only for specific logotypes that need local fallbacks
-  --#{$prefix}-background-image-scania-wordmark-white-svg: url('./assets/logos/scania-wordmark-white.svg');
-  --#{$prefix}-background-image-scania-symbol-svg: url('./assets/logos/scania-symbol.svg');
-  --#{$prefix}-background-image-scania-symbol-png: url('./assets/logos/scania-symbol.png');
+  --#{$prefix}-background-image-scania-wordmark-white-svg-local: url('./assets/logos/scania-wordmark-white.svg');
+  --#{$prefix}-background-image-scania-symbol-svg-local: url('./assets/logos/scania-symbol.svg');
+  --#{$prefix}-background-image-scania-symbol-png-local: url('./assets/logos/scania-symbol.png');
 }

--- a/packages/core/src/components/footer/footer.scss
+++ b/packages/core/src/components/footer/footer.scss
@@ -52,7 +52,8 @@
     }
 
     .brand {
-      background-image: var(--tds-background-image-scania-wordmark-white-svg);
+      background-image: var(--tds-background-image-scania-wordmark-white-svg),
+        var(--tds-background-image-scania-wordmark-white-svg-local);
       background-repeat: no-repeat;
       background-size: 117px;
       background-position: right;

--- a/packages/core/src/components/header/header-brand-symbol/header-brand-symbol.scss
+++ b/packages/core/src/components/header/header-brand-symbol/header-brand-symbol.scss
@@ -8,7 +8,7 @@
   tds-header-item {
     ::slotted(*) {
       background-image: var(--tds-background-image-scania-symbol-svg),
-        var(--tds-background-image-scania-symbol-png);
+        var(--tds-background-image-scania-symbol-svg-local);
       background-size: 30px auto;
       background-position: center;
       background-repeat: no-repeat;


### PR DESCRIPTION
## **Describe pull-request**  
This PR fixes the naming convention for local logotype variables to be consistent with CDN variables. The changes ensure proper fallback behavior for Scania logotypes in both header and footer components.

## **Issue Linking:**  
_Choose one of the following options_
- **No issue:** Due to the same name of local and remote assets, the code generates an issue - CSS variable appears not to have content behind.
Issue in Development channel [here.](https://teams.microsoft.com/l/message/19:5e33f67fe502441f914fbcdc6e2548f5@thread.skype/1743678594125?tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac&groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&parentMessageId=1743678594125&teamName=Tegel%20Design%20System&channelName=Development%20support%20-%20Tegel&createdTime=1743678594125)

## **How to test**  
1. Check preview link.
2. Check Header component, inspect logo, there should be valid CSS variable to represent it.
3. Check Footer component, inspect logotype, there should be valid CSS variable to represent it.

## **Checklist before submission**
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

