### PR TITLE
build: support just ".traton" in color tokens

### DIFF
--- a/build-tokens.mjs
+++ b/build-tokens.mjs
@@ -11,7 +11,8 @@ mkdirSync(componentDir, { recursive: true });
 
 // Transform tokens to remove 'cy' from font family names
 console.log('Transforming tokens...');
-execSync('node transform-tokens.mjs', { stdio: 'inherit' });
+// Import and execute the transform directly instead of using execSync
+import('./transform-tokens.mjs');
 
 register(StyleDictionary);
 

--- a/style-dictionary.config.mjs
+++ b/style-dictionary.config.mjs
@@ -150,7 +150,7 @@ const themeConfigs = Array.from(brands.values()).reduce((configs, brand) => {
         ? `:root,\n.tds-mode-light,\n.scania .tds-mode-light`
         : `.tds-mode-dark,\n.scania .tds-mode-dark`
       : themeType === 'light'
-        ? `.traton .tds-mode-light`
+        ? `.traton,\n.traton .tds-mode-light`
         : `.traton .tds-mode-dark`;
 
     configs[themeName] = {

--- a/tokens/scss/traton/color-light.scss
+++ b/tokens/scss/traton/color-light.scss
@@ -2,6 +2,7 @@
  * Do not edit directly, this file was auto-generated.
  */
 
+.traton,
 .traton .tds-mode-light {
   --color-background-base: var(--traton-color-grey-50);
   --color-background-accent-primary-default: var(--traton-color-blue-800);


### PR DESCRIPTION
## **Describe pull-request**  
Updated the Style Dictionary configuration to include both base and light mode selectors for Traton brand color tokens. This ensures that color tokens are applied at both the base .traton level and specifically for .traton .tds-mode-light, providing better CSS specificity and flexibility for theme switching.

## **Issue Linking:**  
- **Jira:** Add ticket number after `CDEP-`: [CDEP-1054](https://jira.scania.com/browse/CDEP-1054)

## **How to test**  
1. Check `tokens/scss/traton/color-light.scss` and see that `.traton `class is added
2. Check the style dictionary file and see if class ".traton" is added there. 
3. Do not run style dictionary as we might get unwanted changes now. 

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [X] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [X] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors


