### PR TITLE
feat(toast): accessibility improvements

### DIFF
--- a/packages/core/src/components/toast/readme.md
+++ b/packages/core/src/components/toast/readme.md
@@ -7,15 +7,16 @@
 
 ## Properties
 
-| Property    | Attribute    | Description                                            | Type                                                 | Default              |
-| ----------- | ------------ | ------------------------------------------------------ | ---------------------------------------------------- | -------------------- |
-| `closable`  | `closable`   | Enables the close button.                              | `boolean`                                            | `true`               |
-| `header`    | `header`     | Header text for the component.                         | `string`                                             | `undefined`          |
-| `hidden`    | `hidden`     | Hides the Toast.                                       | `boolean`                                            | `false`              |
-| `subheader` | `subheader`  | Subheader text for the component.                      | `string`                                             | `undefined`          |
-| `toastId`   | `toast-id`   | ID for the Toast. Randomly generated if not specified. | `string`                                             | `generateUniqueId()` |
-| `toastRole` | `toast-role` | ARIA role for the Toast.                               | `"alert" \| "log" \| "status"`                       | `'alert'`            |
-| `variant`   | `variant`    | Type of Toast.                                         | `"error" \| "information" \| "success" \| "warning"` | `'information'`      |
+| Property            | Attribute              | Description                                                 | Type                                                 | Default              |
+| ------------------- | ---------------------- | ----------------------------------------------------------- | ---------------------------------------------------- | -------------------- |
+| `closable`          | `closable`             | Enables the close button.                                   | `boolean`                                            | `true`               |
+| `header`            | `header`               | Header text for the component.                              | `string`                                             | `undefined`          |
+| `hidden`            | `hidden`               | Hides the Toast.                                            | `boolean`                                            | `false`              |
+| `subheader`         | `subheader`            | Subheader text for the component.                           | `string`                                             | `undefined`          |
+| `tdsCloseAriaLabel` | `tds-close-aria-label` | Provides an accessible name for the components close button | `string`                                             | `undefined`          |
+| `toastId`           | `toast-id`             | ID for the Toast. Randomly generated if not specified.      | `string`                                             | `generateUniqueId()` |
+| `toastRole`         | `toast-role`           | ARIA role for the Toast.                                    | `"alert" \| "log" \| "status"`                       | `'alert'`            |
+| `variant`           | `variant`              | Type of Toast.                                              | `"error" \| "information" \| "success" \| "warning"` | `'information'`      |
 
 
 ## Events

--- a/packages/core/src/components/toast/readme.md
+++ b/packages/core/src/components/toast/readme.md
@@ -13,6 +13,7 @@
 | `header`            | `header`               | Header text for the component.                              | `string`                                             | `undefined`          |
 | `hidden`            | `hidden`               | Hides the Toast.                                            | `boolean`                                            | `false`              |
 | `subheader`         | `subheader`            | Subheader text for the component.                           | `string`                                             | `undefined`          |
+| `tdsAriaLive`       | `tds-aria-live`        | ARIA live for the Toast.                                    | `"assertive" \| "polite"`                            | `'polite'`           |
 | `tdsCloseAriaLabel` | `tds-close-aria-label` | Provides an accessible name for the components close button | `string`                                             | `undefined`          |
 | `toastId`           | `toast-id`             | ID for the Toast. Randomly generated if not specified.      | `string`                                             | `generateUniqueId()` |
 | `toastRole`         | `toast-role`           | ARIA role for the Toast.                                    | `"alert" \| "log" \| "status"`                       | `'alert'`            |

