### PR TITLE
fix: minor accessibility improvements

### DIFF
--- a/packages/core/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/packages/core/src/components/accordion/accordion-item/accordion-item.tsx
@@ -80,7 +80,12 @@ export class TdsAccordionItem {
                 <slot name="header"></slot>
               </div>
               <div class="tds-accordion-icon">
-                <tds-icon svgTitle="Chevron Down" name="chevron_down" size="16px"></tds-icon>
+                <tds-icon
+                  tdsAriaHidden
+                  svgTitle="Chevron Down"
+                  name="chevron_down"
+                  size="16px"
+                ></tds-icon>
               </div>
             </button>
           </div>

--- a/packages/core/src/components/chip/chip.stories.tsx
+++ b/packages/core/src/components/chip/chip.stories.tsx
@@ -83,6 +83,16 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    tdsAriaLabel: {
+      name: 'Aria Label',
+      description: 'Sets the aria-label of the component.',
+      control: {
+        type: 'text',
+      },
+      table: {
+        defaultValue: { summary: 'A chip component' },
+      },
+    },
   },
   args: {
     inputType: 'Button',
@@ -91,10 +101,11 @@ export default {
     icon: false,
     iconPosition: 'Prefix',
     disabled: false,
+    tdsAriaLabel: 'A chip component',
   },
 };
 
