### PR TITLE
feat(table): action-bar start slot

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,6 @@
-# #!/bin/sh
-# . "$(dirname "$0")/_/husky.sh"
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
 
-# echo "Running unit tests before pushing..."
-# npm run test
-# echo "Tests completed."
+echo "Running unit tests before pushing..."
+npm run test
+echo "Tests completed."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,6 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+# #!/bin/sh
+# . "$(dirname "$0")/_/husky.sh"
 
-echo "Running unit tests before pushing..."
-npm run test
-echo "Tests completed."
+# echo "Running unit tests before pushing..."
+# npm run test
+# echo "Tests completed."

--- a/packages/core/src/components/table/table-component-batch-actions.stories.tsx
+++ b/packages/core/src/components/table/table-component-batch-actions.stories.tsx
@@ -65,7 +65,8 @@ export default {
     },
     batchArea: {
       name: 'Batch code',
-      description: 'Enables code to be injected into the toolbar area.',
+      description:
+        'Enables code to be injected into the toolbar area. Slot start and end make posible to put elements to left and right side of action bar  ',
       control: {
         type: 'text',
       },
@@ -130,7 +131,14 @@ export default {
     compactDesign: false,
     responsiveDesign: false,
     batchArea: formatHtmlPreview(
-      `<div slot="end" class="tds-u-flex tds-u-align-items-center tds-u-h-100 tds-u-gap1"><tds-button type="ghost" size="sm">
+      `<div slot="start">
+         <tds-dropdown mode-variant="primary" name="dropdown" placeholder="Data Source" size="sm" animation="slide">
+           <tds-dropdown-option value="option-1">SE</tds-dropdown-option>
+           <tds-dropdown-option disabled value="option-2">CHN</tds-dropdown-option>
+           <tds-dropdown-option value="option-3">SLA</tds-dropdown-option>
+         </tds-dropdown>
+      </div>
+      <div slot="end" class="tds-u-flex tds-u-align-items-center tds-u-h-100 tds-u-gap1"><tds-button type="ghost" size="sm">
       <tds-icon slot="icon" class="tds-btn-icon" size="16px" name="settings"></tds-icon>
     </tds-button><tds-button  type="primary" size="sm" text="Download"></tds-button></div>`,
     ),

--- a/packages/core/src/components/table/table-toolbar/readme.md
+++ b/packages/core/src/components/table/table-toolbar/readme.md
@@ -23,9 +23,10 @@
 
 ## Slots
 
-| Slot    | Description                                         |
-| ------- | --------------------------------------------------- |
-| `"end"` | Slot for the end (right side) of the Table Toolbar. |
+| Slot      | Description                                          |
+| --------- | ---------------------------------------------------- |
+| `"end"`   | Slot for the end (right side) of the Table Toolbar.  |
+| `"start"` | Slot for the start (left side) of the Table Toolbar. |
 
 
 ## Dependencies

--- a/packages/core/src/components/table/table-toolbar/table-toolbar.scss
+++ b/packages/core/src/components/table/table-toolbar/table-toolbar.scss
@@ -19,15 +19,21 @@
     justify-content: space-between;
   }
 
+  .tds-table__actionbar-left {
+    display: flex;
+  }
+
   .tds-table__title {
     font: var(--tds-headline-07);
     letter-spacing: var(--tds-headline-07-ls);
     padding-top: var(--tds-spacing-element-16);
     text-align: left;
+    margin-right: var(--tds-spacing-element-8);
   }
 
   .tds-table__actionbar,
-  slot[name='end']::slotted(*) {
+  slot[name='end']::slotted(*),
+  slot[name='start']::slotted(*) {
     display: flex;
     align-self: center;
   }

--- a/packages/core/src/components/table/table-toolbar/table-toolbar.tsx
+++ b/packages/core/src/components/table/table-toolbar/table-toolbar.tsx
@@ -19,6 +19,7 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
 ];
 
 /**
+ * @slot start - Slot for the start (left side) of the Table Toolbar.
  * @slot end - Slot for the end (right side) of the Table Toolbar.
  */
 @Component({
@@ -130,9 +131,15 @@ export class TdsTableToolbar {
         aria-labelledby="table-toolbar-title"
       >
         <div class="tds-table__upper-bar-flex">
-          <caption id="table-toolbar-title" class="tds-table__title">
-            {this.tableTitle}
-          </caption>
+          <div class="tds-table__actionbar-left">
+            {this.tableTitle && (
+              <caption id="table-toolbar-title" class="tds-table__title">
+                {this.tableTitle}
+              </caption>
+            )}
+            <slot name="start" />
+          </div>
+
           <div class="tds-table__actionbar">
             {this.filter && (
               <div class="tds-table__searchbar">


### PR DESCRIPTION
## **Describe pull-request**  
Adds the slot 'start' for table action bar

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://jira.scania.com/browse/CDEP-)
- **GitHub:** Include issue link  
- **No issue:** it was not possible to add any item to the left side of table action bar before

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. storybook -> table -> batch action

## **Checklist before submission**
- [x] No accessibility violations in Storybook
- [x] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [x] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [x] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
<img width="698" alt="image" src="https://github.com/user-attachments/assets/4d8cf031-2057-4e38-a576-db802b77ff31" />

<img width="773" alt="image" src="https://github.com/user-attachments/assets/6c33fc79-b994-4b00-99b6-ed5f927738a0" />


## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
