### PR TITLE
fix(card): make header and subheader are 100% wide

### DIFF
--- a/packages/core/src/components/card/card.scss
+++ b/packages/core/src/components/card/card.scss
@@ -48,6 +48,7 @@
   .header-subheader {
     display: flex;
     flex-direction: column;
+    width: 100%;
     gap: 4px;
 
     .header,


### PR DESCRIPTION
## **Describe pull-request**  
Small fix to enable having items in header and subheader in right side of component.

## **Issue Linking:**  
- **No issue:** Came from support channel: [here](https://teams.microsoft.com/l/message/19:5e33f67fe502441f914fbcdc6e2548f5@thread.skype/1752222542385?tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac&groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&parentMessageId=1752222542385&teamName=Tegel%20Design%20System&channelName=Development%20support%20-%20Tegel&createdTime=1752222542385)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Open branch on your local
2. Modify Card story to use header slot
3. Arrange content so it ends up in right side of header slot. Tip, use flex and justify-content: space-between.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

