### PR TITLE
fix(side-menu): hide mobile dropdown on resize

### DIFF
--- a/packages/core/src/components/side-menu/side-menu.tsx
+++ b/packages/core/src/components/side-menu/side-menu.tsx
@@ -61,14 +61,6 @@ export class TdsSideMenu {
   /** @internal Tracks the currently focused element index for keyboard navigation */
   @State() activeElementIndex: number = 0;
 
-  private updateIsMobile() {
-    const isMobile = window.innerWidth <= GRID_LG_BREAKPOINT;
-
-    if (!isMobile) {
-      this.open = false;
-    }
-  }
-
   private matchesLgBreakpointMq: MediaQueryList;
 
   handleMatchesLgBreakpointChange: (e: MediaQueryListEvent) => void = (e) => {
@@ -77,6 +69,7 @@ export class TdsSideMenu {
       this.collapsed = false;
     } else {
       this.collapsed = this.initialCollapsedState;
+      this.open = false;
     }
   };
 
@@ -87,18 +80,11 @@ export class TdsSideMenu {
     }
   }
 
-  @Listen('resize', { target: 'window' })
-  handleResize() {
-    this.updateIsMobile();
-  }
-
   connectedCallback() {
     this.matchesLgBreakpointMq = window.matchMedia(`(min-width: ${GRID_LG_BREAKPOINT}px)`);
     this.matchesLgBreakpointMq.addEventListener('change', this.handleMatchesLgBreakpointChange);
     this.isCollapsed = this.collapsed;
     this.initialCollapsedState = this.collapsed;
-
-    this.updateIsMobile();
   }
 
   componentDidLoad() {

--- a/packages/core/src/components/side-menu/side-menu.tsx
+++ b/packages/core/src/components/side-menu/side-menu.tsx
@@ -61,6 +61,14 @@ export class TdsSideMenu {
   /** @internal Tracks the currently focused element index for keyboard navigation */
   @State() activeElementIndex: number = 0;
 
+  private updateIsMobile() {
+    const isMobile = window.innerWidth <= GRID_LG_BREAKPOINT;
+
+    if (!isMobile) {
+      this.open = false;
+    }
+  }
+
   private matchesLgBreakpointMq: MediaQueryList;
 
   handleMatchesLgBreakpointChange: (e: MediaQueryListEvent) => void = (e) => {
@@ -79,11 +87,18 @@ export class TdsSideMenu {
     }
   }
 
+  @Listen('resize', { target: 'window' })
+  handleResize() {
+    this.updateIsMobile();
+  }
+
   connectedCallback() {
     this.matchesLgBreakpointMq = window.matchMedia(`(min-width: ${GRID_LG_BREAKPOINT}px)`);
     this.matchesLgBreakpointMq.addEventListener('change', this.handleMatchesLgBreakpointChange);
     this.isCollapsed = this.collapsed;
     this.initialCollapsedState = this.collapsed;
+
+    this.updateIsMobile();
   }
 
   componentDidLoad() {


### PR DESCRIPTION
## **Describe pull-request**  
This PR fixes automatic closing of the expanded/dropdown menu from the mobile view of side-menu.

## **Issue Linking:**  
- **GitHub:** https://github.com/scania-digital-design-system/tegel/issues/1163

## **How to test**  
1. Go to the current implementation at https://tds-storybook.tegel.scania.com/?path=/story/patterns-navigation--few-navigation-items
2. Make the screen narrow
3. Open the dropdown for the side-menu in the top left corner
4. Make the screen wider 
5. Notice that it doesn't close and it's not possible to close it with the "close" button either
6. Go to the preview of the fixed version in this PR at https://pr-1173.d3fazya28914g3.amplifyapp.com/?path=/story/patterns-navigation--few-navigation-items
7. Repeat steps 2-4
8. Notice that now it closes

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
None