### PR TITLE
fix(style dictionary): dark mode fix for tokens

### DIFF
--- a/style-dictionary.config.mjs
+++ b/style-dictionary.config.mjs
@@ -148,7 +148,7 @@ const themeConfigs = Array.from(brands.values()).reduce((configs, brand) => {
     const colorTokensSelector = brand.name === 'scania'
       ? themeType === 'light'
         ? `:root,\n.tds-mode-light,\n.scania .tds-mode-light`
-        : `.tds-dark-mode,\n.scania .tds-dark-mode`
+        : `.tds-mode-dark,\n.scania .tds-mode-dark`
       : themeType === 'light'
         ? `.traton .tds-mode-light`
         : `.traton .tds-mode-dark`;

--- a/tokens/scss/scania/color-dark.scss
+++ b/tokens/scss/scania/color-dark.scss
@@ -2,8 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.tds-dark-mode,
-.scania .tds-dark-mode {
+.tds-mode-dark,
+.scania .tds-mode-dark {
   --color-background-base: var(--scania-color-grey-950);
   --color-background-accent-primary-default: var(--scania-color-blue-400);
   --color-background-accent-primary-disabled: var(--scania-color-grey-850);

--- a/transform-tokens.mjs
+++ b/transform-tokens.mjs
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
 // Read the primitive tokens
-const primitivePath = join(process.cwd(), 'tokens-json', 'primitive', 'default.json');
+const primitivePath = join(process.cwd(), 'tokens', 'json', 'primitive', 'default.json');
 const fileContent = readFileSync(primitivePath, 'utf8');
 const primitiveTokens = JSON.parse(fileContent);
 


### PR DESCRIPTION
## **Describe pull-request**  
Fixing incorrect configuration of dark mode class

## **Issue Linking:**  
- **No issue:** In style dictionary when generating the files, the `.tds-mode-dark` class was incorrect. Also `transform-tokens`-script had not been updated to reflect the change of name for tokens dir.


## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to Storybook
2. Verify that dark mode in Scania works.