### PR TITLE
feat(text-field): custom handling for min & max when input type is Number

### DIFF
--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -101,10 +101,31 @@ export class TdsTextField {
 
   // Data input event in value prop
   handleInput(event: InputEvent): void {
-    this.value = (event.target as HTMLInputElement).value;
+    const inputEl = event.target as HTMLInputElement;
+    let { value } = inputEl;
+    
+    // Custom handling of number inputs when min is set
+    if (this.type === 'number' && this.min !== undefined) {
+      const numericValue = Number(value);
+      if (numericValue < Number(this.min)) {
+        value = String(this.min);
+        inputEl.value = value;
+      }
+    }
+  
+    // Custom handling of number inputs when max is set
+    if (this.type === 'number' && this.max !== undefined) {
+      const numericValue = Number(value);
+      if (numericValue > Number(this.max)) {
+        value = String(this.max);
+        inputEl.value = value;
+      }
+    }
+  
+    this.value = value;
     this.tdsInput.emit(event);
   }
-
+    
   /** Focus event for the Text Field */
   @Event({
     eventName: 'tdsFocus',

--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -103,29 +103,26 @@ export class TdsTextField {
   handleInput(event: InputEvent): void {
     const inputEl = event.target as HTMLInputElement;
     let { value } = inputEl;
-    
-    // Custom handling of number inputs when min is set
-    if (this.type === 'number' && this.min !== undefined) {
+
+    // Custom handling of number inputs when min/max are set
+    if (this.type === 'number') {
       const numericValue = Number(value);
-      if (numericValue < Number(this.min)) {
+
+      if (this.min !== undefined && numericValue < Number(this.min)) {
         value = String(this.min);
-        inputEl.value = value;
       }
-    }
-  
-    // Custom handling of number inputs when max is set
-    if (this.type === 'number' && this.max !== undefined) {
-      const numericValue = Number(value);
-      if (numericValue > Number(this.max)) {
+
+      if (this.max !== undefined && numericValue > Number(this.max)) {
         value = String(this.max);
-        inputEl.value = value;
       }
+
+      inputEl.value = value;
     }
-  
+
     this.value = value;
     this.tdsInput.emit(event);
   }
-    
+
   /** Focus event for the Text Field */
   @Event({
     eventName: 'tdsFocus',


### PR DESCRIPTION
## **Describe pull-request**  
Handling of input values when type is Number and Min or Max props is used.
Current behaviour allows typing of higher/lower values then set in max/min - the limits only applies when setting the number with input 'arrows'.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-604`: [CDEP-604](https://jira.scania.com/browse/CDEP-604)
- **GitHub:** Include issue link  
- **No issue:** 

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to Storybook component Text Field
2. Set Type to Number and add a min/max value
3. Confirm that it is not possible to type higher/lower numbers 

## **Checklist before submission**
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [x] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
