### PR TITLE
feat(datetime): added multibrand tokens

### DIFF
--- a/packages/core/src/components/datetime/datetime-vars.scss
+++ b/packages/core/src/components/datetime/datetime-vars.scss
@@ -1,103 +1,134 @@
-:root,
-.tds-mode-light {
-  --tds-datetime-color: var(--tds-grey-868);
-  --tds-datetime-background: var(--tds-grey-50);
-  --tds-datetime-icon: var(--tds-grey-868);
-  --tds-datetime-border-bottom: var(--tds-grey-400);
-  --tds-datetime-placeholder: var(--tds-grey-500);
-  --tds-datetime-border-bottom-hover: var(--tds-grey-600);
+tds-datetime {
+  // Colors - Base
+  --datetime-background-primary: var(--color-background-layer-01);
+  --datetime-background-secondary: var(--color-background-layer-02);
+  --datetime-background: var(--datetime-background-primary);
+  --datetime-text: var(--color-foreground-text-strong);
+  --datetime-icon: var(--color-foreground-icon-strong);
+  --datetime-placeholder: var(--color-foreground-text-subtle);
 
   // Disabled
-  --tds-datetime-background-disabled: var(--tds-white);
-  --tds-datetime-color-disabled: var(--tds-grey-400);
-  --tds-datetime-placeholder-disabled: var(--tds-grey-400);
-  --tds-datetime-label-disabled: var(--tds-grey-400);
-  --tds-datetime-icon-disabled: var(--tds-grey-400);
+  --datetime-background-disabled-primary: var(--color-background-layer-01);
+  --datetime-background-disabled-secondary: var(--color-background-layer-02);
+  --datetime-background-disabled: var(--datetime-background-disabled-primary);
+  --datetime-text-disabled: var(--color-foreground-text-subtle);
+  --datetime-placeholder-disabled: var(--color-foreground-text-subtle);
+  --datetime-label-disabled: var(--color-foreground-text-subtle);
+  --datetime-icon-disabled: var(--color-foreground-text-subtle);
 
   // Label
-  --tds-datetime-label-color: var(--tds-grey-958);
-  --tds-datetime-label-inside-color: var(--tds-grey-700);
-  --tds-datetime-placeholder-color-focus: var(--tds-grey-500);
+  --datetime-label: var(--color-foreground-text-strong);
+  --datetime-label-inside: var(--color-foreground-text-strong);
+  --datetime-placeholder-focus: var(--tds-grey-500);
 
   // Highlight bar
-  --tds-datetime-bar: var(--tds-blue-400);
+  --datetime-highlight-bar: var(--color-foreground-border-accent-focus);
 
   // helper
-  --tds-datetime-helper: var(--tds-grey-700);
-
-  // success
-  --tds-datetime-border-bottom-success: var(--tds-grey-800);
+  --datetime-helper: var(--color-foreground-text-defined);
 
   // error
-  --tds-datetime-border-bottom-error: var(--tds-red-400);
-  --tds-datetime-helper-error: var(--tds-red-400);
-  --tds-datetime-bar-error: var(--tds-red-400);
-  --tds-datetime-icon-error: var(--tds-red-400);
-
-  // Textcounter
-  --tds-datetime-textcounter: var(--tds-grey-700);
-  --tds-datetime-textcounter-divider: var(--tds-grey-500);
-
-  // Prefix and Suffix
-  --tds-datetime-ps-color: var(--tds-grey-600);
+  --datetime-helper-error: var(--color-system-danger-default);
+  --datetime-icon-error: var(--color-system-danger-default);
 
   .tds-mode-variant-primary {
-    --tds-datetime-background: var(--tds-grey-50);
+    --datetime-background: var(--datetime-background-primary);
+    --datetime-background-disabled: var(--datetime-background-disabled-primary);
   }
 
   .tds-mode-variant-secondary {
-    --tds-datetime-background: var(--tds-white);
+    --datetime-background: var(--datetime-background-secondary);
+    --datetime-background-disabled: var(--datetime-background-disabled-secondary);
   }
 }
 
-.tds-mode-dark {
-  --tds-datetime-color: var(--tds-grey-600);
-  --tds-datetime-background: var(--tds-grey-900);
-  --tds-datetime-icon: var(--tds-grey-50);
-  --tds-datetime-border-bottom: var(--tds-grey-600);
-  --tds-datetime-placeholder: var(--tds-grey-500);
-  --tds-datetime-border-bottom-hover: var(--tds-grey-600);
+tds-datetime,
+.scania tds-datetime {
+  /* Datetime: units */
+  --datetime-border-radius: 4px 4px 0 0;
+  --datetime-highlight: var(--datetime-highlight-bar);
+  --datetime-highlight-error: var(--color-system-danger-default);
 
-  // Disabled
-  --tds-datetime-background-disabled: var(--tds-grey-900);
-  --tds-datetime-color-disabled: var(--tds-grey-700);
-  --tds-datetime-placeholder-disabled: var(--tds-grey-700);
-  --tds-datetime-label-disabled: var(--tds-grey-700);
-  --tds-datetime-icon-disabled: var(--tds-grey-800);
+  /* Datetime: border colors */
+  --datetime-border-color-left: transparent;
+  --datetime-border-color-right: transparent;
+  --datetime-border-color-bottom: var(--color-foreground-border-soft);
+  --datetime-border-color-top: transparent;
 
-  // Label
-  --tds-datetime-label-color: var(--tds-grey-100);
-  --tds-datetime-label-inside-color: var(--tds-grey-700);
-  --tds-datetime-placeholder-color-focus: var(--tds-grey-500);
+  /* Datetime: border colors on hover */
+  --datetime-border-color-left-hover: transparent;
+  --datetime-border-color-right-hover: transparent;
+  --datetime-border-color-bottom-hover: var(--color-foreground-border-strong);
+  --datetime-border-color-top-hover: transparent;
 
-  // Highlight bar
-  --tds-datetime-bar: var(--tds-blue-400);
+  /* Datetime: border colors on success */
+  --datetime-border-color-left-success: transparent;
+  --datetime-border-color-right-success: transparent;
+  --datetime-border-color-bottom-success: var(--color-foreground-border-strong);
+  --datetime-border-color-top-success: transparent;
 
-  // helper
-  --tds-datetime-helper: var(--tds-grey-500);
+  /* Datetime: border colors on focus */
+  --datetime-border-color-left-focus: transparent;
+  --datetime-border-color-right-focus: transparent;
+  --datetime-border-color-bottom-focus: var(--color-foreground-border-strong);
+  --datetime-border-color-top-focus: transparent;
+  --datetime-outline-color-focus: none;
 
-  // success
-  --tds-datetime-border-bottom-success: var(--tds-grey-50);
-  --tds-datetime-color-success: var(--tds-grey-50);
+  /* Datetime: border colors on error */
+  --datetime-border-color-left-error: transparent;
+  --datetime-border-color-right-error: transparent;
+  --datetime-border-color-bottom-error: var(--color-system-danger-default);
+  --datetime-border-color-top-error: transparent;
 
-  // error
-  --tds-datetime-border-bottom-error: var(--tds-red-300);
-  --tds-datetime-helper-error: var(--tds-red-300);
-  --tds-datetime-bar-error: var(--tds-red-300);
-  --tds-datetime-icon-error: var(--tds-red-300);
+  /* Datetime: bar colors */
+  --datetime-bar-color-focus: var(--color-foreground-border-accent-focus);
+  --datetime-bar-color-error: var(--color-system-danger-default);
 
-  // Textcounter
-  --tds-datetime-textcounter: var(--tds-grey-700);
-  --tds-datetime-textcounter-divider: var(--tds-grey-500);
+  /* Datetime: disabled */
+  --datetime-disabled-bottom-bar: transparent;
+}
 
-  // Prefix and Suffix
-  --tds-datetime-ps-color: var(--tds-grey-600);
+.traton tds-datetime {
+  /* Datetime: units */
+  --datetime-border-radius: 4px 4px 4px 4px;
+  --datetime-highlight: transparent;
+  --datetime-highlight-error: transparent;
 
-  .tds-mode-variant-primary {
-    --tds-datetime-background: var(--tds-grey-900);
-  }
+  /* Datetime: border colors */
+  --datetime-border-color-left: var(--color-foreground-border-soft);
+  --datetime-border-color-right: var(--color-foreground-border-soft);
+  --datetime-border-color-bottom: var(--color-foreground-border-soft);
+  --datetime-border-color-top: var(--color-foreground-border-soft);
 
-  .tds-mode-variant-secondary {
-    --tds-datetime-background: var(--tds-grey-868);
-  }
+  /* Datetime: border colors on hover */
+  --datetime-border-color-left-hover: var(--color-foreground-border-strong);
+  --datetime-border-color-right-hover: var(--color-foreground-border-strong);
+  --datetime-border-color-bottom-hover: var(--color-foreground-border-strong);
+  --datetime-border-color-top-hover: var(--color-foreground-border-strong);
+
+  /* Datetime: border colors on success */
+  --datetime-border-color-left-success: var(--color-foreground-border-strong);
+  --datetime-border-color-right-success: var(--color-foreground-border-strong);
+  --datetime-border-color-bottom-success: var(--color-foreground-border-strong);
+  --datetime-border-color-top-success: var(--color-foreground-border-strong);
+
+  /* Datetime: border colors on focus */
+  --datetime-border-color-left-focus: var(--color-foreground-border-accent-focus);
+  --datetime-border-color-right-focus: var(--color-foreground-border-accent-focus);
+  --datetime-border-color-bottom-focus: var(--color-foreground-border-accent-focus);
+  --datetime-border-color-top-focus: var(--color-foreground-border-accent-focus);
+  --datetime-outline-color-focus: var(--color-foreground-border-accent-focus);
+
+  /* Datetime: border colors on error */
+  --datetime-border-color-left-error: var(--color-system-danger-default);
+  --datetime-border-color-right-error: var(--color-system-danger-default);
+  --datetime-border-color-bottom-error: var(--color-system-danger-default);
+  --datetime-border-color-top-error: var(--color-system-danger-default);
+
+  /* Datetime: bar colors */
+  --datetime-bar-color-focus: transparent;
+  --datetime-bar-color-error: transparent;
+
+  /* Datetime: disabled */
+  --datetime-disabled-bottom-bar: none;
 }

--- a/packages/core/src/components/datetime/datetime.scss
+++ b/packages/core/src/components/datetime/datetime.scss
@@ -1,40 +1,50 @@
 @import '../../mixins/box-sizing';
+@import '../../../../../typography/utilities/typography-utility';
 
 @mixin datetime-base {
   @include tds-box-sizing;
 
-  border-radius: 4px 4px 0 0;
+  border-radius: var(--datetime-border-radius);
   width: 100%;
   box-sizing: border-box;
   margin: 0;
   border: none;
   outline: none;
   height: 100%;
-  color: var(--tds-datetime-color);
-  background-color: var(--tds-datetime-background);
+  color: var(--datetime-text);
+  background-color: var(--datetime-background);
 
   &::placeholder {
     opacity: 1;
-    color: var(--tds-datetime-placeholder);
+    color: var(--datetime-placeholder);
   }
 
   &:focus::placeholder {
-    color: var(--tds-datetime-placeholder-color-focus);
+    color: var(--datetime-placeholder-focus);
   }
 
   &:disabled {
-    background-color: var(--tds-datetime-background-disabled);
-    color: var(--tds-datetime-color-disabled);
+    background-color: var(--datetime-background-disabled);
+    color: var(--datetime-text-disabled);
     cursor: not-allowed;
 
     &::placeholder {
-      color: var(--tds-datetime-placeholder-disabled);
+      color: var(--datetime-placeholder-disabled);
     }
 
     ~ .tds-datetime-label-inside {
-      color: var(--tds-datetime-label-disabled);
+      color: var(--datetime-label-disabled);
     }
   }
+}
+
+@mixin border-colors($state: '') {
+  $suffix: if($state != '', '-#{$state}', '');
+
+  border-left: 1px solid var(--datetime-border-color-left#{$suffix});
+  border-right: 1px solid var(--datetime-border-color-right#{$suffix});
+  border-bottom: 1px solid var(--datetime-border-color-bottom#{$suffix});
+  border-top: 1px solid var(--datetime-border-color-top#{$suffix});
 }
 
 // icons
@@ -76,41 +86,38 @@
 //Sizes
 .tds-datetime-input {
   @include datetime-base;
+  @include detail-02;
 
-  font: var(--tds-detail-02);
-  letter-spacing: var(--tds-detail-02-ls);
   padding: var(--tds-spacing-element-20) var(--tds-spacing-element-16);
 }
 
 .tds-datetime-input-md {
   @include datetime-base;
+  @include detail-02;
 
-  font: var(--tds-detail-02);
-  letter-spacing: var(--tds-detail-02-ls);
   padding: var(--tds-spacing-element-16);
 }
 
 .tds-datetime-input-sm {
   @include datetime-base;
+  @include detail-02;
 
-  font: var(--tds-detail-02);
-  letter-spacing: var(--tds-detail-02-ls);
   padding: var(--tds-spacing-element-16);
 }
 
 //Container for input field and prefix/suffix
 .tds-datetime-container {
-  border-radius: 4px 4px 0 0;
+  border-radius: var(--datetime-border-radius);
   display: flex;
   position: relative;
   height: 56px;
   box-sizing: border-box;
-  background-color: var(--tds-datetime-background);
-  border-bottom: 1px solid var(--tds-datetime-border-bottom);
+  background-color: var(--datetime-background);
   transition: border-bottom-color 200ms ease;
+  @include border-colors;
 
   &:hover {
-    border-bottom-color: var(--tds-datetime-border-bottom-hover);
+    @include border-colors('hover');
   }
 
   .tds-form-datetime-md & {
@@ -134,24 +141,24 @@
     transform: translateY(-50%);
     right: 18px;
     pointer-events: none;
-    color: var(--tds-datetime-icon);
+    color: var(--datetime-icon);
   }
 }
 
 .tds-datetime-label {
-  font: var(--tds-detail-05);
-  letter-spacing: var(--tds-detail-05-ls);
+  @include detail-05;
+
   display: block;
   margin-bottom: var(--tds-spacing-element-8);
-  color: var(--tds-datetime-label-color);
+  color: var(--datetime-label);
 }
 
 .tds-datetime-label-inside {
-  font: var(--tds-detail-02);
-  letter-spacing: var(--tds-detail-02-ls);
+  @include detail-02;
+
   position: absolute;
   pointer-events: none;
-  color: var(--tds-datetime-label-inside-color);
+  color: var(--datetime-label-inside);
   left: 16px;
 
   &.iphone {
@@ -171,7 +178,7 @@
   //Input field in focus
   &:focus::placeholder {
     transition: color 0.35s ease;
-    color: var(--tds-datetime-placeholder-color-focus);
+    color: var(--datetime-placeholder-focus);
   }
 }
 
@@ -227,24 +234,24 @@
   }
 
   .tds-datetime-input-sm ~ .tds-datetime-label-inside {
-    font: var(--tds-detail-07);
-    letter-spacing: var(--tds-detail-07-ls);
+    @include detail-07;
+
     @include label-inside-transition;
 
     top: 8px;
   }
 
   .tds-datetime-input-md ~ .tds-datetime-label-inside {
-    font: var(--tds-detail-07);
-    letter-spacing: var(--tds-detail-07-ls);
+    @include detail-07;
+
     @include label-inside-transition;
 
     top: 8px;
   }
 
   .tds-datetime-input ~ .tds-datetime-label-inside {
-    font: var(--tds-detail-07);
-    letter-spacing: var(--tds-detail-07-ls);
+    @include detail-07;
+
     @include label-inside-transition;
 
     top: 12px;
@@ -263,7 +270,7 @@
     top: 54px;
     width: 0;
     position: absolute;
-    background: var(--tds-datetime-bar);
+    background: var(--datetime-highlight);
     transition: 0.35s ease all;
 
     .tds-form-datetime-md & {
@@ -291,12 +298,12 @@
 
 //Helper text
 .tds-datetime-helper {
-  font: var(--tds-detail-05);
-  letter-spacing: var(--tds-detail-05-ls);
+  @include detail-05;
+
   display: block;
   flex-basis: 100%;
   padding-top: var(--tds-spacing-element-4);
-  color: var(--tds-datetime-helper);
+  color: var(--datetime-helper);
 
   .tds-helper {
     display: inline-flex;
@@ -307,17 +314,21 @@
 //Disabled state
 .tds-form-datetime-disabled {
   .tds-datetime-container {
-    border-bottom-color: transparent;
+    cursor: not-allowed;
+    border-left: 1px solid transparent;
+    border-right: 1px solid transparent;
+    border-bottom: 1px solid transparent;
+    border-top: 1px solid transparent;
   }
 
   .datetime-icon {
     tds-icon {
-      color: var(--tds-datetime-icon-disabled);
+      color: var(--datetime-icon-disabled);
     }
   }
 
   .tds-datetime-label {
-    color: var(--tds-datetime-label-disabled);
+    color: var(--datetime-label-disabled);
     cursor: not-allowed;
   }
 }
@@ -325,7 +336,8 @@
 //Success state
 .tds-form-datetime-success {
   .tds-datetime-container {
-    border-bottom-color: var(--tds-datetime-border-bottom-success);
+    @include border-colors('success');
+
     color: var(--tds-datetime-color-success);
   }
 
@@ -340,37 +352,24 @@
 //Error State
 .tds-form-datetime-error {
   .tds-datetime-helper {
-    color: var(--tds-datetime-helper-error);
+    color: var(--datetime-helper-error);
   }
 
   .tds-datetime-container {
-    border-bottom-color: var(--tds-datetime-border-bottom-error);
+    @include border-colors('error');
   }
 
   .tds-datetime-bar {
     &::before,
     &::after {
-      background: var(--tds-datetime-bar-error);
+      background: var(--datetime-highlight-error);
     }
   }
 
   .datetime-icon {
     tds-icon {
-      color: var(--tds-datetime-icon-error);
+      color: var(--datetime-icon-error);
     }
-  }
-}
-
-.tds-datetime-textcounter {
-  font: var(--tds-detail-05);
-  letter-spacing: var(--tds-detail-05-ls);
-  color: var(--tds-datetime-textcounter);
-  float: right;
-
-  & .tds-datetime-textcounter-divider {
-    // font: var(--tds-detail-05);
-    letter-spacing: var(--tds-detail-05-ls);
-    color: var(--tds-datetime-textcounter-divider);
   }
 }
 
@@ -406,4 +405,11 @@ input[type='time']::-webkit-calendar-picker-indicator {
   .type-date .icon-datetime-local {
     display: none;
   }
+}
+
+.tds-form-datetime.tds-datetime-focus .tds-datetime-container {
+  @include border-colors('focus');
+
+  outline: 2px solid var(--datetime-outline-color-focus);
+  outline-offset: -1px;
 }


### PR DESCRIPTION
## **Describe pull-request** 
Datetime component using new multibrand tokens

## **Issue Linking:**  
- **Jira:** [CDEP-753](https://jira.scania.com/browse/CDEP-753)

## **How to test**  
**NOTE! THERE IS NO FIGMA FILE FOR DATETIME, THE COMPONENT USES SAME STYLES AS THE TEXTFIELD COMPONENT**

1.Go to preview link
2.Compare Datetime component styles in both Scania and Traton, in both light and dark modes with [Traton UI Kit: Textfield](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=13499-11330&m=dev)

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  