### PR TITLE
fix(side-menu): align padding with figma

### DIFF
--- a/packages/core/src/components/side-menu/side-menu-close-button/side-menu-close-button.scss
+++ b/packages/core/src/components/side-menu/side-menu-close-button/side-menu-close-button.scss
@@ -1,9 +1,11 @@
 :host {
+  margin-left: -2px;
+
   button {
     height: 64px;
     width: 100%;
     text-align: left;
-    padding: 0 24px;
+    padding: 0 22px;
     border: none;
     background-color: var(--tds-sidebar-side-menu-background-cover);
     font: var(--tds-headline-07);

--- a/packages/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.scss
+++ b/packages/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.scss
@@ -47,11 +47,9 @@
   .component.component-selected {
     ::slotted(a),
     ::slotted(button) {
-      border-left: 4px solid var(--tds-nav-item-border-color-active);
+      box-shadow: inset 4px 0 0 var(--tds-nav-item-border-color-active);
       padding-left: 20px;
-      background-color: var(
-        --tds-header-nav-item-dropdown-opened-background-selected
-      ); //var(--tds-grey-868);
+      background-color: var(--tds-header-nav-item-dropdown-opened-background-selected);
     }
   }
 
@@ -59,7 +57,10 @@
     &:not(.component-collapsed) {
       ::slotted(a),
       ::slotted(button) {
-        padding-left: 56px;
+        padding-left: 22px;
+        padding-top: 16px;
+        padding-right: 48px;
+        padding-bottom: 16px;
       }
     }
   }

--- a/packages/core/src/components/side-menu/side-menu-item/side-menu-item.scss
+++ b/packages/core/src/components/side-menu/side-menu-item/side-menu-item.scss
@@ -16,7 +16,7 @@
       display: flex;
       align-items: center;
       gap: 12px;
-      padding: 0 24px;
+      padding: 0 22px;
       border: none;
       background-color: var(--tds-sidebar-side-menu-background-cover);
       font: var(--tds-headline-07);


### PR DESCRIPTION
## **Describe pull-request**  
Align padding with [Figma](https://www.figma.com/design/Oyi7D6ATKzqtohR9xTsd8X/Side-menu-measurements?node-id=0-1&p=f&m=dev) example.

## **Issue Linking:**  
- **Jira:** [CDEP-209](https://jira.scania.com/browse/CDEP-209) `Align padding in code with figma design`

## **How to test**  
1. Go to Side-menu component
2. Inspect elements and compare with figma design