-const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
+const Template = ({ inputType, size, label, icon, iconPosition, disabled, tdsAriaLabel }) => {
   const sizeLookUp = {
     Large: 'lg',
     Small: 'sm',
@@ -107,7 +118,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
     inputType === 'Button'
       ? `<tds-chip type="button" size="${
           sizeLookUp[size]
-        }"${disabledAttribute} tds-aria-label="A chip component">        
+        }"${disabledAttribute} tds-aria-label="${tdsAriaLabel}">        
             ${
               icon && iconPosition === 'Prefix'
                 ? '<tds-icon slot="prefix" name="star" size="16px"></tds-icon>'
@@ -147,9 +158,9 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
     <label id="group-1">Group 1</label>
     <div class="demo-wrapper">
       <div role="group" aria-labelledby="group-1">
-        <tds-chip type="checkbox" size="${
+        <tds-chip type="checkbox"  size="${
           sizeLookUp[size]
-        }" checked ${disabledAttribute} value="checkbox-1-value" tds-aria-label="A chip component">        
+        }" checked ${disabledAttribute} value="checkbox-1-value" tds-aria-label="Label 1">        
             ${
               icon && iconPosition === 'Prefix'
                 ? '<tds-icon slot="prefix" name="heart" size="16px"></tds-icon>'
@@ -166,7 +177,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         </tds-chip>
         <tds-chip type="checkbox" size="${
           sizeLookUp[size]
-        }" value="checkbox-2-value" tds-aria-label="A chip component">
+        }" value="checkbox-2-value" tds-aria-label="Label 2">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="email" size="16px"></tds-icon>'
@@ -183,7 +194,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         </tds-chip>
         <tds-chip type="checkbox" size="${
           sizeLookUp[size]
-        }" value="checkbox-3-value" tds-aria-label="A chip component">
+        }" value="checkbox-3-value" tds-aria-label="Label 3">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="smartphone" size="16px"></tds-icon>'
@@ -230,7 +241,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
       <div role="group" aria-labelledby="group-1">
         <tds-chip name="group1" type="radio" size="${
           sizeLookUp[size]
-        }" checked ${disabledAttribute} value="radio-1-value" tds-aria-label="A chip component">
+        }" checked ${disabledAttribute} value="radio-1-value" tds-aria-label="Label 1">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="sorting" size="16px"></tds-icon>'
@@ -247,7 +258,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         </tds-chip>
         <tds-chip name="group1" type="radio" size="${
           sizeLookUp[size]
-        }" value="radio-2-value" tds-aria-label="A chip component">
+        }" value="radio-2-value" tds-aria-label="Label 2">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="cart" size="16px"></tds-icon>'
@@ -264,7 +275,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         </tds-chip>
         <tds-chip name="group1" type="radio" size="${
           sizeLookUp[size]
-        }" value="radio-3-value" tds-aria-label="A chip component">
+        }" value="radio-3-value" tds-aria-label="Label 3">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="star" size="16px"></tds-icon>'
@@ -286,7 +297,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
       <div role="group" aria-labelledby="group-2">
         <tds-chip name="group2" type="radio" size="${
           sizeLookUp[size]
-        }" checked ${disabledAttribute} value="radio-1-value" tds-aria-label="A chip component">
+        }" checked ${disabledAttribute} value="radio-1-value" tds-aria-label="Label 1">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="sorting" size="16px"></tds-icon>'
@@ -303,7 +314,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         </tds-chip>
         <tds-chip name="group2" type="radio" size="${
           sizeLookUp[size]
-        }" value="radio-2-value" tds-aria-label="A chip component">
+        }" value="radio-2-value" tds-aria-label="Label 2">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="cart" size="16px"></tds-icon>'
@@ -320,7 +331,7 @@ const Template = ({ inputType, size, label, icon, iconPosition, disabled }) => {
         </tds-chip>
         <tds-chip name="group2" type="radio" size="${
           sizeLookUp[size]
-        }" value="radio-3-value" tds-aria-label="A chip component">
+        }" value="radio-3-value" tds-aria-label="Label 3">
           ${
             icon && iconPosition === 'Prefix'
               ? '<tds-icon slot="prefix" name="star" size="16px"></tds-icon>'

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -376,6 +376,9 @@ export class TdsDropdown {
         this.inputElement.value = this.selectedOptions.length ? this.getValue() : '';
       }
     }
+
+    // Update the inert state of dropdown list when open state changes
+    this.updateDropdownListInertState();
   }
 
   @Watch('defaultValue')
@@ -574,6 +577,9 @@ export class TdsDropdown {
     if (form) {
       form.addEventListener('reset', this.resetInput);
     }
+
+    // Initialize inert state after rendering
+    this.updateDropdownListInertState();
   }
 
   disconnectedCallback() {
@@ -586,6 +592,16 @@ export class TdsDropdown {
   connectedCallback() {
     if (!this.tdsAriaLabel) {
       console.warn('Tegel Dropdown component: tdsAriaLabel prop is missing');
+    }
+  }
+
+  private updateDropdownListInertState() {
+    if (this.dropdownList) {
+      if (this.open) {
+        this.dropdownList.removeAttribute('inert');
+      } else {
+        this.dropdownList.setAttribute('inert', '');
+      }
     }
   }
 
@@ -761,6 +777,7 @@ export class TdsDropdown {
           role="listbox"
           aria-label={this.tdsAriaLabel}
           aria-hidden={this.open ? 'false' : 'true'}
+          inert={!this.open}
           aria-orientation="vertical"
           aria-multiselectable={this.multiselect}
           ref={(element) => {

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -658,7 +658,7 @@ export class TdsDropdown {
                   </div>
                 )}
                 <input
-                  aria-label={!labelId ? this.tdsAriaLabel : undefined}
+                  aria-label={this.tdsAriaLabel}
                   aria-labelledby={labelId}
                   aria-describedby={helperId}
                   aria-disabled={this.disabled}
@@ -723,7 +723,7 @@ export class TdsDropdown {
             </div>
           ) : (
             <button
-              aria-label={!labelId ? this.tdsAriaLabel : undefined}
+              aria-label={this.tdsAriaLabel}
               aria-labelledby={labelId}
               aria-describedby={helperId}
               aria-disabled={this.disabled}

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -15,6 +15,7 @@ import findNextFocusableElement from '../../utils/findNextFocusableElement';
 import findPreviousFocusableElement from '../../utils/findPreviousFocusableElement';
 import appendHiddenInput from '../../utils/appendHiddenInput';
 import { convertToString, convertArrayToStrings } from '../../utils/convertToString';
+import generateUniqueId from '../../utils/generateUniqueId';
 
 /**
  * @slot <default> - <b>Unnamed slot.</b> For dropdown option elements.
@@ -590,6 +591,11 @@ export class TdsDropdown {
 
   render() {
     appendHiddenInput(this.host, this.name, this.selectedOptions.join(','), this.disabled);
+
+    // Generate unique IDs for associating labels and helpers with the input/button
+    const labelId = this.label ? `dropdown-label-${this.name || generateUniqueId()}` : undefined;
+    const helperId = this.helper ? `dropdown-helper-${this.name || generateUniqueId()}` : undefined;
+
     return (
       <Host
         class={{
@@ -597,7 +603,9 @@ export class TdsDropdown {
         }}
       >
         {this.label && this.labelPosition === 'outside' && (
-          <div class={`label-outside ${this.disabled ? 'disabled' : ''}`}>{this.label}</div>
+          <div id={labelId} class={`label-outside ${this.disabled ? 'disabled' : ''}`}>
+            {this.label}
+          </div>
         )}
         <div
           class={{
@@ -617,10 +625,13 @@ export class TdsDropdown {
             >
               <div class="value-wrapper">
                 {this.label && this.labelPosition === 'inside' && this.placeholder && (
-                  <div class={`label-inside ${this.size}`}>{this.label}</div>
+                  <div id={labelId} class={`label-inside ${this.size}`}>
+                    {this.label}
+                  </div>
                 )}
                 {this.label && this.labelPosition === 'inside' && !this.placeholder && (
                   <div
+                    id={labelId}
                     class={`
                     label-inside-as-placeholder
                     ${this.size}
@@ -631,7 +642,9 @@ export class TdsDropdown {
                   </div>
                 )}
                 <input
-                  aria-label={this.tdsAriaLabel}
+                  aria-label={!labelId ? this.tdsAriaLabel : undefined}
+                  aria-labelledby={labelId}
+                  aria-describedby={helperId}
                   aria-disabled={this.disabled}
                   // eslint-disable-next-line no-return-assign
                   ref={(inputEl) => (this.inputElement = inputEl as HTMLInputElement)}
@@ -694,7 +707,9 @@ export class TdsDropdown {
             </div>
           ) : (
             <button
-              aria-label={this.tdsAriaLabel}
+              aria-label={!labelId ? this.tdsAriaLabel : undefined}
+              aria-labelledby={labelId}
+              aria-describedby={helperId}
               aria-disabled={this.disabled}
               onClick={() => this.handleToggleOpen()}
               onKeyDown={(event) => {
@@ -711,10 +726,13 @@ export class TdsDropdown {
             >
               <div class={`value-wrapper ${this.size}`}>
                 {this.label && this.labelPosition === 'inside' && this.placeholder && (
-                  <div class={`label-inside ${this.size}`}>{this.label}</div>
+                  <div id={labelId} class={`label-inside ${this.size}`}>
+                    {this.label}
+                  </div>
                 )}
                 {this.label && this.labelPosition === 'inside' && !this.placeholder && (
                   <div
+                    id={labelId}
                     class={`
                     label-inside-as-placeholder
                     ${this.size}
@@ -767,6 +785,7 @@ export class TdsDropdown {
         {/* DROPDOWN LIST */}
         {this.helper && (
           <div
+            id={helperId}
             class={{
               helper: true,
               error: this.error,

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -356,6 +356,13 @@ export class TdsDropdown {
       children[elementIndex].focus();
     } else if (event.key === 'Escape') {
       this.open = false;
+      // Return focus to input/button when Escape key is used
+      if (this.filter) {
+        this.inputElement?.focus();
+      } else {
+        const button = this.host.shadowRoot.querySelector('button');
+        button?.focus();
+      }
     }
   }
 
@@ -670,7 +677,7 @@ export class TdsDropdown {
                 size="16px"
               ></tds-icon>
               <tds-icon
-                tabIndex={0}
+                tdsAriaHidden
                 role="button"
                 aria-label="Open/Close dropdown"
                 svgTitle="Open/Close dropdown"
@@ -735,6 +742,7 @@ export class TdsDropdown {
         <div
           role="listbox"
           aria-label={this.tdsAriaLabel}
+          aria-hidden={this.open ? 'false' : 'true'}
           aria-orientation="vertical"
           aria-multiselectable={this.multiselect}
           ref={(element) => {

--- a/packages/core/src/components/dropdown/test/default/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/default/dropdown.e2e.ts
@@ -25,7 +25,8 @@ testConfigurations.withModeVariants.forEach((config) => {
     });
 
     test('clicking the dropdown button opens the dropdown-list', async ({ page }) => {
-      const dropdownButton = page.getByRole('button', { name: 'Placeholder' });
+      const dropdown = page.getByTestId('tds-dropdown-testid');
+      const dropdownButton = dropdown.getByRole('button');
       const dropdownListElementOne = page
         .locator('tds-dropdown-option')
         .filter({ hasText: 'Option 1' });
@@ -42,7 +43,8 @@ testConfigurations.withModeVariants.forEach((config) => {
 
     test('clicking the dropdown opens the dropdown-list, then click Option 1', async ({ page }) => {
       /* click the dropdown button */
-      const dropdownButton = page.getByRole('button', { name: 'Placeholder' });
+      const dropdown = page.getByTestId('tds-dropdown-testid');
+      const dropdownButton = dropdown.getByRole('button');
       await dropdownButton.click();
 
       /* Click the Option 1 button */
@@ -53,9 +55,8 @@ testConfigurations.withModeVariants.forEach((config) => {
       await dropdownListElementOneButton.click();
 
       await expect(dropdownListElementOneButton).toBeHidden();
-      const dropdownButtonWithOption1 = page.getByRole('button', { name: 'Option 1' });
-      await expect(dropdownButtonWithOption1.first()).toBeVisible();
 
+      await expect(dropdownButton).toHaveText(/Option 1/);
       /* also check screenshot diff to make sure it says Option 1 */
       await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
     });
@@ -98,8 +99,10 @@ test.describe.parallel(componentName, () => {
   });
 
   test('have the placeholder="Placeholder" text', async ({ page }) => {
-    const dropdownButton = page.getByRole('button', { name: 'Placeholder' });
-    await expect(dropdownButton).toBeVisible();
+    // Check that the placeholder text is visible
+    const dropdown = page.getByTestId('tds-dropdown-testid');
+    const dropdownButton = dropdown.getByRole('button');
+    await expect(dropdownButton).toHaveText(/Placeholder/);
   });
 
   test('clicking the dropdown opens the dropdown-list, then click an option 2 that is disabled should not close it', async ({
@@ -108,20 +111,21 @@ test.describe.parallel(componentName, () => {
     const dropdownListElementTwoButton = page
       .locator('tds-dropdown-option')
       .filter({ hasText: /Option 2/ });
-    const dropdownButtonElement = page.getByRole('button', { name: 'Placeholder' });
+    const dropdown = page.getByTestId('tds-dropdown-testid');
+    const dropdownButton = dropdown.getByRole('button');
 
     /* before clicking dropdownlist should not be visible, the button should be */
-    await expect(dropdownButtonElement).toBeVisible();
+    await expect(dropdownButton).toBeVisible();
     await expect(dropdownListElementTwoButton).toBeHidden();
 
     /* after clicking dropdownlist should be visible, the button should also be */
-    await dropdownButtonElement.click();
-    await expect(dropdownButtonElement).toBeVisible();
+    await dropdownButton.click();
+    await expect(dropdownButton).toBeVisible();
     await expect(dropdownListElementTwoButton).toBeVisible();
 
     /* after clicking option 2 that is disabled list should be visible and also button should be */
     await dropdownListElementTwoButton.click();
-    await expect(dropdownButtonElement).toBeVisible();
+    await expect(dropdownButton).toBeVisible();
     await expect(dropdownListElementTwoButton).toBeVisible();
   });
 });

--- a/packages/core/src/components/dropdown/test/error/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/error/dropdown.e2e.ts
@@ -29,7 +29,8 @@ testConfigurations.withModeVariants.forEach((config) => {
         .locator('tds-dropdown-option')
         .filter({ hasText: /Option 1/ })
         .getByRole('option');
-      const dropdownButton = page.getByRole('button', { name: 'Placeholder' });
+      const dropdown = page.getByTestId('tds-dropdown-testid');
+      const dropdownButton = dropdown.getByRole('button');
 
       /* before clicking dropdownlist should not be visible, the button should be */
       await expect(dropdownButton).toBeVisible();

--- a/packages/core/src/components/dropdown/test/multiselect/dropdown.e2e.ts
+++ b/packages/core/src/components/dropdown/test/multiselect/dropdown.e2e.ts
@@ -28,7 +28,8 @@ testConfigurations.withModeVariants.forEach((config) => {
       page,
     }) => {
       /* click the dropdown button */
-      const dropdownButton = page.getByRole('button', { name: 'Placeholder' });
+      const dropdown = page.getByTestId('tds-dropdown-testid');
+      const dropdownButton = dropdown.getByRole('button');
       await dropdownButton.click();
 
       /* Click the Option 1 button */
@@ -38,8 +39,9 @@ testConfigurations.withModeVariants.forEach((config) => {
       await dropdownListElementOneButton.click();
 
       await expect(dropdownListElementOneButton).toBeVisible();
-      const dropdownButtonWithOption1 = page.getByRole('button', { name: 'Option 1' });
-      await expect(dropdownButtonWithOption1.first()).toBeVisible();
+
+      // Check that the dropdown button now has the text "Option 1"
+      await expect(dropdownButton).toHaveText(/Option 1/);
 
       /* also check screenshot diff to make sure it says Option 1 */
       await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });
@@ -49,20 +51,21 @@ testConfigurations.withModeVariants.forEach((config) => {
       page,
     }) => {
       /* click the button */
-      const dropdownButton = page.getByRole('button', { name: 'Placeholder' });
+      const dropdown = page.getByTestId('tds-dropdown-testid');
+      const dropdownButton = dropdown.getByRole('button');
       await dropdownButton.click();
 
       /* get all checkboxes */
-      const dropdownListElementOneButton = page
+      const dropdownListElementOneButton = dropdown
         .getByText(/Option 1/)
         .filter({ has: page.getByRole('checkbox') });
-      const dropdownListElementTwoButton = page
+      const dropdownListElementTwoButton = dropdown
         .getByText(/Option 2/)
         .filter({ has: page.getByRole('checkbox') });
-      const dropdownListElementThreeButton = page
+      const dropdownListElementThreeButton = dropdown
         .getByText(/Option 3/)
         .filter({ has: page.getByRole('checkbox') });
-      const dropdownListElementFourButton = page
+      const dropdownListElementFourButton = dropdown
         .getByText(/Option 4/)
         .filter({ has: page.getByRole('checkbox') });
       await expect(dropdownListElementOneButton).toHaveCount(1);
@@ -72,19 +75,21 @@ testConfigurations.withModeVariants.forEach((config) => {
 
       /* check each one and see that it updates correctly */
       await dropdownListElementOneButton.click();
-      const inputText = page.getByRole('button', { name: /Option 1/ });
-      await expect(inputText).toHaveCount(1);
+
+      // Check that the dropdown button now has the text "Option 1"
+      await expect(dropdownButton).toHaveText(/Option 1/);
 
       await dropdownListElementTwoButton.click();
-      await expect(inputText).toHaveCount(1);
+      // Option 2 is disabled, so clicking it shouldn't change the text
+      await expect(dropdownButton).toHaveText(/Option 1/);
 
       await dropdownListElementThreeButton.click();
-      const inputText2 = page.getByRole('button', { name: /Option 1, Option 3/ });
-      await expect(inputText2).toHaveCount(1);
+      // Now the button should show "Option 1, Option 3"
+      await expect(dropdownButton).toHaveText(/Option 1, Option 3/);
 
       await dropdownListElementFourButton.click();
-      const inputText3 = page.getByRole('button', { name: /Option 1, Option 3, Option 4/ });
-      await expect(inputText3).toHaveCount(1);
+      // Now the button should show "Option 1, Option 3, Option 4"
+      await expect(dropdownButton).toHaveText(/Option 1, Option 3, Option 4/);
 
       /* also check screenshot diff to make sure */
       await expect(page).toHaveScreenshot({ maxDiffPixels: 0 });

--- a/packages/core/src/components/message/message.tsx
+++ b/packages/core/src/components/message/message.tsx
@@ -76,6 +76,7 @@ export class TdsMessage {
         >
           {!this.noIcon && (
             <tds-icon
+              aria-hidden="true"
               aria-label={`${this.variant}`}
               svgTitle={`${this.variant}`}
               name={this.getIconName()}

--- a/packages/core/src/components/message/test/basic/message.e2e.ts
+++ b/packages/core/src/components/message/test/basic/message.e2e.ts
@@ -29,7 +29,7 @@ test.describe.parallel(componentName, () => {
   });
 
   test('has icon', async ({ page }) => {
-    const messageIcon = page.getByRole('img');
+    const messageIcon = page.locator('tds-icon');
     await expect(messageIcon).toHaveCount(1);
     await expect(messageIcon).toBeVisible();
   });

--- a/packages/core/src/components/message/test/error/message.e2e.ts
+++ b/packages/core/src/components/message/test/error/message.e2e.ts
@@ -41,7 +41,7 @@ test.describe.parallel(componentName, () => {
   });
 
   test('has error icon', async ({ page }) => {
-    const messageIcon = page.getByRole('img');
+    const messageIcon = page.locator('tds-icon');
     await expect(messageIcon).toHaveCount(1);
     await expect(messageIcon).toBeVisible();
   });

--- a/packages/core/src/components/stepper/step/step.tsx
+++ b/packages/core/src/components/stepper/step/step.tsx
@@ -84,7 +84,9 @@ export class TdsStep {
                 size={this.size === 'lg' ? '20px' : '16px'}
               ></tds-icon>
             ) : (
-              <span class="index-container">{this.index}</span>
+              <span aria-hidden="true" class="index-container">
+                {this.index}
+              </span>
             )}
           </span>
           {!this.hideLabels && (


### PR DESCRIPTION
## **Describe pull-request**  
Fixing minor a11y issues found in the second a11y audit

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://jira.scania.com/browse/CDEP-)

## **How to test**  
1. Go to aws link and test the following new fixes
🟡 **Accordion**: [Chevron Down icon] should not be focusable
🟡 **Chip**: Configured in Storybook correctly for screen reader.
🟡 **Dropdown**: Closing Dropdown with keyboard return focus to main input
🟡 **Dropdown**: When Dropdown is closed. Dropdown option should not be focusable
🟡 **Dropdown**: Screen reader should first read [LABEL], [HELPERTEXT] if it exist.
🟡 **Message**: Icon within message component should not be reachable with screen reader
🟡 **Step**: Making sure the icon is not reachable with screen reader

## **Checklist before submission**
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [x] Keyboard operability
- [x] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
