### PR TITLE
feat(storybook): add support for primary and secondary mode variants for light and dark themes

### DIFF
--- a/packages/core/.storybook/preview.ts
+++ b/packages/core/.storybook/preview.ts
@@ -7,11 +7,47 @@ import '../dist/tegel/tegel.css';
 import './preview.css';
 import { ScaniaDark, ScaniaLight } from './ScaniaLogotype';
 
+const applyBackgroundColor = (brand: string, modeVariant: string, isDarkMode: boolean) => {
+  const body = document.body;
+
+  const backgrounds = {
+    scania: {
+      light: {
+        primary: '#FFFFFF',
+        secondary: '#F6F7F9',
+      },
+      dark: {
+        primary: '#0E1013',
+        secondary: '#15181D',
+      },
+    },
+    traton: {
+      light: {
+        primary: '#FCFBF7',
+        secondary: '#F6F3E9',
+      },
+      dark: {
+        primary: '#001214',
+        secondary: '#001D21',
+      },
+    },
+  };
+
+  const brandColors = backgrounds[brand]?.[isDarkMode ? 'dark' : 'light'];
+  body.style.backgroundColor = brandColors?.[modeVariant] || '';
+};
+
 const channel = addons.getChannel();
 
 channel.on('DARK_MODE', (isDarkMode) => {
-  document.body.classList.remove('tds-mode-light', 'tds-mode-dark');
-  document.body.classList.add(`tds-mode-${isDarkMode ? 'dark' : 'light'}`);
+  const body = document.body;
+  const brand = document.documentElement.classList.contains('traton') ? 'traton' : 'scania';
+  const modeVariant = body.classList.contains('tds-mode-secondary') ? 'secondary' : 'primary';
+
+  body.classList.remove('tds-mode-light', 'tds-mode-dark');
+  body.classList.add(`tds-mode-${isDarkMode ? 'dark' : 'light'}`);
+
+  applyBackgroundColor(brand, modeVariant, isDarkMode);
 });
 
 // DEV env for traton styles
@@ -37,13 +73,36 @@ const toggleBrandTool = isDev
     }
   : undefined;
 
-const toggleBrandDecorator: Decorator = (StoryFn, context) => {
-  const brand = context.globals.brand || 'scania';
+// Toggle mode variant
+const modeVariantTool = {
+  modeVariant: {
+    name: 'Mode Variant',
+    description: 'Choose between primary or secondary mode',
+    defaultValue: 'primary',
+    toolbar: {
+      icon: 'circlehollow',
+      items: [
+        { value: 'primary', title: 'Primary' },
+        { value: 'secondary', title: 'Secondary' },
+      ],
+      showName: true,
+      dynamicTitle: true,
+    },
+  },
+};
 
+const toggleBrandDecorator: Decorator = (StoryFn, context) => {
+  const { brand = context.globals.brand || 'scania', modeVariant = 'primary' } = context.globals;
   const html = document.documentElement;
 
   html.classList.remove('scania', 'traton');
   html.classList.add(brand);
+
+  document.body.classList.remove('tds-mode-primary', 'tds-mode-secondary');
+  document.body.classList.add(`tds-mode-${modeVariant}`);
+
+  const isDarkMode = document.body.classList.contains('tds-mode-dark');
+  applyBackgroundColor(brand, modeVariant, isDarkMode);
 
   return StoryFn();
 };
@@ -155,6 +214,10 @@ const preview: Preview = {
 
 defineCustomElements();
 
-export const globalTypes = toggleBrandTool;
+export const globalTypes = {
+  ...toggleBrandTool,
+  ...modeVariantTool,
+};
+
 export const decorators = [toggleBrandDecorator];
 export default preview;


### PR DESCRIPTION
## **Describe pull-request**  
Currently, Storybook for Tegel components only offers background toggling between light mode and dark mode. However, many Tegel components support additional theming through modeVariant properties such as primary and secondary.

This enhancement request proposes adding primary and secondary mode options under each of the existing background modes (light and dark). This would allow for more accurate component previews in Storybook, matching real-world implementations more closely.

## **Issue Linking:**  
- **Jira:** : [CDEP-1066](https://jira.scania.com/browse/CDEP-1066)

## **How to test**  
1. Open preview link
2. Go to any component, let's pick dropdown as example
3. Now pick brand, TRATON for example
4. In the toolbar, Switch between primary and secondary mode and notice how the background color of the canvas changes.
5. Switch to dark mode and repeat step 4.
6. Try also with the Scania brand and repeat step 4/5

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
