### PR TITLE
fix: minor accessibility improvements

### DIFF
--- a/packages/core/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/packages/core/src/components/accordion/accordion-item/accordion-item.tsx
@@ -80,7 +80,12 @@ export class TdsAccordionItem {
                 <slot name="header"></slot>
               </div>
               <div class="tds-accordion-icon">
-                <tds-icon svgTitle="Chevron Down" name="chevron_down" size="16px"></tds-icon>
+                <tds-icon
+                  tdsAriaHidden
+                  svgTitle="Chevron Down"
+                  name="chevron_down"
+                  size="16px"
+                ></tds-icon>
               </div>
             </button>
           </div>

--- a/packages/core/src/components/chip/chip.stories.tsx
+++ b/packages/core/src/components/chip/chip.stories.tsx
@@ -83,6 +83,16 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    tdsAriaLabel: {
+      name: 'Aria Label',
+      description: 'Sets the aria-label of the component.',
+      control: {
+        type: 'text',
+      },
+      table: {
+        defaultValue: { summary: 'A chip component' },
+      },
+    },
   },
   args: {
     inputType: 'Button',
@@ -91,10 +101,11 @@ export default {
     icon: false,
     iconPosition: 'Prefix',
     disabled: false,
+    tdsAriaLabel: 'A chip component',
   },
 };
 
