### PR TITLE
fix(focus-outline): fix focus outline on multiple components

### DIFF
--- a/packages/core/src/components/accordion/accordion-item/accordion-item.scss
+++ b/packages/core/src/components/accordion/accordion-item/accordion-item.scss
@@ -95,7 +95,6 @@
     }
 
     &:hover,
-    &:focus-within,
     &:active,
     &.active {
       @include tds-disabled-style;
@@ -134,30 +133,16 @@
     border-bottom: 1px solid var(--tds-accordion-border);
   }
 
-  // Only apply focus border when focus is on the header buttons, not on panel content
-  &:has(.tds-accordion-header-icon-start:focus),
-  &:has(.tds-accordion-header-icon-end:focus) {
-    border-top: 1px solid var(--tds-accordion-border-focus);
+  // Apply focus ring to the whole item when header is focused via keyboard
+  &:has(.tds-accordion-header-icon-start:focus-visible),
+  &:has(.tds-accordion-header-icon-end:focus-visible) {
+    @include tds-focus-state;
+
+    background-color: var(--tds-accordion-background-focus);
   }
 
-  &[disabled='true']:focus-within {
+  &[disabled='true']:focus-visible {
     border-color: var(--tds-accordion-border);
-  }
-}
-
-:host(:focus-within) {
-  .tds-accordion-item {
-    // Only apply focus styles when focus is on the header buttons, not on panel content
-    &:has(.tds-accordion-header-icon-start:focus),
-    &:has(.tds-accordion-header-icon-end:focus) {
-      @include tds-focus-state;
-    }
-
-    .tds-accordion-header-icon-start,
-    .tds-accordion-header-icon-end {
-      background-color: var(--tds-accordion-background-focus);
-      outline: none;
-    }
   }
 }
 
@@ -165,22 +150,6 @@
   .tds-accordion-header-icon-start,
   .tds-accordion-header-icon-end {
     background-color: var(--tds-accordion-background-hover);
-  }
-}
-
-:host(:focus-within:hover) {
-  .tds-accordion-item {
-    // Only apply focus styles when focus is on the header buttons, not on panel content
-    &:has(.tds-accordion-header-icon-start:focus),
-    &:has(.tds-accordion-header-icon-end:focus) {
-      @include tds-focus-state;
-    }
-
-    .tds-accordion-header-icon-start,
-    .tds-accordion-header-icon-end {
-      background-color: var(--tds-accordion-background-hover);
-      outline: none;
-    }
   }
 }
 

--- a/packages/core/src/components/accordion/accordion.scss
+++ b/packages/core/src/components/accordion/accordion.scss
@@ -14,31 +14,13 @@
   }
 }
 
