### PR TITLE
fix(side-menu): accessibility improvements

### DIFF
--- a/packages/core/src/components/side-menu/side-menu-close-button/side-menu-close-button.tsx
+++ b/packages/core/src/components/side-menu/side-menu-close-button/side-menu-close-button.tsx
@@ -9,15 +9,28 @@ import inheritAriaAttributes from '../../../utils/inheritAriaAttributes';
 export class TdsSideMenuCloseButton {
   @Element() host: HTMLElement;
 
+  private static handleClick() {
+    const hamburgerButton = document.querySelector('tds-header-hamburger');
+    if (hamburgerButton) {
+      hamburgerButton.setAttribute('aria-expanded', 'false');
+    }
+  }
+
   render() {
+    // Find the closest side menu to this close button
+    const sideMenuEl = this.host.closest('tds-side-menu');
+    const sideMenuId = sideMenuEl ? sideMenuEl.id : '';
+
     const buttonProps = {
       'aria-label': 'Close',
+      ...(sideMenuId && { 'aria-controls': sideMenuId }),
       ...inheritAriaAttributes(this.host),
+      'onClick': TdsSideMenuCloseButton.handleClick,
     };
     return (
       <Host>
         <button {...buttonProps}>
-          <tds-icon name="cross" size="20px"></tds-icon>
+          <tds-icon name="cross" size="20px" svgTitle="Cross"></tds-icon>
         </button>
       </Host>
     );

--- a/packages/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/packages/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -67,6 +67,7 @@ export class TdsSideMenuCollapseButton {
       <Host
         role="button"
         tabindex="0"
+        aria-expanded={!this.collapsed ? 'true' : 'false'}
         onClick={() => {
           this.handleClick();
         }}

--- a/packages/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
@@ -28,7 +28,7 @@ export class TdsSideMenuDropdownList {
 
   render() {
     return (
-      <Host role="list">
+      <Host role="list" aria-expanded={!this.collapsed ? 'true' : 'false'}>
         <div
           class={{
             'state-collapsed': this.collapsed,

--- a/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -58,6 +58,14 @@ export class TdsSideMenuDropdown {
     this.setHoverStateClosed();
   }
 
+  @Listen('keydown')
+  handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.open = !this.open;
+    }
+  }
+
   setHoverStateOpen() {
     this.hoverState = { isHovered: true, updatedAt: Date.now() };
   }
@@ -99,6 +107,7 @@ export class TdsSideMenuDropdown {
             onClick={() => {
               this.open = !this.open;
             }}
+            aria-expanded={this.getIsOpenState() ? 'true' : 'false'}
           >
             <button>
               <slot name="icon"></slot>
@@ -106,12 +115,17 @@ export class TdsSideMenuDropdown {
                 <Fragment>
                   {this.buttonLabel}
                   <slot name="label"></slot>
-                  <tds-icon class="dropdown-icon" name="chevron_down" size="16px"></tds-icon>
+                  <tds-icon
+                    class="dropdown-icon"
+                    name="chevron_down"
+                    size="16px"
+                    svgTitle="Chevron Down"
+                  ></tds-icon>
                 </Fragment>
               )}
             </button>
           </tds-side-menu-item>
-          <div class="menu">
+          <div class="menu" tabindex={this.collapsed ? '0' : null}>
             {this.collapsed && (
               <h3 class="heading-collapsed">
                 {this.buttonLabel}

--- a/packages/core/src/components/side-menu/side-menu.scss
+++ b/packages/core/src/components/side-menu/side-menu.scss
@@ -142,4 +142,16 @@ aside {
 
     overflow-y: auto;
   }
+
+  [role='navigation'] {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  li {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
 }

--- a/packages/core/src/components/side-menu/side-menu.tsx
+++ b/packages/core/src/components/side-menu/side-menu.tsx
@@ -42,7 +42,7 @@ export class TdsSideMenu {
   @Element() host: HTMLTdsSideMenuElement;
 
   /** Applicable only for mobile. If the Side Menu is open or not. */
-  @Prop() open: boolean = false;
+  @Prop({ mutable: true }) open: boolean = false;
 
   /** Applicable only for desktop. If the Side Menu should always be shown. */
   @Prop() persistent: boolean = false;
@@ -58,6 +58,9 @@ export class TdsSideMenu {
   /* To preserved initial state of collapsed prop as it is changed in runtime */
   @State() initialCollapsedState: boolean = false;
 
+  /** @internal Tracks the currently focused element index for keyboard navigation */
+  @State() activeElementIndex: number = 0;
+
   private matchesLgBreakpointMq: MediaQueryList;
 
   handleMatchesLgBreakpointChange: (e: MediaQueryListEvent) => void = (e) => {
@@ -68,6 +71,13 @@ export class TdsSideMenu {
       this.collapsed = this.initialCollapsedState;
     }
   };
+
+  @Listen('keydown', { target: 'window' })
+  handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Escape' && this.open) {
+      this.open = false;
+    }
+  }
 
   connectedCallback() {
     this.matchesLgBreakpointMq = window.matchMedia(`(min-width: ${GRID_LG_BREAKPOINT}px)`);
@@ -102,6 +112,86 @@ export class TdsSideMenu {
     });
 
     this.isCollapsed = newVal;
+  }
+
+  @Watch('open')
+  onOpenChange(newVal: boolean) {
+    if (newVal) {
+      // When menu opens, focus the first interactive element
+      setTimeout(() => {
+        const focusableElements = this.getFocusableElements();
+        if (focusableElements.length > 0) {
+          this.activeElementIndex = 0;
+          focusableElements[0].focus();
+        }
+      }, 100);
+    } else {
+      // When menu closes, focus the hamburger button
+      const hamburgerComponent = document.querySelector('tds-header-hamburger');
+      if (hamburgerComponent && hamburgerComponent.shadowRoot) {
+        const hamburgerButton = hamburgerComponent.shadowRoot.querySelector('button');
+        if (hamburgerButton) {
+          (hamburgerButton as HTMLElement).focus();
+        }
+      }
+    }
+  }
+
+  private getFocusableElements(): HTMLElement[] {
+    const focusableSelectors = [
+      'a[href]',
+      'button:not([disabled])',
+      'textarea:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(',');
+
+    const focusableInShadowRoot = Array.from(
+      this.host.shadowRoot.querySelectorAll<HTMLElement>(focusableSelectors),
+    );
+    const focusableInSlots = Array.from(
+      this.host.querySelectorAll<HTMLElement>(focusableSelectors),
+    );
+
+    /** Focusable elements */
+    return [...focusableInShadowRoot, ...focusableInSlots];
+  }
+
+  @Listen('keydown', { target: 'window', capture: true })
+  handleFocusTrap(event: KeyboardEvent) {
+    // Only trap focus if the menu is open
+    if (!this.open) return;
+
+    // We care only about the Tab key
+    if (event.key !== 'Tab') return;
+
+    const focusableElements = this.getFocusableElements();
+
+    // If there are no focusable elements
+    if (focusableElements.length === 0) return;
+
+    // Prevent default tab behavior
+    event.preventDefault();
+
+    // Going backwards (Shift + Tab) on the first element => move to last
+    if (event.shiftKey) {
+      this.activeElementIndex -= 1;
+      if (this.activeElementIndex < 0) {
+        this.activeElementIndex = focusableElements.length - 1;
+      }
+    }
+    // Going forwards (Tab) on the last element => move to first
+    else {
+      this.activeElementIndex += 1;
+      if (this.activeElementIndex >= focusableElements.length) {
+        this.activeElementIndex = 0;
+      }
+    }
+
+    // Focus the next element
+    const nextElement = focusableElements[this.activeElementIndex];
+    nextElement.focus();
   }
 
   /** Event that is emitted when the Side Menu is collapsed. */
@@ -139,12 +229,12 @@ export class TdsSideMenu {
   render() {
     return (
       <Host
-        role="navigation"
         class={{
           'menu-opened': this.open,
           'menu-persistent': this.persistent,
           'menu-collapsed': this.collapsed,
         }}
+        aria-expanded={!this.collapsed ? 'true' : 'false'}
       >
         <div
           class={{
@@ -156,16 +246,22 @@ export class TdsSideMenu {
         >
           <slot name="overlay"></slot>
           <aside class={`menu`}>
-            <slot name="close-button"></slot>
-            <div class="tds-side-menu-wrapper">
-              <ul class={`tds-side-menu-list tds-side-menu-list-upper`}>
-                <slot></slot>
-              </ul>
-              <ul class={`tds-side-menu-list tds-side-menu-list-end`}>
-                <slot name="end"></slot>
-              </ul>
+            <div role="navigation">
+              <slot name="close-button"></slot>
+              <div class="tds-side-menu-wrapper">
+                <ul class={`tds-side-menu-list tds-side-menu-list-upper`}>
+                  <li>
+                    <slot></slot>
+                  </li>
+                </ul>
+                <ul class={`tds-side-menu-list tds-side-menu-list-end`}>
+                  <li>
+                    <slot name="end"></slot>
+                  </li>
+                </ul>
+              </div>
+              <slot name="sticky-end"></slot>
             </div>
-            <slot name="sticky-end"></slot>
           </aside>
         </div>
       </Host>

--- a/packages/core/src/components/side-menu/side-menu.tsx
+++ b/packages/core/src/components/side-menu/side-menu.tsx
@@ -154,8 +154,15 @@ export class TdsSideMenu {
       this.host.querySelectorAll<HTMLElement>(focusableSelectors),
     );
 
+    const closeBtn = this.host
+      .querySelector<HTMLElement>('[slot="close-button"]')
+      ?.shadowRoot.querySelector('button');
+
+    let focusableElements = [...focusableInShadowRoot, ...focusableInSlots];
+    if (closeBtn) focusableElements.push(closeBtn);
+
     /** Focusable elements */
-    return [...focusableInShadowRoot, ...focusableInSlots];
+    return focusableElements;
   }
 
   @Listen('keydown', { target: 'window', capture: true })

--- a/packages/core/src/components/side-menu/test/default/index.html
+++ b/packages/core/src/components/side-menu/test/default/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
+
   <head>
     <meta charset="UTF-8" />
     <title>Side Menu - Default</title>
@@ -15,20 +16,20 @@
     <tds-side-menu aria-label="Side menu" id="demo-side-menu" persistent>
       <tds-side-menu-item>
         <button>
-          <tds-icon name="timer" size="24px"></tds-icon>
+          <tds-icon name="timer" size="24px" svgTitle="Timer icon" aria-hidden="true"></tds-icon>
           About us
         </button>
       </tds-side-menu-item>
 
       <tds-side-menu-item>
         <button>
-          <tds-icon name="truck" size="24px"></tds-icon>
+          <tds-icon name="truck" size="24px" svgTitle="Truck icon" aria-hidden="true"></tds-icon>
           Trucks
         </button>
       </tds-side-menu-item>
 
       <tds-side-menu-dropdown default-open selected>
-        <tds-icon slot="icon" name="profile" size="24px"></tds-icon>
+        <tds-icon slot="icon" name="profile" size="24px" svgTitle="Profile icon" aria-hidden="true"></tds-icon>
         <span slot="label">Wheel types</span>
         <tds-side-menu-dropdown-list>
           <tds-side-menu-dropdown-list-item>
@@ -42,7 +43,7 @@
 
       <tds-side-menu-item>
         <button>
-          <tds-icon name="star" size="24px"></tds-icon>
+          <tds-icon name="star" size="24px" svgTitle="Star icon" aria-hidden="true"></tds-icon>
           Values
         </button>
       </tds-side-menu-item>

--- a/packages/core/src/components/side-menu/test/default/side-menu.axe.ts
+++ b/packages/core/src/components/side-menu/test/default/side-menu.axe.ts
@@ -1,0 +1,14 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import { tegelAnalyze } from '../../../../utils/axeHelpers';
+
+const componentTestPath = 'src/components/side-menu/test/default/index.html';
+
+test.describe.parallel('Side Menu accessibility test', () => {
+  test('Should render without detected accessibility issues', async ({ page }) => {
+    await page.goto(componentTestPath);
+    const { violations } = await tegelAnalyze(page);
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## **Describe pull-request**  

### Automatic Accessibility tests
✅ I have added the axe tests

### Keyboard interactability
✅ Close Hamburger Menu with Escape Key
✅ Focus on Inner Content After Opening Hamburger Menu

🟡 Open Submenu and Focus on First Item When Pressing Enter
_Did not manage to get this as I wish. I think the current logic is OK._

✅ Reverse Tabbing in Side Menu Should Work
✅ Move Focus Out When Exiting Menu Bar

### Screen Reader behavior
✅ Add aria-expanded to Collapsible Side Menu
✅ Add aria-controls to Close Button
✅ Use aria-expanded on Collapsed Side Menu List


## **Issue Linking:**  
_Choose one of the following options_
- **Jira:**  [CDEP-424](https://jira.scania.com/browse/CDEP-424)

## **How to test**  

✅ Close Hamburger Menu with Escape Key
1. Go to the [[side menu component]](https://pr-1127.d3fazya28914g3.amplifyapp.com/?path=/story/components-side-menu--default&globals=backgrounds.value:!hex(F9FAFB))
2. Make sure you can close the side menu with escape button
---
✅ Focus on Inner Content After Opening Hamburger Menu
1. Go to the [[side menu component]](https://pr-1127.d3fazya28914g3.amplifyapp.com/?path=/story/components-side-menu--default&globals=backgrounds.value:!hex(F9FAFB))
2. When opening the side menu with keyboard the focus should be on the first item in the menu list.
---
✅ Reverse Tabbing in Side Menu Should Work
1. Go to the [[side menu component]](https://pr-1127.d3fazya28914g3.amplifyapp.com/?path=/story/components-side-menu--default&globals=backgrounds.value:!hex(F9FAFB))
2. Open the side menu with the keyboard.
3. navigate all the way through the menu list with keyboard
4. when you have focus on the last menu item, pressing tab should shift focus to the first menu item.
5. And when focus is on the first menu item and you reverse tab focus should shift to the last menu item
---
✅ Move Focus Out When Exiting Menu Bar
1. Go to the [[side menu component]](https://pr-1127.d3fazya28914g3.amplifyapp.com/?path=/story/components-side-menu--default&globals=backgrounds.value:!hex(F9FAFB))
2. When opening the side menu with keyboard and close it with esc, the focus should move out of the side menu.
---
✅ Add aria-expanded to Collapsible Side Menu
1. Go to the [[side menu component]](https://pr-1127.d3fazya28914g3.amplifyapp.com/?path=/story/components-side-menu--default&globals=backgrounds.value:!hex(F9FAFB))
2. Make sure aria-expanded are added to collapsible side menu
---
✅ Add aria-controls to Close Button
1. Go to the [[side menu component]](https://pr-1127.d3fazya28914g3.amplifyapp.com/?path=/story/components-side-menu--default&globals=backgrounds.value:!hex(F9FAFB))
2. Make sure aria-controls are added to close button
---
✅ Use aria-expanded on Collapsed Side Menu List
1. Go to the [[side menu component]](https://pr-1127.d3fazya28914g3.amplifyapp.com/?path=/story/components-side-menu--default&globals=backgrounds.value:!hex(F9FAFB))
2. Make sure aira-expanded are added on side menu sub list.

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [x] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
