### PR TITLE
feat(stepper): added multibrand tokens

### DIFF
--- a/packages/core/src/components/stepper/step/step.scss
+++ b/packages/core/src/components/stepper/step/step.scss
@@ -28,16 +28,6 @@
       .content-container {
         height: 30px;
         min-width: 30px;
-
-        tds-icon {
-          position: var(--stepper-icon-position);
-          vertical-align: bottom;
-          top: var(--stepper-icon-top);
-        }
-
-        .index-container {
-          vertical-align: sub;
-        }
       }
 
       &.vertical {
@@ -58,7 +48,7 @@
           height: 1px;
           left: calc(50% + 24px);
           right: 0;
-          top: 18px;
+          top: 16px;
         }
 
         &::before {
@@ -67,7 +57,7 @@
           height: 1px;
           right: calc(50% + 24px);
           left: 0;
-          top: 18px;
+          top: 16px;
         }
 
         &.text-aside {
@@ -182,6 +172,9 @@
     }
 
     .content-container {
+      display: flex;
+      align-items: center;
+      justify-content: space-around;
       border-radius: 100px;
       border: 1px solid var(--stepper-icon-background);
       text-align: center;

--- a/packages/core/src/components/stepper/stepper-vars.scss
+++ b/packages/core/src/components/stepper/stepper-vars.scss
@@ -17,14 +17,3 @@ tds-stepper {
   // Divider
   --stepper-divider-line: var(--color-foreground-icon-disabled);
 }
-
-tds-stepper,
-.scania tds-stepper {
-  --stepper-icon-position: none;
-  --stepper-icon-top: 0;
-}
-
-.traton tds-stepper {
-  --stepper-icon-position: relative;
-  --stepper-icon-top: 2px;
-}

--- a/packages/core/src/components/stepper/stepper.scss
+++ b/packages/core/src/components/stepper/stepper.scss
@@ -1,10 +1,11 @@
 :host {
   [role='list'] {
     &:not(.text-position-aside) {
-      display: table;
-      table-layout: fixed;
+      // display: table;
+      // table-layout: fixed;
       width: 100%;
-      list-style: none;
+
+      // list-style: none;
     }
 
     display: flex;


### PR DESCRIPTION
## **Describe pull-request** 
Stepper component using new multibrand tokens

## **Issue Linking:**  
- **Jira:** [CDEP-761](https://jira.scania.com/browse/CDEP-761)

## **How to test**  
1.Go to preview link
2.Compare Stepper component styles in both Scania and Traton, in both light and dark modes with [Traton UI Kit: Stepper](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=14067-174694&m=dev)

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  

Currently, in Figma linked above, the background color of the CURRENT step is white in light mode. That is outdated and should be black acording to the Tegel UI KIT. In this PR, the background color is black for the current step.