### PR TITLE
fix(dropdown): add label parameter to setValue to revert breaking change

### DIFF
--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -17,6 +17,11 @@ import appendHiddenInput from '../../utils/appendHiddenInput';
 import { convertToString, convertArrayToStrings } from '../../utils/convertToString';
 import generateUniqueId from '../../utils/generateUniqueId';
 
+function hasValueChanged(newValue: string[], currentValue: string[]): boolean {
+  if (newValue.length !== currentValue.length) return true;
+  return newValue.some((val) => !currentValue.includes(val));
+}
+
 /**
  * @slot <default> - <b>Unnamed slot.</b> For dropdown option elements.
  */
@@ -104,7 +109,7 @@ export class TdsDropdown {
     const normalizedValue = this.normalizeValue(newValue);
 
     // Only update if actually changed
-    if (this.hasValueChanged(normalizedValue, this.selectedOptions)) {
+    if (hasValueChanged(normalizedValue, this.selectedOptions)) {
       this.updateDropdownStateFromUser(normalizedValue);
     }
   }
@@ -131,11 +136,6 @@ export class TdsDropdown {
       .toString()
       .split(',')
       .filter((v) => v !== '');
-  }
-
-  private hasValueChanged(newValue: string[], currentValue: string[]): boolean {
-    if (newValue.length !== currentValue.length) return true;
-    return newValue.some((val) => !currentValue.includes(val));
   }
 
   private updateDropdownStateInternal(values: string[]) {
@@ -217,8 +217,24 @@ export class TdsDropdown {
     });
   }
 
+  /** Method for setting the selected value of the Dropdown.
+   *
+   * Single selection example:
+   *
+   * <code>
+   *  dropdown.setValue('option-1', 'Option 1');
+   * </code>
+   *
+   * Multiselect example:
+   *
+   * <code>
+   *  dropdown.setValue(['option-1', 'option-2']);
+   * </code>
+   */
   @Method()
-  async setValue(value: string | number | string[] | number[]) {
+  // @ts-expect-error for label: the label is optional here ONLY to not break the API. Should be removed for 2.0.
+  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+  async setValue(value: string | number | string[] | number[], label?: string) {
     let normalizedValue: string[];
     if (Array.isArray(value)) {
       normalizedValue = convertArrayToStrings(value);
@@ -259,25 +275,6 @@ export class TdsDropdown {
     // Always trigger the focus event to open the dropdown
     this.handleFocus({});
   }
-
-  /** Method for setting the value of the Dropdown.
-   *
-   * Single selection example:
-   *
-   * <code>
-   *  dropdown.setValue('option-1', 'Option 1');
-   * </code>
-   *
-   * Multiselect example:
-   *
-   * <code>
-   *  dropdown.setValue(['option-1', 'option-2']);
-   * </code>
-   */
-  @Method()
-  //  The label is optional here ONLY to not break the API. Should be removed for 2.0.
-  // @ts-ignore
-  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 
   /** Method for closing the Dropdown. */
   @Method()
@@ -328,7 +325,7 @@ export class TdsDropdown {
   onAnyClick(event: MouseEvent) {
     if (this.open) {
       // Source: https://lamplightdev.com/blog/2021/04/10/how-to-detect-clicks-outside-of-a-web-component/
-      const isClickOutside = !event.composedPath().includes(this.host as any);
+      const isClickOutside = !event.composedPath().includes(this.host);
       if (isClickOutside) {
         this.open = false;
       }

--- a/packages/core/src/components/dropdown/readme.md
+++ b/packages/core/src/components/dropdown/readme.md
@@ -46,19 +46,7 @@
 
 ### `close() => Promise<void>`
 
-Method for setting the value of the Dropdown.
-
-Single selection example:
-
-<code>
-dropdown.setValue('option-1', 'Option 1');
-</code>
-
-Multiselect example:
-
-<code>
-dropdown.setValue(['option-1', 'option-2']);
-</code>
+Method for closing the Dropdown.
 
 #### Returns
 
@@ -102,15 +90,28 @@ Type: `Promise<void>`
 
 
 
-### `setValue(value: string | number | string[] | number[]) => Promise<{ value: string | number; label: string; }[]>`
+### `setValue(value: string | number | string[] | number[], label?: string) => Promise<{ value: string | number; label: string; }[]>`
 
+Method for setting the selected value of the Dropdown.
 
+Single selection example:
+
+<code>
+dropdown.setValue('option-1', 'Option 1');
+</code>
+
+Multiselect example:
+
+<code>
+dropdown.setValue(['option-1', 'option-2']);
+</code>
 
 #### Parameters
 
 | Name    | Type                                       | Description |
 | ------- | ------------------------------------------ | ----------- |
 | `value` | `string \| number \| string[] \| number[]` |             |
+| `label` | `string`                                   |             |
 
 #### Returns
 


### PR DESCRIPTION
## **Describe pull-request**  
This PR fixes the previously introduced breaking change by adding back the label parameter for the setValue method in dropdown.tsx. I also needed to address some other console warnings when I committed the code.

## **Issue Linking:**  
None

## **How to test**  
Nothing to test

## **Checklist before submission**
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
None