### PR TITLE
fix(checkbox): implement new variable tokens

### DIFF
--- a/packages/core/src/components/checkbox/checkbox-vars.scss
+++ b/packages/core/src/components/checkbox/checkbox-vars.scss
@@ -12,10 +12,23 @@ tds-checkbox {
   // units
   --checkbox-background-opacity-hover: 0.12;
   --checkbox-background-opacity-focus: 0.24;
+}
 
-  // images
-  --checkbox-background-img: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-  --checkbox-background-img-indeterminate: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%23ffffff'/></svg>");
-  --checkbox-background-img-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23b0b7c4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-  --checkbox-background-img-indeterminate-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%23b0b7c4'/></svg>");
+// Icons
+.tds-mode-light {
+  tds-checkbox {
+    --checkbox-background-img: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+    --checkbox-background-img-indeterminate: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%23ffffff'/></svg>");
+    --checkbox-background-img-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23b0b7c4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+    --checkbox-background-img-indeterminate-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%23b0b7c4'/></svg>");
+  }
+}
+
+.tds-mode-dark {
+  tds-checkbox {
+    --checkbox-background-img: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%230D0F13' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+    --checkbox-background-img-indeterminate: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%230D0F13'/></svg>");
+    --checkbox-background-img-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%2356657A' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+    --checkbox-background-img-indeterminate-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%2356657A'/></svg>");
+  }
 }

