### PR TITLE
fix(text-field): add id for helper text

### DIFF
--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -251,7 +251,7 @@ export class TdsTextField {
                 }
               }}
               aria-label={this.tdsAriaLabel ? this.tdsAriaLabel : this.label}
-              aria-describedby="text-field-helper-element"
+              aria-describedby={`text-field-helper-element-${this.uuid}`}
               aria-readonly={this.readOnly}
               id={`text-field-input-element-${this.uuid}`}
             />
@@ -292,7 +292,7 @@ export class TdsTextField {
 
         <div aria-live="assertive">
           {(this.helper || this.maxLength > 0) && (
-            <div class="text-field-helper">
+            <div class="text-field-helper" id={`text-field-helper-element-${this.uuid}`}>
               {this.state === 'error' && (
                 <div class="text-field-helper-error-state">
                   {!this.readOnly && <tds-icon name="error" size="16px" />}


### PR DESCRIPTION
## **Describe pull-request**  
Adds back the id in the helper text element (was removed in a commit after it was originally added), used by screen readers. Also now added a unique id to make it work correctly when there are multiple text-field elements in one page.

## **Issue Linking:**  
None

## **How to test**  
1. Go to https://pr-1170.d3fazya28914g3.amplifyapp.com/?path=/story/components-text-field--default&args=helper:Here+is+the+helper+text
2. Activate your screen reader and tab to the text-field element
3. Verify that "Here is the helper text" is announced

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
None
