### PR TITLE
ci(release): add early git tagging after core publish and safeguard

### DIFF
--- a/.github/workflows/holy-grail.yml
+++ b/.github/workflows/holy-grail.yml
@@ -132,6 +132,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # ✅ Tag immediately after successful publish
+      - name: Core - Tag version
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: |
+          VERSION=$(jq -r .version package.json)
+          git tag @scania/tegel@$VERSION
+          git push --no-verify origin @scania/tegel@$VERSION
+
       - name: Core - Commit and push changes
         run: |
           git add .
@@ -390,11 +398,17 @@ jobs:
           git config --global user.email "tegel.design.system@gmail.com"
           git remote set-url origin https://x-access-token:${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }}
 
-      - name: Core - Create git tag
-        run: git tag @scania/tegel@${{ needs.create-release-branch.outputs.version }}
-
-      - name: Core - Push git tag
-        run: git push --no-verify origin @scania/tegel@${{ needs.create-release-branch.outputs.version }}
+      # ✅ Conditionally create/push tag only if it's missing
+      - name: Check and create git tag if missing
+        run: |
+          VERSION=${{ needs.create-release-branch.outputs.version }}
+          if git rev-parse "@scania/tegel@$VERSION" >/dev/null 2>&1; then
+            echo "✅ Tag @scania/tegel@$VERSION already exists. Skipping."
+          else
+            echo "🏷️ Creating and pushing tag @scania/tegel@$VERSION..."
+            git tag @scania/tegel@$VERSION
+            git push --no-verify origin @scania/tegel@$VERSION
+          fi
 
   #MERGE DEVELOP INTO MAIN
   merge-develop-into-main:


### PR DESCRIPTION
## **Describe pull-request**  
In our current release workflow, the Git tag (e.g., @scania/tegel@1.28.0) is only created at the very end of the pipeline, after merging the release branch into develop.

This causes an issue when the core package is published successfully to npm, but the Git tag hasn’t been created yet. If the pipeline fails afterward (e.g., a wrapper build fails), our next release might incorrectly calculate the version based on the previous tag, leading to misaligned or even lower version numbers (e.g., 1.27.1 after 1.28.0).

Solution
This PR adds:

✅ A new step in the release-core job to create and push the Git tag immediately after the core is published.

✅ A safeguard in the create-git-tag job that conditionally checks if the tag already exists before trying to push it again.

This ensures:

Git and npm always stay in sync, even if the workflow fails halfway.

No duplicate tag errors.

Future version bumps are always calculated correctly.