### PR TITLE
feat(textarea): accessibility improvements

### DIFF
--- a/packages/core/src/components/textarea/readme.md
+++ b/packages/core/src/components/textarea/readme.md
@@ -7,24 +7,25 @@
 
 ## Properties
 
-| Property           | Attribute             | Description                             | Type                                  | Default      |
-| ------------------ | --------------------- | --------------------------------------- | ------------------------------------- | ------------ |
-| `autofocus`        | `autofocus`           | Control of autofocus                    | `boolean`                             | `false`      |
-| `cols`             | `cols`                | Textarea cols attribute                 | `number`                              | `undefined`  |
-| `disabled`         | `disabled`            | Set input in disabled state             | `boolean`                             | `false`      |
-| `helper`           | `helper`              | Helper text                             | `string`                              | `undefined`  |
-| `hideReadOnlyIcon` | `hide-read-only-icon` | Hide the readonly icon                  | `boolean`                             | `false`      |
-| `label`            | `label`               | Label text                              | `string`                              | `''`         |
-| `labelPosition`    | `label-position`      | Position of the label for the Textarea. | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
-| `maxLength`        | `max-length`          | Max length of input                     | `number`                              | `undefined`  |
-| `modeVariant`      | `mode-variant`        | Mode variant of the Textarea            | `"primary" \| "secondary"`            | `null`       |
-| `name`             | `name`                | Name attribute                          | `string`                              | `''`         |
-| `noMinWidth`       | `no-min-width`        | Unset minimum width of 208px.           | `boolean`                             | `false`      |
-| `placeholder`      | `placeholder`         | Placeholder text                        | `string`                              | `''`         |
-| `readOnly`         | `read-only`           | Set input in readonly state             | `boolean`                             | `false`      |
-| `rows`             | `rows`                | Textarea rows attribute                 | `number`                              | `undefined`  |
-| `state`            | `state`               | Error state of input                    | `"default" \| "error" \| "success"`   | `'default'`  |
-| `value`            | `value`               | Value of the input text                 | `string`                              | `''`         |
+| Property           | Attribute             | Description                                                                                                  | Type                                  | Default      |
+| ------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------- | ------------ |
+| `autofocus`        | `autofocus`           | Control of autofocus                                                                                         | `boolean`                             | `false`      |
+| `cols`             | `cols`                | Textarea cols attribute                                                                                      | `number`                              | `undefined`  |
+| `disabled`         | `disabled`            | Set input in disabled state                                                                                  | `boolean`                             | `false`      |
+| `helper`           | `helper`              | Helper text                                                                                                  | `string`                              | `undefined`  |
+| `hideReadOnlyIcon` | `hide-read-only-icon` | Hide the readonly icon                                                                                       | `boolean`                             | `false`      |
+| `label`            | `label`               | Label text                                                                                                   | `string`                              | `''`         |
+| `labelPosition`    | `label-position`      | Position of the label for the Textarea.                                                                      | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
+| `maxLength`        | `max-length`          | Max length of input                                                                                          | `number`                              | `undefined`  |
+| `modeVariant`      | `mode-variant`        | Mode variant of the Textarea                                                                                 | `"primary" \| "secondary"`            | `null`       |
+| `name`             | `name`                | Name attribute                                                                                               | `string`                              | `''`         |
+| `noMinWidth`       | `no-min-width`        | Unset minimum width of 208px.                                                                                | `boolean`                             | `false`      |
+| `placeholder`      | `placeholder`         | Placeholder text                                                                                             | `string`                              | `''`         |
+| `readOnly`         | `read-only`           | Set input in readonly state                                                                                  | `boolean`                             | `false`      |
+| `rows`             | `rows`                | Textarea rows attribute                                                                                      | `number`                              | `undefined`  |
+| `state`            | `state`               | Error state of input                                                                                         | `"default" \| "error" \| "success"`   | `'default'`  |
+| `tdsAriaLabel`     | `tds-aria-label`      | Value to be used for the aria-label attribute. Can be used for announcing that readOnly prop is set to true. | `string`                              | `undefined`  |
+| `value`            | `value`               | Value of the input text                                                                                      | `string`                              | `''`         |
 
 
 ## Events

