### PR TITLE
feat(dropdown): enhance focus handling for filter and non-filter modes

### DIFF
--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -246,7 +246,17 @@ export class TdsDropdown {
   /** Method that forces focus on the input element. */
   @Method()
   async focusElement() {
-    this.focusInputElement();
+    if (this.filter) {
+      // For filter mode, focus the input element
+      this.focusInputElement();
+    } else {
+      // For non-filter mode, focus the button element
+      const button = this.host.shadowRoot.querySelector('button');
+      if (button) {
+        button.focus();
+      }
+    }
+    // Always trigger the focus event to open the dropdown
     this.handleFocus({});
   }
 
@@ -492,7 +502,14 @@ export class TdsDropdown {
     if (!this.disabled) {
       this.open = !this.open;
       if (this.open) {
-        this.focusInputElement();
+        if (this.filter) {
+          this.focusInputElement();
+        } else {
+          const button = this.host.shadowRoot.querySelector('button');
+          if (button) {
+            button.focus();
+          }
+        }
       }
     }
   };
@@ -542,11 +559,13 @@ export class TdsDropdown {
   private handleFocus = (event) => {
     this.open = true;
     this.filterFocus = true;
-    if (this.multiselect) {
+    if (this.multiselect && this.inputElement) {
       this.inputElement.value = '';
     }
     this.tdsFocus.emit(event);
-    this.handleFilter({ target: { value: '' } });
+    if (this.filter) {
+      this.handleFilter({ target: { value: '' } });
+    }
   };
 
   private handleBlur = (event) => {


### PR DESCRIPTION
## **Describe pull-request**  
Added support for programmatically focusing dropdown components even when no option is selected. This enhancement improves usability by allowing developers to focus the dropdown using the focusElement() method regardless of selection state, which opens the dropdown and allows the user to make a selection. It correctly handles both regular dropdowns (focusing the button) and filter dropdowns (focusing the input).

## **Issue Linking:**  
_Choose one of the following options_
- **GitHub:** Related to #904 

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
Steps to test coming soon...


## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
