### PR TITLE
build: fix spawn error on Windows

### DIFF
--- a/packages/core/scripts/build-css.js
+++ b/packages/core/scripts/build-css.js
@@ -21,11 +21,13 @@ const generateSourceMaps = false; // Toggle for CSS source maps
 const args = [];
 if (!generateSourceMaps) args.push('--no-source-map');
 files.forEach(([src, dest]) => {
-  args.push(`${path.join(dirname, '..', src)}:${path.join(dirname, '..', dest)}`);
+  const srcPath = path.join(dirname, '..', src);
+  const destPath = path.join(dirname, '..', dest);
+  args.push(`${srcPath}:${destPath}`);
 });
 if (watch) args.unshift('--watch');
 
-const sass = spawn(sassCmd, args, { stdio: 'inherit' });
+const sass = spawn(sassCmd, args, { stdio: 'inherit', shell: true });
 
 sass.on('close', (code) => {
   process.exit(code ?? 0);


### PR DESCRIPTION
## **Describe pull-request**  
this should fix spawn error when building sass on Windows machines.

## **How to test**  
1. Download repo
2. `npm i && cd packages/core && npm i && npm run build`

## **Checklist before submission**
- [ ] `npm run build:all` without errors

## **Additional context**  
Make sure this change is not breaking build for Mac OS
