### PR TITLE
fix(textarea): add unique id

### DIFF
--- a/packages/core/src/components/textarea/textarea.tsx
+++ b/packages/core/src/components/textarea/textarea.tsx
@@ -1,4 +1,5 @@
 import { Component, h, Prop, State, Event, EventEmitter } from '@stencil/core';
+import generateUniqueId from '../../utils/generateUniqueId';
 
 @Component({
   tag: 'tds-textarea',
@@ -9,6 +10,8 @@ import { Component, h, Prop, State, Event, EventEmitter } from '@stencil/core';
 export class TdsTextarea {
   /** Text input for focus state */
   textEl?: HTMLTextAreaElement;
+
+  private uuid: string = generateUniqueId();
 
   /** Label text */
   @Prop() label: string = '';
@@ -158,13 +161,13 @@ export class TdsTextarea {
         }}
       >
         {this.labelPosition !== 'no-label' && (
-          <label htmlFor="textarea-element" class={'textarea-label'}>
+          <label htmlFor={`textarea-element-${this.uuid}`} class={'textarea-label'}>
             {this.label}
           </label>
         )}
         <div class="textarea-wrapper">
           <textarea
-            id="textarea-element"
+            id={`textarea-element-${this.uuid}`}
             class={'textarea-input'}
             ref={(inputEl: HTMLTextAreaElement) => {
               this.textEl = inputEl;
@@ -193,7 +196,7 @@ export class TdsTextarea {
             aria-invalid={this.state === 'error' ? 'true' : 'false'}
             aria-readonly={this.readOnly ? 'true' : 'false'}
             aria-label={this.tdsAriaLabel ? this.tdsAriaLabel : this.label}
-            aria-describedby="textarea-helper-element"
+            aria-describedby={`textarea-helper-element-${this.uuid}`}
           />
           <span class="textarea-resizer-icon">
             <svg
@@ -223,7 +226,11 @@ export class TdsTextarea {
           )}
         </div>
 
-        <span class={'textarea-helper'} aria-live="assertive" id="textarea-helper-element">
+        <span
+          class={'textarea-helper'}
+          aria-live="assertive"
+          id={`textarea-helper-element-${this.uuid}`}
+        >
           {this.state === 'error' && !this.readOnly && <tds-icon name="error" size="16px" />}
           {this.helper}
         </span>


### PR DESCRIPTION
## **Describe pull-request**  
When there are multiple textarea elements on a page, when clicking on any of their labels, the first textarea is focused. This PR fixes so that the correct textarea is focused.

## **Issue Linking:**  
- **Jira:** [CDEP-663](https://jira.scania.com/browse/CDEP-663)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to https://pr-231.d2vh2lmnzgzrkl.amplifyapp.com/form
2. Click on the labels of the two textarea elements and verify that only the one belonging to the label gets focused

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
None