--- a/packages/core/src/components/checkbox/checkbox-vars.scss
+++ b/packages/core/src/components/checkbox/checkbox-vars.scss
@@ -1,35 +1,21 @@
-:root,
-.tds-mode-light {
-  --tds-checkbox-color: var(--tds-grey-900);
-  --tds-checkbox-interaction-01: var(--tds-blue-800);
-  --tds-checkbox-interaction-02: var(--tds-white);
-  --tds-checkbox-background-hover: var(--tds-blue-800);
-  --tds-checkbox-background-focus: var(--tds-blue-800);
-  --tds-checkbox-background-opacity-hover: 0.12;
-  --tds-checkbox-background-opacity-focus: 0.24;
-  --tds-checkbox-disabled: var(--tds-grey-400);
-  --tds-checkbox-background-img: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-  --tds-checkbox-background-img-indeterminate: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%23ffffff'/></svg>");
-  --tds-checkbox-background-img-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23b0b7c4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-  --tds-checkbox-background-img-indeterminate-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%23b0b7c4'/></svg>");
-  --tds-checkbox-border-color-disabled-after: var(--tds-grey-500);
-  --tds-checkbox-color-disabled-after: var(--tds-grey-500);
+tds-checkbox {
+  --checkbox-label: var(--color-foreground-text-strong);
+  --checkbox-label-disabled: var(--color-foreground-text-disabled);
+  --checkbox-icon: var(--color-foreground-icon-strong);
+  --checkbox-fill: var(--color-foreground-icon-inverse-strong);
+  --checkbox-fill-disabled: var(--color-background-accent-primary-disabled);
+  --checkbox-border: var(--color-foreground-border-strong);
+  --checkbox-border-hover: var(--color-foreground-border-subtle);
+  --checkbox-border-focus: var(--color-foreground-border-accent-focus);
+  --checkbox-border-disabled: var(--color-foreground-border-discrete);
 
-  // TODO - Add correct colors for dark theme
-  .tds-mode-dark {
-    --tds-checkbox-color: var(--tds-white);
-    --tds-checkbox-interaction-01: var(--tds-white);
-    --tds-checkbox-interaction-02: var(--tds-grey-958);
-    --tds-checkbox-background-hover: var(--tds-grey-600);
-    --tds-checkbox-background-focus: var(--tds-grey-600);
-    --tds-checkbox-background-opacity-hover: 0.48;
-    --tds-checkbox-background-opacity-focus: 0.72;
-    --tds-checkbox-disabled: white;
-    --tds-checkbox-background-img: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%230D0F13' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-    --tds-checkbox-background-img-indeterminate: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%230D0F13'/></svg>");
-    --tds-checkbox-background-img-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%2356657A' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-    --tds-checkbox-background-img-indeterminate-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%2356657A'/></svg>");
-    --tds-checkbox-border-color-disabled-after: var(--tds-grey-700);
-    --tds-checkbox-color-disabled-after: var(--tds-grey-700);
-  }
+  // units
+  --checkbox-background-opacity-hover: 0.12;
+  --checkbox-background-opacity-focus: 0.24;
+
+  // images
+  --checkbox-background-img: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  --checkbox-background-img-indeterminate: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%23ffffff'/></svg>");
+  --checkbox-background-img-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23b0b7c4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  --checkbox-background-img-indeterminate-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%23b0b7c4'/></svg>");
 }

--- a/packages/core/src/components/checkbox/checkbox-vars.scss
+++ b/packages/core/src/components/checkbox/checkbox-vars.scss
@@ -12,16 +12,10 @@ tds-checkbox {
   // units
   --checkbox-background-opacity-hover: 0.12;
   --checkbox-background-opacity-focus: 0.24;
-}
-
-// Icons
-.tds-mode-light {
-  tds-checkbox {
-    --checkbox-background-img: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-    --checkbox-background-img-indeterminate: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%23ffffff'/></svg>");
-    --checkbox-background-img-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23b0b7c4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-    --checkbox-background-img-indeterminate-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%23b0b7c4'/></svg>");
-  }
+  --checkbox-background-img: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  --checkbox-background-img-indeterminate: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%23ffffff'/></svg>");
+  --checkbox-background-img-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23b0b7c4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  --checkbox-background-img-indeterminate-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='2' viewBox='0 0 8 2' fill='none' xmlns='http://www.w3.org/2000/svg'><rect y='0.5' width='8' height='1' rx='0.5' fill='%23b0b7c4'/></svg>");
 }
 
 .tds-mode-dark {

--- a/packages/core/src/components/checkbox/checkbox.scss
+++ b/packages/core/src/components/checkbox/checkbox.scss
@@ -1,4 +1,5 @@
 @import '../../mixins/box-sizing';
+@import '../../../../../typography/utilities/typography-utility';
 
 :host {
   // If the user sets a custom height on the checkbox
@@ -15,10 +16,9 @@
 
 .tds-checkbox {
   @include tds-box-sizing;
+  @include detail-02;
 
-  font: var(--tds-detail-02);
-  letter-spacing: var(--tds-detail-02-ls);
-  color: var(--tds-checkbox-text);
+  color: var(--checkbox-label);
   display: flex;
   align-items: center;
   margin-left: -4px;
@@ -37,7 +37,7 @@
     align-self: flex-start;
 
     + label {
-      color: var(--tds-checkbox-color);
+      color: var(--checkbox-label);
       padding-left: var(--tds-spacing-element-4);
       padding-top: var(--tds-spacing-element-4);
       padding-bottom: var(--tds-spacing-element-4);
@@ -72,8 +72,8 @@
     }
 
     &::after {
-      border: 1px solid var(--tds-checkbox-interaction-01);
-      background-color: var(--tds-checkbox-interaction-02);
+      border: 1px solid var(--checkbox-border);
+      background-color: var(--checkbox-fill);
       width: 16px;
       height: 16px;
       left: 4px;
@@ -83,15 +83,15 @@
 
     &:hover {
       &::before {
-        background-color: var(--tds-checkbox-background-hover);
-        opacity: var(--tds-checkbox-background-opacity-hover);
+        background-color: var(--checkbox-border-hover);
+        opacity: var(--checkbox-background-opacity-hover);
       }
     }
 
     &:focus {
       &::before {
-        background-color: var(--tds-checkbox-background-focus);
-        opacity: var(--tds-checkbox-background-opacity-focus);
+        background-color: var(--checkbox-border-focus);
+        opacity: var(--checkbox-background-opacity-focus);
         transition: opacity 0.2s ease-in-out;
       }
     }
@@ -101,11 +101,11 @@
       cursor: not-allowed;
 
       &::after {
-        border-color: var(--tds-checkbox-border-color-disabled-after);
+        border-color: var(--checkbox-border-disabled);
       }
 
       + label {
-        color: var(--tds-grey-600);
+        color: var(--checkbox-label-disabled);
         cursor: not-allowed;
       }
 
@@ -118,16 +118,16 @@
 
     &:checked {
       &::after {
-        background-image: var(--tds-checkbox-background-img);
-        background-color: var(--tds-checkbox-interaction-01);
+        background-image: var(--checkbox-background-img);
+        background-color: var(--checkbox-border);
         background-repeat: no-repeat;
         background-position: center;
       }
 
       &:hover {
         &::before {
-          background-color: var(--tds-checkbox-background-hover);
-          opacity: var(--tds-checkbox-background-opacity-hover);
+          background-color: var(--checkbox-border-hover);
+          opacity: var(--checkbox-background-opacity-hover);
         }
       }
 
@@ -144,17 +144,17 @@
         }
 
         &::after {
-          background-image: var(--tds-checkbox-background-img-disabled);
-          background-color: var(--tds-checkbox-interaction-02);
-          color: var(--tds-checkbox-color-disabled-after);
+          background-image: var(--checkbox-background-img-disabled);
+          background-color: var(--checkbox-fill-disabled);
+          color: var(--checkbox-border-disabled);
         }
       }
     }
 
     &:indeterminate {
       &::after {
-        background-image: var(--tds-checkbox-background-img-indeterminate);
-        background-color: var(--tds-checkbox-interaction-01);
+        background-image: var(--checkbox-background-img-indeterminate);
+        background-color: var(--checkbox-border);
         background-repeat: no-repeat;
         background-position: center;
       }
@@ -171,9 +171,9 @@
         }
 
         &::after {
-          background-image: var(--tds-checkbox-background-img-indeterminate-disabled);
-          background-color: var(--tds-checkbox-interaction-02);
-          color: var(--tds-checkbox-color-disabled-after);
+          background-image: var(--checkbox-background-img-indeterminate-disabled);
+          background-color: var(--checkbox-fill-disabled);
+          color: var(--checkbox-border-disabled);
         }
       }
     }


### PR DESCRIPTION
## **Describe pull-request**  
Implementation of new variable tokens for colors

## **Issue Linking:**  

- **Jira:**`feat(checkbox): start using new color & typography token system in CSS files`: [CDEP-748](https://jira.scania.com/browse/CDEP-748)


## **How to test**  
1. Go to Checkbox in storybook, compare with "live [Checkbox](https://tds-storybook.tegel.scania.com/?path=/story/components-checkbox--default)"
Link to [Figma](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=13865-180378&m=dev) if needed
2. Play with controls
3. Toggle darkmode and change background color in storybook preview
4. Toggle Traton

## **Additional context**  
Right now different SVG:s are imported in CSS as background images, depending on dark/light theme, therefor we need to keep the selectors. This might be for further inspection in a later PR.