-const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
+const Template = ({ inputType, size, label, icon, iconPosition, disabled, tdsAriaLabel }) => {
   const sizeLookUp = {
     Large: 'lg',
     Small: 'sm',
@@ -107,7 +118,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
     inputType === 'Button'
       ? `<tds-chip type="button" size="${
           sizeLookUp[size]
-        }"${disabledAttribute} tds-aria-label="A chip component">        
+        }"${disabledAttribute} tds-aria-label="${tdsAriaLabel}">        
             ${
               icon && iconPosition === 'Prefix'
                 ? '<tds-icon slot="prefix" name="star" size="16px"></tds-icon>'
@@ -147,9 +158,9 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
     <label id="group-1">Group 1</label>
     <div class="demo-wrapper">
       <div role="group" aria-labelledby="group-1">
-        <tds-chip type="checkbox" size="${
+        <tds-chip type="checkbox"  size="${
           sizeLookUp[size]
-        }" checked ${disabledAttribute} value="checkbox-1-value" tds-aria-label="A chip component">        
+        }" checked ${disabledAttribute} value="checkbox-1-value" tds-aria-label="Label 1">        
             ${
               icon && iconPosition === 'Prefix'
                 ? '<tds-icon slot="prefix" name="heart" size="16px"></tds-icon>'
@@ -166,7 +177,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         </tds-chip>
         <tds-chip type="checkbox" size="${
           sizeLookUp[size]
-        }" value="checkbox-2-value" tds-aria-label="A chip component">
+        }" value="checkbox-2-value" tds-aria-label="Label 2">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="email" size="16px"></tds-icon>'
@@ -183,7 +194,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         </tds-chip>
         <tds-chip type="checkbox" size="${
           sizeLookUp[size]
-        }" value="checkbox-3-value" tds-aria-label="A chip component">
+        }" value="checkbox-3-value" tds-aria-label="Label 3">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="smartphone" size="16px"></tds-icon>'
@@ -230,7 +241,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
       <div role="group" aria-labelledby="group-1">
         <tds-chip name="group1" type="radio" size="${
           sizeLookUp[size]
-        }" checked ${disabledAttribute} value="radio-1-value" tds-aria-label="A chip component">
+        }" checked ${disabledAttribute} value="radio-1-value" tds-aria-label="Label 1">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="sorting" size="16px"></tds-icon>'
@@ -247,7 +258,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         </tds-chip>
         <tds-chip name="group1" type="radio" size="${
           sizeLookUp[size]
-        }" value="radio-2-value" tds-aria-label="A chip component">
+        }" value="radio-2-value" tds-aria-label="Label 2">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="cart" size="16px"></tds-icon>'
@@ -264,7 +275,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         </tds-chip>
         <tds-chip name="group1" type="radio" size="${
           sizeLookUp[size]
-        }" value="radio-3-value" tds-aria-label="A chip component">
+        }" value="radio-3-value" tds-aria-label="Label 3">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="star" size="16px"></tds-icon>'
@@ -286,7 +297,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
       <div role="group" aria-labelledby="group-2">
         <tds-chip name="group2" type="radio" size="${
           sizeLookUp[size]
-        }" checked ${disabledAttribute} value="radio-1-value" tds-aria-label="A chip component">
+        }" checked ${disabledAttribute} value="radio-1-value" tds-aria-label="Label 1">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="sorting" size="16px"></tds-icon>'
@@ -303,7 +314,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         </tds-chip>
         <tds-chip name="group2" type="radio" size="${
           sizeLookUp[size]
-        }" value="radio-2-value" tds-aria-label="A chip component">
+        }" value="radio-2-value" tds-aria-label="Label 2">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="cart" size="16px"></tds-icon>'
@@ -320,7 +331,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         </tds-chip>
         <tds-chip name="group2" type="radio" size="${
           sizeLookUp[size]
-        }" value="radio-3-value" tds-aria-label="A chip component">
+        }" value="radio-3-value" tds-aria-label="Label 3">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="star" size="16px"></tds-icon>'

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -736,7 +736,6 @@ export class TdsDropdown {
           role="listbox"
           aria-label={this.tdsAriaLabel}
           aria-hidden={this.open ? 'false' : 'true'}
-          tabindex={this.open ? 0 : -1}
           aria-orientation="vertical"
           aria-multiselectable={this.multiselect}
           ref={(element) => {

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -735,6 +735,8 @@ export class TdsDropdown {
         <div
           role="listbox"
           aria-label={this.tdsAriaLabel}
+          aria-hidden={this.open ? 'false' : 'true'}
+          tabindex={this.open ? 0 : -1}
           aria-orientation="vertical"
           aria-multiselectable={this.multiselect}
           ref={(element) => {

--- a/packages/core/src/components/message/message.tsx
+++ b/packages/core/src/components/message/message.tsx
@@ -76,6 +76,7 @@ export class TdsMessage {
         >
           {!this.noIcon && (
             <tds-icon
+              aria-hidden="true"
               aria-label={`${this.variant}`}
               svgTitle={`${this.variant}`}
               name={this.getIconName()}

--- a/packages/core/src/components/message/test/basic/message.e2e.ts
+++ b/packages/core/src/components/message/test/basic/message.e2e.ts
@@ -29,7 +29,7 @@ test.describe.parallel(componentName, () => {
   });
 
   test('has icon', async ({ page }) => {
-    const messageIcon = page.getByRole('img');
+    const messageIcon = page.locator('tds-icon');
     await expect(messageIcon).toHaveCount(1);
     await expect(messageIcon).toBeVisible();
   });

--- a/packages/core/src/components/message/test/error/message.e2e.ts
+++ b/packages/core/src/components/message/test/error/message.e2e.ts
@@ -41,7 +41,7 @@ test.describe.parallel(componentName, () => {
   });
 
   test('has error icon', async ({ page }) => {
-    const messageIcon = page.getByRole('img');
+    const messageIcon = page.locator('tds-icon');
     await expect(messageIcon).toHaveCount(1);
     await expect(messageIcon).toBeVisible();
   });

--- a/packages/core/src/components/stepper/step/step.tsx
+++ b/packages/core/src/components/stepper/step/step.tsx
@@ -84,7 +84,9 @@ export class TdsStep {
                 size={this.size === 'lg' ? '20px' : '16px'}
               ></tds-icon>
             ) : (
-              <span class="index-container">{this.index}</span>
+              <span aria-hidden="true" class="index-container">
+                {this.index}
+              </span>
             )}
           </span>
           {!this.hideLabels && (


### PR DESCRIPTION
## **Describe pull-request**  
🟡 **Accordion**: Put aria-hidden on "Chevron Down" as its a decorative element
🟡 **Chip**: Configured in Storybook correctly for screen reader.
🟡 **Dropdown**: tabbing with SR weird focus between dropdown and helper text. fixed by setting aria-hidden on listbox when its closed.
🟡 **Message**: Making sure the icon is not reachable with screen reader
🟡 **Step**: Making sure the icon is not reachable with screen reader

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://jira.scania.com/browse/CDEP-)

## **How to test**  
1. Go to amplify link for all test cases
2. Make sure screen reader cannot access the chevron down in accordion component
3. Make sure Chip component is read out correctly in Storybook. 
4. Go to Dropdown component and make sure the dropdown is closed. Tab from the dropdown element to the helper text and make sure it works.
5. Make sure the message icon is not reachable with screen reader
5. Make sure the Step icon is not reachable with screen reader

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
