### PR TITLE
feat(dropdown-option): add tdsAriaLabel prop for dropdown option

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -35,6 +35,9 @@ export class TdsDropdownOption {
   /** Sets the option as disabled. */
   @Prop() disabled: boolean = false;
 
+  /** Defines aria-label attribute for the option */
+  @Prop() tdsAriaLabel: string;
+
   @State() selected: boolean = false;
 
   @State() multiselect: boolean = false;
@@ -43,7 +46,7 @@ export class TdsDropdownOption {
 
   private parentElement: HTMLTdsDropdownElement | null = null;
 
-  // @ts-ignore
+  // @ts-expect-error - label property is used internally for text content tracking
   // eslint-disable-next-line no-unused-vars,
   private label: string = '';
 
@@ -90,6 +93,12 @@ export class TdsDropdownOption {
 
   componentWillLoad() {
     this.internalValue = convertToString(this.value);
+  }
+
+  connectedCallback() {
+    if (!this.tdsAriaLabel && !this.multiselect) {
+      console.warn('Tegel Dropdown component: tdsAriaLabel prop is missing');
+    }
   }
 
   componentWillRender = () => {
@@ -176,6 +185,7 @@ export class TdsDropdownOption {
                 }}
                 disabled={this.disabled}
                 checked={this.selected}
+                tdsAriaLabel={this.tdsAriaLabel}
                 class={{
                   [this.size]: true,
                 }}
@@ -190,6 +200,7 @@ export class TdsDropdownOption {
               role="option"
               aria-disabled={this.disabled}
               aria-selected={this.selected}
+              aria-label={this.tdsAriaLabel}
               onClick={() => {
                 this.handleSingleSelect();
               }}

--- a/packages/core/src/components/dropdown/dropdown-option/readme.md
+++ b/packages/core/src/components/dropdown/dropdown-option/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                  | Type               | Default     |
-| ---------- | ---------- | ---------------------------- | ------------------ | ----------- |
-| `disabled` | `disabled` | Sets the option as disabled. | `boolean`          | `false`     |
-| `value`    | `value`    | Value of the dropdown option | `number \| string` | `undefined` |
+| Property       | Attribute        | Description                                 | Type               | Default     |
+| -------------- | ---------------- | ------------------------------------------- | ------------------ | ----------- |
+| `disabled`     | `disabled`       | Sets the option as disabled.                | `boolean`          | `false`     |
+| `tdsAriaLabel` | `tds-aria-label` | Defines aria-label attribute for the option | `string`           | `undefined` |
+| `value`        | `value`          | Value of the dropdown option                | `number \| string` | `undefined` |
 
 
 ## Events


### PR DESCRIPTION
## **Describe pull-request**  
This pull request adds accessibility improvements to the dropdown option component by introducing a tdsAriaLabel prop.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://jira.scania.com/browse/CDEP-)
- **GitHub:** Include issue link  
- **No issue:** Describe the problem being solved.  

## **How to test**  
1. Go to Storybook and navigate to the Dropdown component
2. Check in the browser's developer tools that dropdown options now accept a tdsAriaLabel prop
3. Run a screen reader test to verify that options are properly announced when the tdsAriaLabel is provided
4. Test both single-select and multi-select dropdown configurations
5. Verify that the console warning appears when tdsAriaLabel is missing for single-select options

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [x] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [x] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

