### PR TITLE
fix(storybook): exclude tegel-light

### DIFF
--- a/packages/core/.storybook/main.ts
+++ b/packages/core/.storybook/main.ts
@@ -10,10 +10,12 @@ function loadStories() {
   );
 
   // If in development environment, return all story files
-  // Otherwise, exclude stories from the _beta folder
+  // Otherwise, exclude stories from the _beta and tegel-light folders
   return process.env.VITE_STORYBOOK_ENV === 'dev'
     ? storyFiles
-    : storyFiles.filter((file: string | string[]) => !file.includes('/_beta/'));
+    : storyFiles.filter(
+        (file: string | string[]) => !file.includes('/_beta/') && !file.includes('/tegel-light/'),
+      );
 }
 
 let addons = [


### PR DESCRIPTION
## **Describe pull-request**  
Exclude tegel-light stories from prod storybook

## **Issue Linking:**  
- **No issue:** Noticed today that tegel-light stories are not excluded

## **How to test**  
1. Check this branc on your local
2. Set no env variable
3. Run code
4. There should not be tegel-light stories
5. Try setting VITE_STORYBOOK_ENV=dev and see if you get tegel-light in Stroybook