### PR TITLE
fix(dropdown): allow value to be Number 0

### DIFF
--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -109,7 +109,7 @@ export class TdsDropdown {
   }
 
   private normalizeValue(value: string | number | (string | number)[] | null): string[] {
-    if (!value || value === '') return [];
+    if (value === null || value === undefined || value === '') return [];
 
     // For single select, ensure we handle both string and array inputs
     if (!this.multiselect) {
@@ -391,7 +391,7 @@ export class TdsDropdown {
       const defaultValueStr = convertToString(this.defaultValue);
       const initialValue = this.multiselect
         ? defaultValueStr.split(',').map(convertToString)
-        : [convertToString(this.defaultValue)];
+        : [defaultValueStr];
       this.updateDropdownStateInternal(initialValue);
     }
   }
@@ -435,7 +435,8 @@ export class TdsDropdown {
     return this.selectedOptions
       .map((stringValue) => {
         const matchingElement = this.getChildren()?.find(
-          (element: HTMLTdsDropdownOptionElement) => element.value === stringValue,
+          (element: HTMLTdsDropdownOptionElement) =>
+            convertToString(element.value) === convertToString(stringValue),
         );
         return matchingElement;
       })


### PR DESCRIPTION
## **Describe pull-request**  
Converting Number values to strings, and allow Number 0 as value.

beta release: `1.27.0-allow-numbers-and-zero-values-beta.0`

showcase in react wrapper: https://github.com/scania-digital-design-system/tegel-react-demo/pull/228 

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-598`: [CDEP-598](https://jira.scania.com/browse/CDEP-598)
- **GitHub:** [Issue - The dropdown doesn't select the correct option when a numeric value is used #1125](https://github.com/scania-digital-design-system/tegel/issues/1125)
- **No issue:** Describe the problem being solved.  

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Beta release installed in react wrapper here: https://github.com/scania-digital-design-system/tegel-react-demo/pull/228 
2. Start the branch locally
3. Test the dropdown that now has numbers including zero as values

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [x] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
