### PR TITLE
feat(breadcrumbs): added multibrand tokens

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
+++ b/packages/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
@@ -1,21 +1,21 @@
-@import '../../../mixins/focus-state';
-
 :host([role='listitem']) {
   div {
     ::slotted(*) {
-      color: var(--tds-breadcrumb-color);
+      color: var(--breadcrumb-label);
       text-decoration: none;
     }
 
     &:hover {
       ::slotted(*) {
-        color: var(--tds-breadcrumb-color-hover);
+        color: var(--breadcrumb-color-hover);
         text-decoration: underline;
       }
     }
 
     ::slotted(*:focus-visible) {
-      @include tds-focus-state;
+      outline: 2px solid var(--color-foreground-border-accent-focus);
+      box-shadow: 0 0 0 1px var(--tds-white);
+      outline-offset: 1px;
 
       // Overrides the offset of the tds-focus-state to align with design.
       outline-offset: -0;
@@ -26,7 +26,7 @@
       ::slotted(*) {
         pointer-events: none;
         cursor: default;
-        color: var(--tds-breadcrumb-color-current);
+        color: var(--breadcrumb-color-current);
       }
 
       &:hover {
@@ -39,7 +39,7 @@
 
     &::after {
       content: '\203A';
-      color: var(--tds-breadcrumb-separator-color);
+      color: var(--breadcrumb-separator-color);
       margin-right: 4px;
       margin-left: 4px;
       display: inline-block;

--- a/packages/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
+++ b/packages/core/src/components/breadcrumbs/breadcrumb/breadcrumb.scss
@@ -7,7 +7,7 @@
 
     &:hover {
       ::slotted(*) {
-        color: var(--breadcrumb-color-hover);
+        color: var(--breadcrumb-hover);
         text-decoration: underline;
       }
     }
@@ -26,7 +26,7 @@
       ::slotted(*) {
         pointer-events: none;
         cursor: default;
-        color: var(--breadcrumb-color-current);
+        color: var(--breadcrumb-current);
       }
 
       &:hover {

--- a/packages/core/src/components/breadcrumbs/breadcrumbs-vars.scss
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs-vars.scss
@@ -1,6 +1,6 @@
 tds-breadcrumbs {
   --breadcrumb-label: var(--color-foreground-text-strong);
-  --breadcrumb-color-hover: var(--color-foreground-text-defined);
-  --breadcrumb-color-current: var(--color-foreground-text-disabled);
+  --breadcrumb-hover: var(--color-foreground-text-defined);
+  --breadcrumb-current: var(--color-foreground-text-disabled);
   --breadcrumb-separator-color: var(--color-foreground-text-strong);
 }

--- a/packages/core/src/components/breadcrumbs/breadcrumbs-vars.scss
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs-vars.scss
@@ -1,16 +1,6 @@
-:root,
-.tds-mode-light {
-  --tds-breadcrumb-color: var(--tds-grey-950);
-  --tds-breadcrumb-color-hover: var(--tds-grey-950);
-  --tds-breadcrumb-color-focus: var(--tds-grey-950);
-  --tds-breadcrumb-color-current: var(--tds-grey-500);
-  --tds-breadcrumb-separator-color: var(--tds-grey-950);
-}
-
-.tds-mode-dark {
-  --tds-breadcrumb-color: var(--tds-white);
-  --tds-breadcrumb-color-hover: var(--tds-white);
-  --tds-breadcrumb-color-focus: var(--tds-white);
-  --tds-breadcrumb-color-current: var(--tds-grey-300);
-  --tds-breadcrumb-separator-color: var(--tds-white);
+tds-breadcrumbs {
+  --breadcrumb-label: var(--color-foreground-text-strong);
+  --breadcrumb-color-hover: var(--color-foreground-text-defined);
+  --breadcrumb-color-current: var(--color-foreground-text-disabled);
+  --breadcrumb-separator-color: var(--color-foreground-text-strong);
 }

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.scss
@@ -1,4 +1,5 @@
 @import '../../mixins/box-sizing';
+@import '../../../../../typography/utilities/typography-utility';
 
 :host {
   @include tds-box-sizing;
@@ -6,8 +7,8 @@
   [role='list'] {
     padding: 0;
     margin: 0;
-    font: var(--tds-detail-02);
-    letter-spacing: var(--tds-detail-02-ls);
+    @include detail-02;
+
     display: flex;
     flex-wrap: wrap;
     list-style-type: none;


### PR DESCRIPTION
## **Describe pull-request**  
Breadcrumbs component using new multibrand tokens

## **Issue Linking:**  
- **Jira:** [CDEP-745](https://jira.scania.com/browse/CDEP-745)

## **How to test**  

1.Go to preview link
2.Compare Breadcrumbs component styles in both Scania and Traton, in both light and dark modes with [Traton UI Kit: Breadcrumbs](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=2703-4931&m=dev)

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
