### PR TITLE
fix(dropdown-option): corrected console warning for a11y

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -97,7 +97,7 @@ export class TdsDropdownOption {
 
   connectedCallback() {
     if (!this.tdsAriaLabel && !this.multiselect) {
-      console.warn('Tegel Dropdown component: tdsAriaLabel prop is missing');
+      console.warn('Tegel Dropdown option component: tdsAriaLabel prop is missing');
     }
   }
 
@@ -164,7 +164,7 @@ export class TdsDropdownOption {
     return (
       <Host>
         <div
-          class={`dropdown-option 
+          class={`dropdown-option
           ${this.size}
           ${this.selected ? 'selected' : ''}
           ${this.disabled ? 'disabled' : ''}


### PR DESCRIPTION
## **Describe pull-request**  
Users get confused by warnings as same one comes from dropdown and dropdown option

## **Issue Linking:**  
- **No issue:** Check conversation from [support channel](https://teams.microsoft.com/l/message/19:5e33f67fe502441f914fbcdc6e2548f5@thread.skype/1753354331038?tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac&groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&parentMessageId=1753354331038&teamName=Tegel%20Design%20System&channelName=Development%20support%20-%20Tegel&createdTime=1753354331038).

## **How to test**  
1. Check if warning message is speaking of correct component so it is not misleading.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


