### PR TITLE
docs(storybook): add yellow scale to color palette

### DIFF
--- a/packages/core/src/stories/foundations/color/colors.mdx
+++ b/packages/core/src/stories/foundations/color/colors.mdx
@@ -119,6 +119,20 @@ These are our core brand colors. Note: The brand palette is currently under revi
   <div className="color-item" style={{ backgroundColor: '#112616' }}>var(--tds-green-900)</div>
 </div>
 
+### Yellow Scale
+<div className="color-grid">
+  <div className="color-item light-text" style={{ backgroundColor: '#f9eec3' }}>var(--tds-yellow-50)</div>
+  <div className="color-item light-text" style={{ backgroundColor: '#f8e596' }}>var(--tds-yellow-100)</div>
+  <div className="color-item light-text" style={{ backgroundColor: '#f4d65d' }}>var(--tds-yellow-200)</div>
+  <div className="color-item light-text" style={{ backgroundColor: '#f1c21b' }}>var(--tds-yellow-300)</div>
+  <div className="color-item light-text" style={{ backgroundColor: '#eaad06' }}>var(--tds-yellow-400)</div>
+  <div className="color-item" style={{ backgroundColor: '#b87c14' }}>var(--tds-yellow-500)</div>
+  <div className="color-item" style={{ backgroundColor: '#975717' }}>var(--tds-yellow-600)</div>
+  <div className="color-item" style={{ backgroundColor: '#6b3b10' }}>var(--tds-yellow-700)</div>
+  <div className="color-item" style={{ backgroundColor: '#4d260a' }}>var(--tds-yellow-800)</div>
+  <div className="color-item" style={{ backgroundColor: '#361b07' }}>var(--tds-yellow-900)</div>
+</div>
+
 ## Semantic Colors (To Be Removed)
 
 <div className="color-grid">


### PR DESCRIPTION
## **Describe pull-request**  
I have added the yellow color scale to Storybook since its missing. 

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-1047](https://jira.scania.com/browse/CDEP-1047)


## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to the [color system in Storybook](https://pr-1305.d3fazya28914g3.amplifyapp.com/?path=/docs/foundations-color-system--docs).
3. Make sure the yellow color scale exists amongst the other colors

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
![yellow-scale](https://github.com/user-attachments/assets/0cd0f1f6-728e-4048-b04b-8b15351d3e1f)

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