--- a/packages/core/src/components/toast/test/information/toast.axe.ts
+++ b/packages/core/src/components/toast/test/information/toast.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/accordion/test/basic/index.html';
+
+test.describe.parallel('Toast accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/core/src/components/toast/toast.stories.tsx
+++ b/packages/core/src/components/toast/toast.stories.tsx
@@ -90,6 +90,7 @@ const Template = ({ variant, header, subheader, actions, hidden, closable }) =>
         ${subheader ? `subheader="${subheader}"` : ''}
         ${hidden ? 'hidden' : ''}
         closable="${closable ? 'true' : 'false'}"
+        tds-close-aria-label="Toast close button"
     >
     ${actions || ''}
     </tds-toast>

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -39,6 +39,9 @@ export class TdsToast {
   /** Provides an accessible name for the components close button */
   @Prop() tdsCloseAriaLabel: string;
 
+  /** ARIA live for the Toast. */
+  @Prop() tdsAriaLive: 'polite' | 'assertive' = 'polite';
+
   /** Hides the Toast. */
   @Method()
   async hideToast() {
@@ -95,13 +98,19 @@ export class TdsToast {
     }
   };
 
+  connectedCallback() {
+    if (!this.tdsCloseAriaLabel) {
+      console.warn('tds-toast: tdsCloseAriaLabel is required');
+    }
+  }
+
   render() {
     const usesHeaderSlot = hasSlot('header', this.host);
     const usesSubheaderSlot = hasSlot('subheader', this.host);
     const usesActionsSlot = hasSlot('actions', this.host);
     return (
       <Host
-        aria-live="polite"
+        aria-live={this.tdsAriaLive}
         toastRole={this.toastRole}
         aria-describedby={this.host.getAttribute('aria-describedby')}
         class={{
@@ -134,7 +143,12 @@ export class TdsToast {
           </div>
 
           {this.closable && (
-            <button id="my-button" aria-label={this.tdsCloseAriaLabel} onClick={this.handleClose} class="close">
+            <button
+              id="my-button"
+              aria-label={this.tdsCloseAriaLabel}
+              onClick={this.handleClose}
+              class="close"
+            >
               <tds-icon name="cross" size="20px"></tds-icon>
             </button>
           )}

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -36,6 +36,9 @@ export class TdsToast {
   /** ARIA role for the Toast. */
   @Prop() toastRole: 'alert' | 'log' | 'status' = 'alert';
 
+  /** Provides an accessible name for the components close button */
+  @Prop() tdsCloseAriaLabel: string;
+
   /** Hides the Toast. */
   @Method()
   async hideToast() {
@@ -98,6 +101,7 @@ export class TdsToast {
     const usesActionsSlot = hasSlot('actions', this.host);
     return (
       <Host
+        aria-live="polite"
         toastRole={this.toastRole}
         aria-describedby={this.host.getAttribute('aria-describedby')}
         class={{
@@ -130,7 +134,7 @@ export class TdsToast {
           </div>
 
           {this.closable && (
-            <button onClick={this.handleClose} class="close">
+            <button id="my-button" aria-label={this.tdsCloseAriaLabel} onClick={this.handleClose} class="close">
               <tds-icon name="cross" size="20px"></tds-icon>
             </button>
           )}


### PR DESCRIPTION
## **Describe pull-request**  
Toast component accessibility improvements.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-429](https://jira.scania.com/browse/CDEP-429)

## **How to test**  
**Feature: Ensure component responsiveness**
Given the component is rendered in Storybook 
When viewport changes width 
Then the component should adjust its size accordingly without layout breaks 
And it should maintain a clear and consistent UI

### Feature: Component compliant with screen reader behavior
**Scenario: Announce Dynamic Content with aria-live**
 Given the component is rendered in Storybook
 When dynamic content is displayed, such as a toast message
 Then aria-live should be added to ensure the content is properly announced by screen readers
 But currently, aria-live is missing, so dynamic updates are not announced to users

**Scenario: Clarify Close Button Function with aria-label**
 Given the component is rendered in Storybook
 When the close button is displayed in the toast notification
 Then the close button should include an aria-label that clearly describes its function, such as "Close"
 But currently, the close button lacks an aria-label, making it unclear to screen reader users what action it performs

## **Checklist before submission**
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors
