### PR TITLE
fix(holy-grail): ensure npm version bump works in scheduled runs

### DIFF
--- a/.github/workflows/holy-grail.yml
+++ b/.github/workflows/holy-grail.yml
@@ -38,6 +38,11 @@ on:
   schedule:
     - cron: '0 3 * * 1-5' #3AM every weekday
 
+env:
+  VERSION: patch
+  NODE_VERSION: '22.11.0'
+  TAG: latest
+
 jobs:
   #CREATE RELEASE BRANCH
   create-release-branch:
@@ -54,22 +59,22 @@ jobs:
       - name: Core - Bump version
         id: core-version
         working-directory: packages/core
-        run: npm version ${{ github.event.inputs.version || 'patch' }} --no-git-tag-version
+        run: npm version ${{ github.event.inputs.version || env.VERSION }} --no-git-tag-version
 
       - name: Angular - Bump version
         id: angular-version
         working-directory: packages/angular
-        run: npm version ${{ github.event.inputs.version || 'patch' }} --no-git-tag-version
+        run: npm version ${{ github.event.inputs.version || env.VERSION }} --no-git-tag-version
 
       - name: Angular 17 - Bump version
         id: angular-17-version
         working-directory: packages/angular-17/projects/components
-        run: npm version ${{ github.event.inputs.version || 'patch' }} --no-git-tag-version
+        run: npm version ${{ github.event.inputs.version || env.VERSION }} --no-git-tag-version
 
       - name: React - Bump version
         id: react-version
         working-directory: packages/react
-        run: npm version ${{ github.event.inputs.version || 'patch' }} --no-git-tag-version
+        run: npm version ${{ github.event.inputs.version || env.VERSION }} --no-git-tag-version
 
       - name: Core - Read package.json Version
         id: version
@@ -119,7 +124,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ github.event.inputs.nodeVersion }}
+          node-version: ${{ github.event.inputs.nodeVersion || env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Set up Git for authentication
@@ -198,7 +203,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ github.event.inputs.nodeVersion }}
+          node-version: ${{ github.event.inputs.nodeVersion || env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Set Tegel user
@@ -282,7 +287,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ github.event.inputs.nodeVersion }}
+          node-version: ${{ github.event.inputs.nodeVersion || env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies in root
@@ -322,7 +327,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ github.event.inputs.nodeVersion }}
+          node-version: ${{ github.event.inputs.nodeVersion || env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies in root
@@ -366,7 +371,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ github.event.inputs.nodeVersion }}
+          node-version: ${{ github.event.inputs.nodeVersion || env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: React - Read package.json Version
@@ -462,7 +467,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ github.event.inputs.nodeVersion }}
+          node-version: ${{ github.event.inputs.nodeVersion || env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Set up Git for authentication

--- a/.github/workflows/holy-grail.yml
+++ b/.github/workflows/holy-grail.yml
@@ -54,22 +54,22 @@ jobs:
       - name: Core - Bump version
         id: core-version
         working-directory: packages/core
-        run: npm version ${{ github.event.inputs.version }} --no-git-tag-version
+        run: npm version ${{ github.event.inputs.version || 'patch' }} --no-git-tag-version
 
       - name: Angular - Bump version
         id: angular-version
         working-directory: packages/angular
-        run: npm version ${{ github.event.inputs.version }} --no-git-tag-version
+        run: npm version ${{ github.event.inputs.version || 'patch' }} --no-git-tag-version
 
       - name: Angular 17 - Bump version
         id: angular-17-version
         working-directory: packages/angular-17/projects/components
-        run: npm version ${{ github.event.inputs.version }} --no-git-tag-version
+        run: npm version ${{ github.event.inputs.version || 'patch' }} --no-git-tag-version
 
       - name: React - Bump version
         id: react-version
         working-directory: packages/react
-        run: npm version ${{ github.event.inputs.version }} --no-git-tag-version
+        run: npm version ${{ github.event.inputs.version || 'patch' }} --no-git-tag-version
 
       - name: Core - Read package.json Version
         id: version


### PR DESCRIPTION
## **Describe pull-request**  
Scheduled (cron) triggers don’t provide workflow inputs like version, which previously caused npm version to silently fail during automated dry runs.

This PR introduces a global env: block to define fallback defaults:

![image](https://github.com/user-attachments/assets/bb1cf526-5224-438e-afc6-2bf865784448)

Now, version bumping and related actions use:

`${{ github.event.inputs.version || env.VERSION }}`

This ensures versioning works reliably in both manual and scheduled executions.
## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://jira.scania.com/browse/CDEP-)
- **GitHub:** Include issue link  
- **No issue:** Describe the problem being solved.  

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to...
2. Check in...
3. Run ...

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
