### PR TITLE
fix(textarea): only render error icon when helper text is present

### DIFF
--- a/packages/core/src/components/textarea/textarea.tsx
+++ b/packages/core/src/components/textarea/textarea.tsx
@@ -231,7 +231,9 @@ export class TdsTextarea {
           aria-live="assertive"
           id={`textarea-helper-element-${this.uuid}`}
         >
-          {this.state === 'error' && !this.readOnly && <tds-icon name="error" size="16px" />}
+          {this.state === 'error' && this.helper && !this.readOnly && (
+            <tds-icon name="error" size="16px" />
+          )}
           {this.helper}
         </span>
 


### PR DESCRIPTION
## **Describe pull-request**  
Not rendering error icon when there is no helper text to align with behaviour of tds-text-field.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:**: [CDEP-824](https://jira.scania.com/browse/CDEP-824)
- **GitHub:** https://github.com/scania-digital-design-system/tegel/issues/1215 

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to textarea component in storybook.
2. Set state to 'error' without providing a helper text. Note that the error icon isn't present.
3. Add helper text, confirm that error icon & helper text is displayed.

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
**Before:** 

<img width="500" alt="image" src="https://github.com/user-attachments/assets/6cdaf522-fc2a-41fd-999e-0fbe923c4ebc" />

**After:**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/3cd8094b-c3a0-4770-8e56-7fdef35a6697" />

