### PR TITLE
fix(textarea): component tokens rebase

### DIFF
--- a/packages/core/src/components/textarea/textarea-mixins.scss
+++ b/packages/core/src/components/textarea/textarea-mixins.scss
@@ -1,0 +1,45 @@
+@mixin textfield-base {
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  border: none;
+  outline: none;
+  height: 100%;
+  color: var(--textarea-text);
+  background-color: var(--textarea-background);
+
+  &::placeholder {
+    opacity: 1;
+    color: var(--textarea-placeholder);
+  }
+
+  &:disabled {
+    background-color: var(--textarea-disabled-background);
+    color: var(--textarea-disabled-text);
+    cursor: not-allowed;
+
+    &::placeholder {
+      color: var(--textarea-disabled-placeholder);
+    }
+  }
+}
+
+@mixin placeholder-label {
+  &::placeholder {
+    color: transparent;
+  }
+
+  ::placeholder {
+    color: transparent;
+  }
+
+  //Input field in focus
+  &:focus::placeholder {
+    transition: color 0.35s ease;
+    color: var(--textarea-placeholder);
+  }
+}
+
+@mixin textarea-focus {
+  border-bottom: 2px solid var(--textarea-bar);
+}

--- a/packages/core/src/components/textarea/textarea-vars.scss
+++ b/packages/core/src/components/textarea/textarea-vars.scss
@@ -1,119 +1,100 @@
-:root,
-.tds-mode-light {
-  --tds-textarea-background-primary: var(--tds-grey-50);
-  --tds-textarea-background-secondary: var(--tds-white);
-  --tds-textarea-background: var(--tds-textarea-background-primary);
-  --tds-textarea-color: var(--tds-grey-958);
+tds-textarea {
+  --textarea-background-primary: var(--color-background-layer-01);
+  --textarea-background-secondary: var(--color-background-layer-02);
+  --textarea-background: var(--textarea-background-primary);
+  --textarea-text: var(--color-foreground-text-strong);
 
   // Disabled
-  --tds-textarea-disabled-color: var(--tds-grey-400);
-  --tds-textarea-disabled-background-primary: var(--tds-grey-50);
-  --tds-textarea-disabled-background-secondary: var(--tds-white);
-  --tds-textarea-disabled-background: var(--tds-textarea-disabled-background-primary);
-  --tds-textarea-disabled-placeholder: var(--tds-grey-400);
-  --tds-textarea-disabled-label: var(--tds-grey-400);
-  --tds-textarea-helper-disabled: var(--tds-grey-400);
-  --tds-textarea-textcounter-disabled: var(--tds-grey-400);
+  --textarea-disabled-text: var(--color-foreground-text-disabled);
+  --textarea-disabled-placeholder: var(--color-foreground-text-disabled);
+  --textarea-disabled-label: var(--color-foreground-text-disabled);
+  --textarea-helper-disabled: var(--color-foreground-text-disabled);
+  --textarea-textcounter-disabled: var(--color-foreground-text-disabled);
 
   // Label
-  --tds-textarea-label-color: var(--tds-grey-958);
-  --tds-textarea-label-inside-color: var(--tds-grey-958);
+  --textarea-label: var(--color-foreground-text-strong);
+  --textarea-label-inside: var(--color-foreground-text-strong);
 
   // Placeholder
-  --tds-textarea-placeholder: var(--tds-grey-500);
+  --textarea-placeholder: var(--color-foreground-text-subtle);
 
   // Helper
-  --tds-textarea-helper: var(--tds-grey-700);
-  --tds-textarea-helper-error: var(--tds-negative);
+  --textarea-helper: var(--color-foreground-text-defined);
+  --textarea-helper-error: var(--color-system-danger-default);
 
   // Highlight bar
-  --tds-textarea-bar: var(--tds-blue-400);
-  --tds-textarea-bar-error: var(--tds-negative);
+  --textarea-bar: var(--color-foreground-border-accent-focus);
+  --textarea-bar-error: var(--color-system-danger-default);
 
   // Textcounter
-  --tds-textarea-textcounter: var(--tds-grey-700);
-  --tds-textarea-textcounter-divider: var(--tds-grey-500);
+  --textarea-textcounter: var(--color-foreground-text-defined);
+  --textarea-textcounter-divider: var(--color-foreground-text-subtle);
 
   // Border bottom
-  --tds-textarea-border-bottom: var(--tds-grey-600);
-  --tds-textarea-border-bottom-hover: var(--tds-grey-800);
-  --tds-textarea-border-bottom-success: var(--tds-grey-958);
-  --tds-textarea-border-bottom-error: var(--tds-negative);
+  --textarea-border-bottom: var(--color-foreground-border-soft);
+  --textarea-border-bottom-hover: var(--color-foreground-border-defined);
+  --textarea-border-bottom-success: var(--color-foreground-border-strong);
+  --textarea-border-bottom-error: var(--color-system-danger-default);
+
+  // Border radius
+  --textarea-border-radius: 4px 4px 0 0;
 
   // Read only
-  --tds-textarea-border-bottom-read-only-color: var(--tds-grey-500);
-  --tds-textarea-icon-read-only-color: var(--tds-grey-958);
-  --tds-textarea-icon-read-only-label-color: var(--tds-grey-958);
+  --textarea-border-bottom-read-only-text: var(--color-foreground-border-subtle);
+  --textarea-icon-read-only-text: var(--color-foreground-text-strong);
+  --textarea-icon-read-only-label: var(--color-foreground-text-strong);
 
   // Resize
-  --tds-textarea-resize-icon: var(--tds-grey-500);
+  --textarea-resize-icon: var(--color-foreground-text-subtle);
 
   .tds-mode-variant-primary {
-    --tds-textarea-background: var(--tds-textarea-background-primary);
-    --tds-textarea-disabled-background: var(--tds-textarea-disabled-background-primary);
+    --textarea-background: var(--textarea-background-primary);
+    --textarea-disabled-background: var(--textarea-disabled-background-primary);
   }
 
   .tds-mode-variant-secondary {
-    --tds-textarea-background: var(--tds-textarea-background-secondary);
-    --tds-textarea-disabled-background: var(--tds-textarea-disabled-background-secondary);
+    --textarea-background: var(--textarea-background-secondary);
+    --textarea-disabled-background: var(--textarea-disabled-background-secondary);
   }
 }
 
-.tds-mode-dark {
-  --tds-textarea-background-primary: var(--tds-grey-900);
-  --tds-textarea-background-secondary: var(--tds-grey-868);
-  --tds-textarea-background: var(--tds-textarea-background-primary);
-  --tds-textarea-color: var(--tds-grey-50);
+.traton tds-textarea {
+  --textarea-border-radius: 4px;
+}
 
-  // Disabled
-  --tds-textarea-disabled-color: var(--tds-grey-800);
-  --tds-textarea-disabled-background-primary: var(--tds-grey-900);
-  --tds-textarea-disabled-background-secondary: var(--tds-grey-868);
-  --tds-textarea-disabled-background: var(--tds-textarea-disabled-background-primary);
-  --tds-textarea-disabled-placeholder: var(--tds-grey-800);
-  --tds-textarea-disabled-label: var(--tds-grey-800);
-  --tds-textarea-helper-disabled: var(--tds-grey-800);
-  --tds-textarea-textcounter-disabled: var(--tds-grey-800);
-
-  // Label
-  --tds-textarea-label-color: var(--tds-grey-50);
-  --tds-textarea-label-inside-color: var(--tds-grey-50);
-
-  // Placeholder
-  --tds-textarea-placeholder: var(--tds-grey-600);
-
-  // Helper
-  --tds-textarea-helper: var(--tds-grey-600);
-  --tds-textarea-helper-error: var(--tds-negative);
-
-  // Highlight bar
-  --tds-textarea-bar: var(--tds-blue-400);
-  --tds-textarea-bar-error: var(--tds-negative);
-
-  // Textcounter
-  --tds-textarea-textcounter: var(--tds-grey-600);
-  --tds-textarea-textcounter-divider: var(--tds-grey-700);
-
-  // Border bottom
-  --tds-textarea-border-bottom: var(--tds-grey-600);
-  --tds-textarea-border-bottom-hover: var(--tds-grey-400);
-  --tds-textarea-border-bottom-success: var(--tds-grey-50);
-  --tds-textarea-border-bottom-error: var(--tds-negative);
-
-  // Read only
-  --tds-textarea-icon-read-only-color: var(--tds-grey-100);
-  --tds-textarea-icon-read-only-label-color: var(--tds-grey-50);
-
-  // Resize
-  --tds-textarea-resize-icon: var(--tds-grey-500);
-
-  .tds-mode-variant-primary {
-    --tds-textarea-background: var(--tds-textarea-background-primary);
-    --tds-textarea-disabled-background: var(--tds-textarea-disabled-background-primary);
+.traton {
+  .textarea-container:not(.textarea-disabled) {
+    textarea {
+      &:focus {
+        outline: solid 2px var(--textarea-bar);
+      }
+    }
   }
+}
 
-  .tds-mode-variant-secondary {
-    --tds-textarea-background: var(--tds-textarea-background-secondary);
-    --tds-textarea-disabled-background: var(--tds-textarea-disabled-background-secondary);
+.scania .textarea-container:not(.textarea-disabled) {
+  .textarea-wrapper {
+    &::before,
+    &::after {
+      content: '';
+      height: 2px;
+      width: 0;
+      position: absolute;
+      background: var(--textarea-bar);
+      transition: 0.35s ease all;
+    }
+
+    &::before {
+      left: 50%;
+    }
+
+    &::after {
+      right: 50%;
+    }
+
+    &::after,
+    &::before {
+      top: calc(100% - 2px);
+    }
   }
 }

--- a/packages/core/src/components/textarea/textarea-vars.scss
+++ b/packages/core/src/components/textarea/textarea-vars.scss
@@ -31,10 +31,11 @@ tds-textarea {
   --textarea-textcounter-divider: var(--color-foreground-text-subtle);
 
   // Border bottom
-  --textarea-border-bottom: var(--color-foreground-border-soft);
-  --textarea-border-bottom-hover: var(--color-foreground-border-defined);
-  --textarea-border-bottom-success: var(--color-foreground-border-strong);
-  --textarea-border-bottom-error: var(--color-system-danger-default);
+  --textarea-border-bottom: 1px solid var(--color-foreground-border-soft);
+  --textarea-border-bottom-hover: 1px solid var(--color-foreground-border-defined);
+  --textarea-border-bottom-success: 1px solid var(--color-foreground-border-strong);
+  --textarea-border-bottom-error: 1px solid var(--color-system-danger-default);
+  --textarea-outline: none;
 
   // Border radius
   --textarea-border-radius: 4px 4px 0 0;
@@ -59,7 +60,20 @@ tds-textarea {
 }
 
 .traton tds-textarea {
+  // Radius
   --textarea-border-radius: 4px;
+
+  // Border
+  --textarea-border-bottom: none;
+  --textarea-border-bottom-hover: none;
+  --textarea-border-bottom-success: none;
+  --textarea-border-bottom-error: none;
+
+  // Outline
+  --textarea-outline: 1px solid var(--color-foreground-border-soft);
+  --textarea-outline-hover: 1px solid var(--color-foreground-border-defined);
+  --textarea-outline-success: 1px solid var(--color-foreground-border-strong);
+  --textarea-outline-error: 1px solid var(--color-system-danger-default);
 }
 
 .traton {

--- a/packages/core/src/components/textarea/textarea.scss
+++ b/packages/core/src/components/textarea/textarea.scss
@@ -1,54 +1,9 @@
-@mixin textfield-base {
-  border-radius: 4px 4px 0 0;
-  width: 100%;
-  box-sizing: border-box;
-  margin: 0;
-  border: none;
-  outline: none;
-  height: 100%;
-  color: var(--tds-textarea-color);
-  background-color: var(--tds-textarea-background);
-
-  &::placeholder {
-    opacity: 1;
-    color: var(--tds-textarea-placeholder);
-  }
-
-  &:disabled {
-    background-color: var(--tds-textarea-disabled-background);
-    color: var(--tds-textarea-disabled-color);
-    cursor: not-allowed;
-
-    &::placeholder {
-      color: var(--tds-textarea-disabled-placeholder);
-    }
-  }
-}
-
-@mixin placeholder-label {
-  &::placeholder {
-    color: transparent;
-  }
-
-  ::placeholder {
-    color: transparent;
-  }
-
-  //Input field in focus
-  &:focus::placeholder {
-    transition: color 0.35s ease;
-    color: var(--tds-textarea-placeholder);
-  }
-}
+@import './textarea-mixins';
 
 .textarea-container {
-  //@extend .tds-textfield-container;
-  border-radius: 4px 4px 0 0;
+  border-radius: var(--textarea-border-radius);
   position: relative;
   box-sizing: border-box;
-
-  //@extend end
-
   height: auto;
   width: 100%;
   min-width: 208px;
@@ -70,42 +25,16 @@
   }
 }
 
-.textarea-container:not(.textarea-disabled) {
-  .textarea-wrapper {
-    &::before,
-    &::after {
-      content: '';
-      height: 2px;
-      width: 0;
-      position: absolute;
-      background: var(--tds-textarea-bar);
-      transition: 0.35s ease all;
-    }
-
-    &::before {
-      left: 50%;
-    }
-
-    &::after {
-      right: 50%;
-    }
-
-    &::after,
-    &::before {
-      top: calc(100% - 2px);
-    }
-  }
-}
-
 .textarea-input {
   @include textfield-base;
 
+  border-radius: var(--textarea-border-radius);
   font: var(--tds-detail-02);
   letter-spacing: var(--tds-detail-02-ls);
   padding: var(--tds-spacing-element-20) var(--tds-spacing-element-16);
   display: block;
   resize: vertical;
-  border-bottom: 1px solid var(--tds-textarea-border-bottom);
+  border-bottom: 1px solid var(--textarea-border-bottom);
   transition: border-bottom-color 200ms ease;
 
   // Display none only works in Chrome
@@ -114,13 +43,13 @@
   }
 
   &:hover {
-    border-bottom-color: var(--tds-textarea-border-bottom-hover);
+    border-bottom-color: var(--textarea-border-bottom-hover);
   }
 }
 
 // Need to override default resizer in FF & Safari
 .textarea-resizer-icon {
-  color: var(--tds-textarea-resize-icon);
+  color: var(--textarea-resize-icon);
   position: absolute;
   display: block;
   bottom: 2px;
@@ -128,7 +57,7 @@
   padding-bottom: 2px;
   padding-right: 2px;
   pointer-events: none;
-  background-color: var(--tds-textarea-background);
+  background-color: var(--textarea-background);
 
   svg {
     display: block;
@@ -141,7 +70,7 @@
   display: block;
   z-index: 1;
   margin-bottom: var(--tds-spacing-element-8);
-  color: var(--tds-textarea-label-color);
+  color: var(--textarea-label);
 }
 
 .textarea-container {
@@ -150,10 +79,7 @@
       font: var(--tds-detail-02);
       letter-spacing: var(--tds-detail-02-ls);
       transition: 0.1s ease all;
-
-      //@include end
-
-      color: var(--tds-textarea-label-inside-color);
+      color: var(--textarea-label-inside);
       position: absolute;
       top: var(--tds-spacing-element-20);
       left: var(--tds-spacing-element-16);
@@ -161,7 +87,7 @@
 
     &.textarea-disabled {
       .textarea-label {
-        color: var(--tds-textarea-disabled-label);
+        color: var(--textarea-disabled-label);
       }
     }
 
@@ -202,13 +128,13 @@
   //@extend .tds-textfield-textcounter;
   font: var(--tds-detail-05);
   letter-spacing: var(--tds-detail-05-ls);
-  color: var(--tds-textarea-textcounter);
+  color: var(--textarea-textcounter);
   float: right;
 
   & .textfield-textcounter-divider {
     font: var(--tds-detail-05);
     letter-spacing: var(--tds-detail-05-ls);
-    color: var(--tds-textarea-textcounter-divider);
+    color: var(--textarea-textcounter-divider);
   }
 
   //@extend end
@@ -225,7 +151,7 @@
   gap: 8px;
   align-items: center;
   padding-top: var(--tds-spacing-element-4);
-  color: var(--tds-textarea-helper);
+  color: var(--textarea-helper);
   flex-grow: 2;
   flex-basis: auto;
 
@@ -238,24 +164,24 @@
 
 .textarea-success {
   .textarea-input {
-    border-bottom-color: var(--tds-textarea-border-bottom-success);
+    border-bottom-color: var(--textarea-border-bottom-success);
   }
 }
 
 .textarea-error {
   .textarea-input {
-    border-bottom-color: var(--tds-textarea-border-bottom-error);
+    border-bottom-color: var(--textarea-border-bottom-error);
   }
 
   .textarea-wrapper {
     &::after,
     &::before {
-      background: var(--tds-textarea-bar-error);
+      background: var(--textarea-bar-error);
     }
   }
 
   .textarea-helper {
-    color: var(--tds-textarea-helper-error);
+    color: var(--textarea-helper-error);
   }
 }
 
@@ -270,19 +196,23 @@
   }
 
   .textarea-label {
-    color: var(--tds-textarea-disabled-label);
+    color: var(--textarea-disabled-label);
   }
 
   .textarea-helper {
-    color: var(--tds-textarea-helper-disabled);
+    color: var(--textarea-helper-disabled);
   }
 
   .textarea-textcounter {
-    color: var(--tds-textarea-textcounter-disabled);
+    color: var(--textarea-textcounter-disabled);
 
     & .textfield-textcounter-divider {
-      color: var(--tds-textarea-textcounter-disabled);
+      color: var(--textarea-textcounter-disabled);
     }
+  }
+
+  .textarea-resizer-icon {
+    background-color: var(--textarea-background-secondary);
   }
 }
 
@@ -292,7 +222,7 @@
   position: absolute;
   right: 18px;
   top: 18px;
-  color: var(--tds-textarea-icon-read-only-color);
+  color: var(--textarea-icon-read-only-color);
 
   &-label {
     display: none;
@@ -302,8 +232,8 @@
     font: var(--tds-detail-05);
     letter-spacing: var(--tds-detail-05-ls);
     padding: 8px;
-    color: var(--tds-textarea-icon-read-only-label-color);
-    background-color: var(--tds-textarea-icon-read-only-label-background);
+    color: var(--textarea-icon-read-only-label-color);
+    background-color: var(--textarea-icon-read-only-label-background);
     white-space: nowrap;
     border-radius: 4px 0 4px 4px;
   }
@@ -315,7 +245,7 @@
   }
 
   .textarea-input {
-    border: 1px solid var(--tds-textarea-border-bottom-read-only-color);
+    border: 1px solid var(--textarea-border-bottom-read-only-text);
   }
 
   .textfield-container {

--- a/packages/core/src/components/textarea/textarea.scss
+++ b/packages/core/src/components/textarea/textarea.scss
@@ -35,7 +35,8 @@
   padding: var(--tds-spacing-element-20) var(--tds-spacing-element-16);
   display: block;
   resize: vertical;
-  border-bottom: 1px solid var(--textarea-border-bottom);
+  border-bottom: var(--textarea-border-bottom);
+  outline: var(--textarea-outline);
   transition: border-bottom-color 200ms ease;
 
   // Display none only works in Chrome
@@ -44,7 +45,8 @@
   }
 
   &:hover {
-    border-bottom-color: var(--textarea-border-bottom-hover);
+    border-bottom: var(--textarea-border-bottom-hover);
+    outline: var(--textarea-outline-hover);
   }
 }
 
@@ -165,13 +167,15 @@
 
 .textarea-success {
   .textarea-input {
-    border-bottom-color: var(--textarea-border-bottom-success);
+    border-bottom: var(--textarea-border-bottom-success);
+    outline: var(--textarea-outline-success);
   }
 }
 
 .textarea-error {
   .textarea-input {
-    border-bottom-color: var(--textarea-border-bottom-error);
+    border-bottom: var(--textarea-border-bottom-error);
+    outline: var(--textarea-outline-error);
   }
 
   .textarea-wrapper {

--- a/packages/core/src/components/textarea/textarea.scss
+++ b/packages/core/src/components/textarea/textarea.scss
@@ -1,4 +1,5 @@
 @import './textarea-mixins';
+@import '../../../../../typography/utilities/typography-utility';
 
 .textarea-container {
   border-radius: var(--textarea-border-radius);
@@ -29,8 +30,8 @@
   @include textfield-base;
 
   border-radius: var(--textarea-border-radius);
-  font: var(--tds-detail-02);
-  letter-spacing: var(--tds-detail-02-ls);
+  @include detail-02;
+
   padding: var(--tds-spacing-element-20) var(--tds-spacing-element-16);
   display: block;
   resize: vertical;
@@ -65,8 +66,8 @@
 }
 
 .textarea-label {
-  font: var(--tds-detail-05);
-  letter-spacing: var(--tds-detail-05-ls);
+  @include detail-05;
+
   display: block;
   z-index: 1;
   margin-bottom: var(--tds-spacing-element-8);
@@ -76,8 +77,8 @@
 .textarea-container {
   &.textarea-label-inside {
     .textarea-label {
-      font: var(--tds-detail-02);
-      letter-spacing: var(--tds-detail-02-ls);
+      @include detail-02;
+
       transition: 0.1s ease all;
       color: var(--textarea-label-inside);
       position: absolute;
@@ -99,8 +100,8 @@
   &.textarea-focus {
     &.textarea-label-inside {
       .textarea-label {
-        font: var(--tds-detail-07);
-        letter-spacing: var(--tds-detail-07-ls);
+        @include detail-07;
+
         top: var(--tds-spacing-element-8);
       }
     }
@@ -116,8 +117,8 @@
   &.textarea-data {
     &.textarea-label-inside {
       .textarea-label {
-        font: var(--tds-detail-07);
-        letter-spacing: var(--tds-detail-07-ls);
+        @include detail-07;
+
         top: var(--tds-spacing-element-8);
       }
     }
@@ -126,14 +127,14 @@
 
 .textarea-textcounter {
   //@extend .tds-textfield-textcounter;
-  font: var(--tds-detail-05);
-  letter-spacing: var(--tds-detail-05-ls);
+  @include detail-05;
+
   color: var(--textarea-textcounter);
   float: right;
 
   & .textfield-textcounter-divider {
-    font: var(--tds-detail-05);
-    letter-spacing: var(--tds-detail-05-ls);
+    @include detail-05;
+
     color: var(--textarea-textcounter-divider);
   }
 
@@ -145,8 +146,8 @@
 }
 
 .textarea-helper {
-  font: var(--tds-detail-05);
-  letter-spacing: var(--tds-detail-05-ls);
+  @include detail-05;
+
   display: flex;
   gap: 8px;
   align-items: center;
@@ -229,8 +230,8 @@
     position: absolute;
     right: 18px;
     top: 48px;
-    font: var(--tds-detail-05);
-    letter-spacing: var(--tds-detail-05-ls);
+    @include detail-05;
+
     padding: 8px;
     color: var(--textarea-icon-read-only-label-color);
     background-color: var(--textarea-icon-read-only-label-background);


### PR DESCRIPTION
## **Describe pull-request**  
Added css multibrand tokens for Textarea

## **Issue Linking:**  
- **Jira:** [CDEP-765](https://jira.scania.com/browse/CDEP-765)

## **How to test**  
1. Go to textarea in storybook
2. Compare to [Figma](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=26756-59843&p=f&m=dev) and if needed [Prod](https://tds-storybook.tegel.scania.com/?path=/story/components-textarea--default)
3. Check both brands in dark/light mode