### PR TITLE
fix(text-field): add tooltip to read only and remove old label

### DIFF
--- a/packages/core/src/components/text-field/readme.md
+++ b/packages/core/src/components/text-field/readme.md
@@ -65,12 +65,15 @@ Type: `Promise<void>`
 
 ### Depends on
 
+- [tds-tooltip](../tooltip)
 - [tds-icon](../icon)
 
 ### Graph
 ```mermaid
 graph TD;
+  tds-text-field --> tds-tooltip
   tds-text-field --> tds-icon
+  tds-tooltip --> tds-popover-core
   style tds-text-field fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/core/src/components/text-field/text-field.scss
+++ b/packages/core/src/components/text-field/text-field.scss
@@ -295,17 +295,8 @@
   transform: translateY(-50%);
   color: var(--tds-text-field-icon-read-only-label-color);
 
-  &-label {
-    display: none;
-    position: absolute;
-    right: 18px;
-    top: 48px;
-    font: var(--tds-detail-05);
-    letter-spacing: var(--tds-detail-05-ls);
-    padding: 8px;
-    white-space: nowrap;
-    border-radius: 4px 0 4px 4px;
-    background-color: var(--tds-text-field-icon-read-only-label-background);
+  & .tds-tooltip {
+    min-width: 150px;
   }
 }
 

--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -284,10 +284,14 @@ export class TdsTextField {
 
           {this.readOnly && !this.hideReadOnlyIcon && (
             <span class="text-field-icon__readonly">
-              <tds-icon name="edit_inactive" size="20px" />
+              <tds-tooltip
+                placement="top-end"
+                text="This field is non-editable"
+                selector="#readonly-tooltip"
+              />
+              <tds-icon id="readonly-tooltip" name="edit_inactive" size="20px" />
             </span>
           )}
-          <span class="text-field-icon__readonly-label">This field is non-editable</span>
         </div>
 
         <div aria-live="assertive">

--- a/packages/core/src/components/tooltip/readme.md
+++ b/packages/core/src/components/tooltip/readme.md
@@ -103,6 +103,7 @@ Example:
 
 ### Used by
 
+ - [tds-text-field](../text-field)
  - [tds-textarea](../textarea)
 
 ### Depends on
@@ -113,6 +114,7 @@ Example:
 ```mermaid
 graph TD;
   tds-tooltip --> tds-popover-core
+  tds-text-field --> tds-tooltip
   tds-textarea --> tds-tooltip
   style tds-tooltip fill:#f9f,stroke:#333,stroke-width:4px
 ```


### PR DESCRIPTION
## **Describe pull-request**  
Remove and replace the current hover state that displays a label to the correct view of tooltip instead.

## **Issue Linking:**  
[CDEP-1087](https://jira.scania.com/browse/CDEP-1087)

## **How to test**  
1. Go to -- and the text-field component and set read only to true
2. When you hover over the read only icon:
   - The tooltip should be visible on top of the field (like the textarea component)
   - There should be no label under the field (removed)

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
Comment if you think I should write a test for this.
