### PR TITLE
feat(divider): a11y color update and variant prop

### DIFF
--- a/packages/core/src/components/divider/divider-vars.scss
+++ b/packages/core/src/components/divider/divider-vars.scss
@@ -1,12 +1,22 @@
 :root,
 .tds-mode-light {
-  --tds-divider-background: var(--tds-grey-350);
+  --tds-divider-background-discrete: var(--tds-grey-200);
+  --tds-divider-background-subtle: var(--tds-grey-350);
+  --tds-divider-background-soft: var(--tds-grey-500);
+  --tds-divider-background-defined: var(--tds-grey-650);
+  --tds-divider-background-dark-blue: var(--tds-blue-700);
+
+  /* Default variant */
+  --tds-divider-background: var(--tds-divider-background-subtle);
 }
 
 .tds-mode-dark {
-  --tds-divider-background: var(--tds-grey-500);
-}
+  --tds-divider-background-discrete: var(--tds-grey-600);
+  --tds-divider-background-subtle: var(--tds-grey-400);
+  --tds-divider-background-soft: var(--tds-grey-300);
+  --tds-divider-background-defined: var(--tds-grey-200);
+  --tds-divider-background-dark-blue: var(--tds-blue-800);
 
-.tds-theme-colored {
-  --tds-divider-background: var(--tds-blue-700);
+  /* Default variant */
+  --tds-divider-background: var(--tds-divider-background-subtle);
 }

--- a/packages/core/src/components/divider/divider.scss
+++ b/packages/core/src/components/divider/divider.scss
@@ -3,14 +3,34 @@
 .divider {
   @include tds-box-sizing;
 
+  background-color: var(--tds-divider-background);
+
+  &.discrete {
+    background-color: var(--tds-divider-background-discrete);
+  }
+
+  &.subtle {
+    background-color: var(--tds-divider-background-subtle);
+  }
+
+  &.soft {
+    background-color: var(--tds-divider-background-soft);
+  }
+
+  &.defined {
+    background-color: var(--tds-divider-background-defined);
+  }
+
+  &.dark-blue {
+    background-color: var(--tds-divider-background-dark-blue);
+  }
+
   &.horizontal {
-    background-color: var(--tds-divider-background);
     width: 100%;
     height: 1px;
   }
 
   &.vertical {
-    background-color: var(--tds-divider-background);
     height: 100%;
     width: 1px;
   }

--- a/packages/core/src/components/divider/divider.stories.tsx
+++ b/packages/core/src/components/divider/divider.stories.tsx
@@ -51,7 +51,7 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Discrete', 'Subtle', 'Soft', 'Defined', 'Dark Blue'],
+      options: ['Discrete', 'Subtle', 'Soft', 'Defined', 'Dark-Blue'],
       table: {
         defaultValue: { summary: 'Subtle' },
       },

--- a/packages/core/src/components/divider/divider.stories.tsx
+++ b/packages/core/src/components/divider/divider.stories.tsx
@@ -23,8 +23,8 @@ export default {
       description: 'Choose Divider orientation.',
       control: {
         type: 'radio',
-        options: ['Horizontal', 'Vertical'],
       },
+      options: ['Horizontal', 'Vertical'],
       table: {
         defaultValue: { summary: 'horizontal' },
       },
@@ -45,18 +45,31 @@ export default {
       },
       if: { arg: 'orientation', eq: 'Vertical' },
     },
+    variant: {
+      name: 'Variant',
+      description: 'Choose Divider variant.',
+      control: {
+        type: 'radio',
+      },
+      options: ['Discrete', 'Subtle', 'Soft', 'Defined', 'Dark Blue'],
+      table: {
+        defaultValue: { summary: 'Subtle' },
+      },
+    },
   },
   args: {
+    variant: 'Subtle',
     orientation: 'Horizontal',
+
     width: 150,
     height: 150,
   },
 };
 
-const Template = ({ orientation, width, height }) =>
+const Template = ({ orientation, variant, width, height }) =>
   formatHtmlPreview(`
   <div style="${orientation === 'Horizontal' ? `width: ${width}px;` : `height: ${height}px;`}">
-    <tds-divider orientation="${orientation.toLowerCase()}"></tds-divider>
+    <tds-divider orientation="${orientation.toLowerCase()}" variant="${variant.toLowerCase()}"></tds-divider>
   </div>
 `);
 

--- a/packages/core/src/components/divider/divider.tsx
+++ b/packages/core/src/components/divider/divider.tsx
@@ -9,13 +9,27 @@ export class Divider {
   /** Orientation of the Divider, horizontal if not specified. */
   @Prop() orientation: 'horizontal' | 'vertical' = 'horizontal';
 
+  /** Variant of the Divider, subtle if not specified. */
+  @Prop() variant: 'discrete' | 'subtle' | 'soft' | 'defined' | 'dark-blue' = 'subtle';
+
   render() {
     return (
       <Host
         role="separator"
         aria-orientation={this.orientation === 'vertical' ? 'vertical' : undefined}
       >
-        <div class={`divider ${this.orientation}`} />
+        <div
+          class={{
+            'divider': true,
+            'vertical': this.orientation === 'vertical',
+            'horizontal': this.orientation === 'horizontal',
+            'discrete': this.variant === 'discrete',
+            'subtle': this.variant === 'subtle',
+            'soft': this.variant === 'soft',
+            'defined': this.variant === 'defined',
+            'dark-blue': this.variant === 'dark-blue',
+          }}
+        />
       </Host>
     );
   }

--- a/packages/core/src/components/divider/readme.md
+++ b/packages/core/src/components/divider/readme.md
@@ -7,9 +7,10 @@
 
 ## Properties
 
-| Property      | Attribute     | Description                                              | Type                         | Default        |
-| ------------- | ------------- | -------------------------------------------------------- | ---------------------------- | -------------- |
-| `orientation` | `orientation` | Orientation of the Divider, horizontal if not specified. | `"horizontal" \| "vertical"` | `'horizontal'` |
+| Property      | Attribute     | Description                                              | Type                                                           | Default        |
+| ------------- | ------------- | -------------------------------------------------------- | -------------------------------------------------------------- | -------------- |
+| `orientation` | `orientation` | Orientation of the Divider, horizontal if not specified. | `"horizontal" \| "vertical"`                                   | `'horizontal'` |
+| `variant`     | `variant`     | Variant of the Divider, subtle if not specified.         | `"dark-blue" \| "defined" \| "discrete" \| "soft" \| "subtle"` | `'subtle'`     |
 
 
 ## Dependencies


### PR DESCRIPTION
## **Describe pull-request**  
Updating Divider component with new a11y colors and new color variants.
To prevent braking changes "subtle" is chosen as default if user does not selected different variant.

## **Issue Linking:**  
- **Jira:** Add ticket number after `CDEP-`: [CDEP-1086](https://jira.scania.com/browse/CDEP-1086)

## **How to test**  
1. Open preview link.
2. Check Divider component
3. Open [Figma A11Y: Divider
](https://www.figma.com/design/d8bTgEx7h694MSesi2CTLF/branch/Z96Fk4cDATOIlr3sUcWX2l/Tegel-UI-Library?m=auto&node-id=34149-125001&t=9yxb2kiImPv96roT-1)
4. Compare Figma with Code - they should match


## **Checklist before submission**
- [x] Designer approves new design (if applicable)
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [x] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [x] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