-:host(:focus) {
-  @include tds-focus-state;
-
+:host(:active) {
   .tds-accordion-item {
     .tds-accordion-header-icon-start,
     .tds-accordion-header-icon-end {
-      background-color: var(--tds-accordion-background-focus);
+      background-color: var(--tds-accordion-background-active);
       outline: none;
-
-      &::after {
-        border-color: var(--tds-accordion-border-focus);
-      }
     }
-  }
-
-  .disabled {
-    @include tds-disabled-style;
-  }
-}
-
-:host(:active) {
-  .tds-accordion-header-icon-start,
-  .tds-accordion-header-icon-end {
-    background-color: var(--tds-accordion-background-active);
-    outline: none;
   }
 
   .disabled {

--- a/packages/core/src/components/checkbox/checkbox.scss
+++ b/packages/core/src/components/checkbox/checkbox.scss
@@ -88,7 +88,7 @@
       }
     }
 
-    &:focus {
+    &:focus-visible {
       &::before {
         background-color: var(--tds-checkbox-background-focus);
         opacity: var(--tds-checkbox-background-opacity-focus);

--- a/packages/core/src/components/dropdown/dropdown-button.scss
+++ b/packages/core/src/components/dropdown/dropdown-button.scss
@@ -33,14 +33,14 @@
       line-height: 1.3;
     }
 
-    &:focus {
+    &:focus-visible {
       border-bottom: 0;
     }
 
     &.error {
       border-bottom: 1px solid var(--tds-dropdown-error);
 
-      &:focus {
+      &:focus-visible {
         border-bottom-color: transparent;
 
         &::before {

--- a/packages/core/src/components/dropdown/dropdown-filter.scss
+++ b/packages/core/src/components/dropdown/dropdown-filter.scss
@@ -3,7 +3,7 @@
 
 :host {
   .dropdown-select {
-    &:focus-within {
+    &:focus-visible {
       @include tds-focus-state;
     }
   }

--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.scss
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.scss
@@ -23,7 +23,7 @@
       color: var(--tds-dropdown-option-color-disabled);
     }
 
-    & button:focus {
+    & button:focus-visible {
       outline: 2px solid var(--tds-dropdown-option-focus);
       box-shadow: inset 0 0 0 3px var(--tds-white);
       outline-offset: -2px;

--- a/packages/core/src/components/dropdown/dropdown.scss
+++ b/packages/core/src/components/dropdown/dropdown.scss
@@ -24,7 +24,7 @@
   .dropdown-select {
     position: relative;
 
-    button:focus {
+    button:focus-visible {
       @include tds-focus-state;
 
       border-radius: 0;
@@ -47,7 +47,7 @@
       border-bottom-color: var(--tds-dropdown-error);
     }
 
-    button.error:focus {
+    button.error:focus-visible {
       border-bottom-color: transparent;
     }
 

--- a/packages/core/src/components/radio-button/radio-button.scss
+++ b/packages/core/src/components/radio-button/radio-button.scss
@@ -59,7 +59,7 @@
       }
     }
 
-    &:focus {
+    &:focus-visible {
       &::before {
         background-color: var(--tds-radio-button-background-focus);
         animation: rb-focus 0.4s cubic-bezier(0.65, 0.05, 0.38, 0.95) forwards;

--- a/packages/core/src/components/toggle/toggle.scss
+++ b/packages/core/src/components/toggle/toggle.scss
@@ -52,13 +52,13 @@
       top: 4px;
     }
 
-    &:focus {
+    &:focus-visible {
       outline: none;
       outline: 2px solid var(--tds-toggle-border-outline);
       border-radius: 16px;
       outline-offset: 0;
 
-       &::before {
+      &::before {
         background-color: var(--tds-toggle-off-slider-focus);
         border: 1px solid var(--tds-toggle-off-border-focus);
       }
@@ -76,7 +76,7 @@
         background-color: var(--tds-toggle-on-slider);
       }
 
-      &:focus {
+      &:focus-visible {
         &::before {
           background-color: var(--tds-toggle-on-slider-focus);
           border: 1px solid var(--tds-toggle-off-border-focus);


### PR DESCRIPTION
## **Describe pull-request**  
This PR resolves an issue where a focus outline appears when clicking on certain UI components. The affected components are:

- Accordion
- Dropdown
- Radio Button
- Checkbox
- Toggle

To fix this, I replaced the :focus pseudo-class with :focus-visible, which ensures that focus outlines only appear when users navigate via keyboard (not on mouse click).
Most components responded well to this change. However, the Accordion required some additional refactoring to ensure proper behavior.

## **Issue Linking:**  
- **Jira:** [CDEP-1099](https://jira.scania.com/browse/CDEP-1099)

## **How to test**  
### 1. Open the production version of the following components (links provided below).
Accordion, Dropdown, Radio Button, Checkbox, Toggle

Click on each component using your mouse. You will notice that a focus outline appears when you click.

### 2. Open the preview version of the same components (links provided below).
Accordion, Dropdown, Radio Button, Checkbox, Toggle

1. Click on each component using your mouse.
2. This time, no focus outline should appear.

3. Test keyboard navigation:
Use the Tab key to move focus to each component.
When the component is focused using the keyboard, a visible focus outline should appear.

### 4. Test in both light mode and dark mode:
1. Make sure the focus outlines are clearly visible when using the keyboard.
2. Make sure there are no outlines when clicking with the mouse.
3. Check that everything looks consistent in both color modes.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
