### PR TITLE
fix(popover-canvas): update color variables for light and dark modes

### DIFF
--- a/packages/core/src/components/popover-canvas/popover-canvas-vars.scss
+++ b/packages/core/src/components/popover-canvas/popover-canvas-vars.scss
@@ -1,10 +1,10 @@
 :root,
 .tds-mode-light {
-  --tds-popover-canvas-color: var(--tds-grey-958);
+  --tds-popover-canvas-color: var(--tds-grey-950);
   --tds-popover-canvas-background: var(--tds-white);
 }
 
 .tds-mode-dark {
   --tds-popover-canvas-color: var(--tds-grey-50);
-  --tds-popover-canvas-background: var(--tds-grey-900);
+  --tds-popover-canvas-background: var(--tds-grey-850);
 }


### PR DESCRIPTION
## **Describe pull-request**  
This PR updates the color variables for the popover canvas to better align with a11y contrast.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-1128](https://jira.scania.com/browse/CDEP-1128)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to [the popover canvas in the preview link](https://pr-1363.d3fazya28914g3.amplifyapp.com/?path=/story/components-popover-canvas--default)
2. Compare the popover canvas to [the figma file](https://www.figma.com/design/d8bTgEx7h694MSesi2CTLF/Tegel-UI-Library?node-id=56102-1598&m=dev) 

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [x] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
