### PR TITLE
chore: :memo: remove font important tag in preview styling

### DIFF
--- a/packages/core/.storybook/preview.css
+++ b/packages/core/.storybook/preview.css
@@ -16,7 +16,7 @@ h6,
 p,
 ul > li,
 a {
-  font-family: 'Scania Sans', arial, helvetica, sans-serif !important;
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
 }
 
 *:has(> .docblock-code-toggle) {


### PR DESCRIPTION
## **Describe pull-request**  
Removed !important from font-family styling in storybook as it was incorrectly overriding styling in typography story.

## **Issue Linking:**  
#1352 

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to typography story in storybook
2. Verify correct styling is used.

## **Checklist before submission** N/A
- [] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps** N/A
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
Before
<img width="513" height="405" alt="Screenshot 2025-07-28 at 08 59 27" src="https://github.com/user-attachments/assets/1123ca35-8d86-4281-ae76-8a623aee2c76" />
After
<img width="685" height="485" alt="Screenshot 2025-07-28 at 08 59 58" src="https://github.com/user-attachments/assets/679aa08a-c931-4bc2-af1c-e69945463a16" />
