### PR TITLE
fix(text-field): add unique id

### DIFF
--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Event, EventEmitter, h, Method, Prop, State } from '@stencil/core';
 import hasSlot from '../../utils/hasSlot';
+import generateUniqueId from '../../utils/generateUniqueId';
 
 /**
  * @slot prefix - Slot for the prefix in the component.
@@ -13,6 +14,8 @@ import hasSlot from '../../utils/hasSlot';
 })
 export class TdsTextField {
   @Element() host: HTMLElement;
+
+  private uuid: string = generateUniqueId();
 
   /** Text input for focus state */
   textInput?: HTMLInputElement;
@@ -197,7 +200,7 @@ export class TdsTextField {
       >
         {this.labelPosition === 'outside' && (
           <div class="text-field-label-outside">
-            <label htmlFor="text-field-input-element">{this.label}</label>
+            <label htmlFor={`text-field-input-element-${this.uuid}`}>{this.label}</label>
           </div>
         )}
         <div onClick={() => this.textInput.focus()} class="text-field-container">
@@ -250,11 +253,14 @@ export class TdsTextField {
               aria-label={this.tdsAriaLabel ? this.tdsAriaLabel : this.label}
               aria-describedby="text-field-helper-element"
               aria-readonly={this.readOnly}
-              id="text-field-input-element"
+              id={`text-field-input-element-${this.uuid}`}
             />
 
             {this.labelPosition === 'inside' && this.size !== 'sm' && (
-              <label class="text-field-label-inside" htmlFor="text-field-input-element">
+              <label
+                class="text-field-label-inside"
+                htmlFor={`text-field-input-element-${this.uuid}`}
+              >
                 {this.label}
               </label>
             )}


### PR DESCRIPTION
## **Describe pull-request**  
When there are multiple text-field elements on a page, when clicking on any of their labels, the first text-field is focused. This PR fixes so that the correct text-field is focused.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-662](https://jira.scania.com/browse/CDEP-662)
- **GitHub:** https://github.com/scania-digital-design-system/tegel/issues/1155

## **How to test**  
1. Go to https://pr-230.d2vh2lmnzgzrkl.amplifyapp.com/form
2. Click on the text-field labels (e.g. for Phone number) and verify that the correct text-field is focused.
3. Compare with the current code on https://react-demo.tegel.scania.com/form where it doesn't work correctly

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
None