--- a/packages/core/src/components/textarea/test/default/textarea.axe.ts
+++ b/packages/core/src/components/textarea/test/default/textarea.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/textarea/test/default/index.html';
+
+test.describe.parallel('Textarea accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/core/src/components/textarea/textarea.stories.tsx
+++ b/packages/core/src/components/textarea/textarea.stories.tsx
@@ -181,7 +181,8 @@ const Template = ({
   <style>
   /* demo-wrapper is for demonstration purposes only*/
     .demo-wrapper {
-      width: 400px;
+      width: calc(100vw - 40px);
+      max-width: 400px;
     }
   </style>
 

--- a/packages/core/src/components/textarea/textarea.stories.tsx
+++ b/packages/core/src/components/textarea/textarea.stories.tsx
@@ -137,6 +137,13 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    tdsAriaLabel: {
+      name: 'Aria Label',
+      description: 'Value to be used for the aria-label attribute',
+      control: {
+        type: 'text',
+      },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -152,6 +159,7 @@ export default {
     readonly: false,
     hideReadonlyIcon: false,
     disabled: false,
+    tdsAriaLabel: 'A textarea component',
   },
 };
 
@@ -169,6 +177,7 @@ const Template = ({
   readonly,
   hideReadonlyIcon,
   disabled,
+  tdsAriaLabel,
 }) => {
   const maxlength = maxLength > 0 ? `max-length="${maxLength}"` : '';
   const stateValue = state.toLowerCase();
@@ -204,7 +213,9 @@ const Template = ({
           ${noMinWidth ? 'no-min-width' : ''}
           placeholder="${placeholder}"
           ${maxlength}
-          value="${textValue}">
+          value="${textValue}"
+          tds-aria-label="${tdsAriaLabel}"
+          >
         </tds-textarea>
   </div>
   <!-- Script tag for demo purposes -->

--- a/packages/core/src/components/textarea/textarea.tsx
+++ b/packages/core/src/components/textarea/textarea.tsx
@@ -58,6 +58,9 @@ export class TdsTextarea {
   /** Unset minimum width of 208px. */
   @Prop() noMinWidth: boolean = false;
 
+  /** Value to be used for the aria-label attribute. Can be used for announcing that readOnly prop is set to true. */
+  @Prop() tdsAriaLabel: string;
+
   /** Listen to the focus state of the input */
   @State() focusInput: boolean;
 
@@ -131,6 +134,14 @@ export class TdsTextarea {
     return modeVariant;
   }
 
+  connectedCallback() {
+    if (!this.tdsAriaLabel && !this.label) {
+      console.warn(
+        'Tegel Textarea component: specify label or tdsAriaLabel prop for accessibility',
+      );
+    }
+  }
+
   render() {
     return (
       <div
@@ -146,9 +157,14 @@ export class TdsTextarea {
           'no-min-width': this.noMinWidth,
         }}
       >
-        {this.labelPosition !== 'no-label' && <span class={'textarea-label'}>{this.label}</span>}
+        {this.labelPosition !== 'no-label' && (
+          <label htmlFor="textarea-element" class={'textarea-label'}>
+            {this.label}
+          </label>
+        )}
         <div class="textarea-wrapper">
           <textarea
+            id="textarea-element"
             class={'textarea-input'}
             ref={(inputEl: HTMLTextAreaElement) => {
               this.textEl = inputEl;
@@ -174,6 +190,10 @@ export class TdsTextarea {
             }}
             onInput={(event) => this.handleInput(event)}
             onChange={(event) => this.handleChange(event)}
+            aria-invalid={this.state === 'error' ? 'true' : 'false'}
+            aria-readonly={this.readOnly ? 'true' : 'false'}
+            aria-label={this.tdsAriaLabel ? this.tdsAriaLabel : this.label}
+            aria-describedby="textarea-helper-element"
           />
           <span class="textarea-resizer-icon">
             <svg
@@ -202,7 +222,8 @@ export class TdsTextarea {
             </span>
           )}
         </div>
-        <span class={'textarea-helper'}>
+
+        <span class={'textarea-helper'} aria-live="assertive" id="textarea-helper-element">
           {this.state === 'error' && !this.readOnly && <tds-icon name="error" size="16px" />}
           {this.helper}
         </span>


### PR DESCRIPTION
## **Describe pull-request**  
Improves accessibility for the Textarea component.

## **Issue Linking:**  
- **Jira:** [CDEP-428](https://jira.scania.com/browse/CDEP-428)

## **How to test** 

### Feature: Ensure component responsiveness

#### Scenario 1:

> Given the component is rendered in Storybook 
> When viewport changes width 
> Then the component should adjust its size accordingly without layout breaks 
> And it should maintain a clear and consistent UI

How to test:
1. Go to https://pr-1136.d3fazya28914g3.amplifyapp.com/?path=/story/components-textarea--default
2. Change the width of the window and verify that the textarea adjusts its width


### Feature: Keyboard interactability
#### Scenario 2:

This has not been fixed, see Additional context.


### Feature: Component compliant with screen reader behavior
#### Scenario 3:

> Scenario: Proper Association Between Label and Textarea
> Given the component is rendered in Storybook
> When the label is displayed for the textarea
> Then the label should have a for attribute linking to the id of the textarea
> And the textarea should have an id to ensure proper association for screen readers
> But currently, the for attribute is missing from the label, and the id is missing from the textarea, which affects screen reader accessibility

How to test:
1. Go to https://pr-1136.d3fazya28914g3.amplifyapp.com/?path=/story/components-textarea--default&args=labelPosition:Outside;tdsAriaLabel:
3. Open browser dev tools
4. Inspect the label element and verify that it has for="textarea-element"
5. Inspect the textarea element and verify that it has id="textarea-element"
6. Activate screen reader and tab to the textarea component
7. Verify that it announces "Label" 

Note: this (last point above) is actually done by using the label prop as fallback for the aria-label attribute if the tdsAriaLabel prop isn't specified. If tdsAriaLabel is specified, it will announce that one instead, you can verify this by adding text to the "Aria Label" input in the storybook controls and tab to the element when using screen reader.


#### Scenario 4:

> Scenario: Indicate Error State with aria-invalid
> Given the component is rendered in Storybook
> When the textarea is in an error state
> Then the aria-invalid attribute should be added to the textarea to indicate that it has an error
> But currently, the aria-invalid attribute is missing, making the error state unclear to assistive technologies

How to test:
1. Go to https://pr-1136.d3fazya28914g3.amplifyapp.com/?path=/story/components-textarea--default&args=state:Error;helper:Error+message+here
2. Activate screen reader and tab to the textarea component
3. Verify that it announces "Invalid data"


#### Scenario 5:

> Scenario: Connect Helper Text Using aria-describedby
> Given the component is rendered in Storybook
> When there is helper text displayed for the textarea
> Then the aria-describedby attribute should be added to the textarea to associate it with the helper text
> But currently, the aria-describedby attribute is not present, preventing screen readers from associating the helper text with the textarea

How to test:
1. Go to https://pr-1136.d3fazya28914g3.amplifyapp.com/?path=/story/components-textarea--default&args=state:Error;helper:Error+message+here
2. Activate screen reader and tab to the textarea component
3. Verify that it announces "Error message here"

For this, similarly to how it was done for the text-field component, I also added the aria-live attribute to the helper element so that if it is changed e.g. while a user is typing, it announces the helper text immediately when it changes (with "assertive").


## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  

### Regarding scenario 2:

> Scenario: Ensure Focus Ring on Textarea
> Given the component is rendered in Storybook
> When the textarea is focused
> Then a visible focus ring should appear around the textarea to indicate focus
> But currently, the focus ring is missing, which may cause confusion for users relying on visual cues for focus

This has not been fixed, needs to be addressed by designers before we can implement it in code.