### PR TITLE
fix(folder-tabs): focus state improvement

### DIFF
--- a/packages/core/src/components/tabs/folder-tabs/folder-tab/folder-tab.scss
+++ b/packages/core/src/components/tabs/folder-tabs/folder-tab/folder-tab.scss
@@ -32,6 +32,9 @@
 
   ::slotted(*:focus-visible) {
     @include tds-focus-state;
+
+    box-shadow: none;
+    outline-offset: -4px;
   }
 
   div:not(.selected) {

--- a/packages/core/src/components/tabs/folder-tabs/folder-tabs.scss
+++ b/packages/core/src/components/tabs/folder-tabs/folder-tabs.scss
@@ -1,4 +1,3 @@
-@import '../../../mixins/focus-state';
 @import '../../../mixins/box-sizing';
 
 :host {
@@ -48,18 +47,6 @@
       display: block;
       opacity: 1;
       pointer-events: all;
-    }
-
-    &:hover {
-      background-color: var(--folder-tabs-scroll-button-surface-hover);
-    }
-
-    &:active {
-      background-color: var(--folder-tabs-scroll-button-surface-active);
-    }
-
-    &:focus {
-      @include tds-focus-state;
     }
 
     svg {

--- a/packages/core/src/components/tabs/inline-tabs/inline-tabs.scss
+++ b/packages/core/src/components/tabs/inline-tabs/inline-tabs.scss
@@ -62,18 +62,6 @@
       pointer-events: all;
     }
 
-    &:hover {
-      background-color: var(--inline-tabs-scroll-button-hover);
-    }
-
-    &:active {
-      background-color: var(--inline-tabs-scroll-button-active);
-    }
-
-    &:focus {
-      @include tds-focus-state;
-    }
-
     svg {
       fill: var(--inline-tabs-scroll-button-text);
     }

--- a/packages/core/src/components/tabs/navigation-tabs/navigation-tabs.scss
+++ b/packages/core/src/components/tabs/navigation-tabs/navigation-tabs.scss
@@ -63,18 +63,6 @@
       pointer-events: all;
     }
 
-    &:hover {
-      background-color: var(--navigation-tabs-scroll-button-hover);
-    }
-
-    &:active {
-      background-color: var(--navigation-tabs-scroll-button-active);
-    }
-
-    &:focus {
-      @include tds-focus-state;
-    }
-
     svg {
       fill: var(--navigation-tabs-scroll-button-color);
     }


### PR DESCRIPTION
## **Describe pull-request**  
Fix for broken focus state

## **Issue Linking:**  
- **Jira:** Add ticket number after `CDEP-`: [CDEP-1106](https://jira.scania.com/browse/CDEP-1106)

## **How to test**  
1. Open preview link
2. Check Folder tabs component
3. Try to "Tab" thought it
4. It should be blue outline, a bit inside of tab and very visible

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events