### PR TITLE
fix(icons-gallery): updated link to icon story

### DIFF
--- a/packages/core/src/stories/foundations/icons-gallery.stories.tsx
+++ b/packages/core/src/stories/foundations/icons-gallery.stories.tsx
@@ -54,7 +54,7 @@ const Template = () => {
         <p class="tds-body-01">
             The icons displayed here provide an easy overview of all available icons in the library. 
             Each icon is shown at 48px for presentation purposes only; we do not recommend using this size in the product. 
-            To export a single icon, we suggest using the <a href="/?path=/story/foundations-icons--default">Component</a> story.
+            To export a single icon, we suggest using the <a href="/?path=/story/components-icon--default">Component</a> story.
         </p>
         <div style="width: 256px;">
             <tds-text-field


### PR DESCRIPTION
## **Describe pull-request**  
Icon story was moved from Foundations to Components and had gotten a new path because of it, so this link was broken before. Should work now!

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-1046](https://jira.scania.com/browse/CDEP-1046)
- ~**GitHub:** Include issue link~
- ~**No issue:** Describe the problem being solved.~

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to icons gallery in Storybook
2. Click the link inside the description, referring to the icon component page
3. Verify ending up in the correct story without error message

## **Checklist before submission**
- [x] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
