### PR TITLE
fix(form-input-components): compensate for box shadow

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-button.scss
+++ b/packages/core/src/components/dropdown/dropdown-button.scss
@@ -43,6 +43,9 @@
 
     &:focus {
       @include box-shadow('focus');
+
+      // compensate for box shadow
+      padding-bottom: 2px;
     }
 
     &:active {

--- a/packages/core/src/components/dropdown/dropdown-button.scss
+++ b/packages/core/src/components/dropdown/dropdown-button.scss
@@ -2,6 +2,9 @@
 @import './box-shadow';
 
 :host {
+  // compensate for box shadow
+  padding-bottom: 1px;
+
   button {
     all: unset;
     @include box-shadow;

--- a/packages/core/src/components/dropdown/dropdown-button.scss
+++ b/packages/core/src/components/dropdown/dropdown-button.scss
@@ -43,9 +43,6 @@
 
     &:focus {
       @include box-shadow('focus');
-
-      // compensate for box shadow
-      padding-bottom: 2px;
     }
 
     &:active {

--- a/packages/core/src/components/dropdown/dropdown-filter.scss
+++ b/packages/core/src/components/dropdown/dropdown-filter.scss
@@ -3,6 +3,9 @@
 @import './box-shadow';
 
 :host {
+  // compensate for box shadow
+  padding-bottom: 1px;
+
   .filter {
     @include box-shadow;
 

--- a/packages/core/src/components/dropdown/dropdown-filter.scss
+++ b/packages/core/src/components/dropdown/dropdown-filter.scss
@@ -84,9 +84,6 @@
 
     &.focus {
       @include box-shadow('focus');
-
-      // compensate for box shadow
-      padding-bottom: 2px;
     }
 
     &.error {

--- a/packages/core/src/components/dropdown/dropdown-filter.scss
+++ b/packages/core/src/components/dropdown/dropdown-filter.scss
@@ -84,6 +84,9 @@
 
     &.focus {
       @include box-shadow('focus');
+
+      // compensate for box shadow
+      padding-bottom: 2px;
     }
 
     &.error {

--- a/packages/core/src/components/dropdown/dropdown.scss
+++ b/packages/core/src/components/dropdown/dropdown.scss
@@ -5,8 +5,6 @@
 @import '../../../../../typography/utilities/typography-utility';
 
 :host {
-  // compensate for box shadow
-  padding-bottom: 1px;
   @include detail-02;
 
   display: block;

--- a/packages/core/src/components/dropdown/dropdown.scss
+++ b/packages/core/src/components/dropdown/dropdown.scss
@@ -5,6 +5,8 @@
 @import '../../../../../typography/utilities/typography-utility';
 
 :host {
+  // compensate for box shadow
+  padding-bottom: 1px;
   @include detail-02;
 
   display: block;
@@ -118,7 +120,7 @@
   .helper {
     @include detail-05;
 
-    margin-top: 4px;
+    padding-top: var(--tds-spacing-element-4);
     color: var(--dropdown-helper-text);
     display: flex;
     align-items: center;

--- a/packages/core/src/components/text-field/text-field.scss
+++ b/packages/core/src/components/text-field/text-field.scss
@@ -148,9 +148,6 @@
 //Focus state
 .form-text-field {
   &.text-field-focus {
-    // compensate for box shadow
-    padding-bottom: 2px;
-
     .text-field-container {
       outline: var(--text-field-focus-outline);
       outline-offset: var(--text-field-focus-outline-offset);

--- a/packages/core/src/components/text-field/text-field.scss
+++ b/packages/core/src/components/text-field/text-field.scss
@@ -76,6 +76,11 @@
   color: var(--text-field-placeholder);
 }
 
+.form-text-field {
+  // compensate for box shadow
+  padding-bottom: 1px;
+}
+
 //text-field container with label inside
 //Handling position, focus and transition for label inside
 .form-text-field.text-field-container-label-inside {

--- a/packages/core/src/components/text-field/text-field.scss
+++ b/packages/core/src/components/text-field/text-field.scss
@@ -148,6 +148,9 @@
 //Focus state
 .form-text-field {
   &.text-field-focus {
+    // compensate for box shadow
+    padding-bottom: 2px;
+
     .text-field-container {
       outline: var(--text-field-focus-outline);
       outline-offset: var(--text-field-focus-outline-offset);

--- a/packages/core/src/components/textarea/textarea.scss
+++ b/packages/core/src/components/textarea/textarea.scss
@@ -36,6 +36,11 @@
       transform: scaleX(0);
       transition: 0.35s ease transform;
     }
+
+    &.texarea-focus {
+      // compensate for box shadow
+      padding-bottom: 2px;
+    }
   }
 }
 

--- a/packages/core/src/components/textarea/textarea.scss
+++ b/packages/core/src/components/textarea/textarea.scss
@@ -20,6 +20,8 @@
 
 .textarea-container {
   .textarea-wrapper {
+    // compensate for box shadow
+    padding-bottom: 1px;
     position: relative;
     width: unset;
     min-width: 100%;

--- a/packages/core/src/components/textarea/textarea.scss
+++ b/packages/core/src/components/textarea/textarea.scss
@@ -36,11 +36,6 @@
       transform: scaleX(0);
       transition: 0.35s ease transform;
     }
-
-    &.texarea-focus {
-      // compensate for box shadow
-      padding-bottom: 2px;
-    }
   }
 }
 


### PR DESCRIPTION
## **Describe pull-request**  
fixing the overlap issue where box-shadow is not taking up any space on demo pages. Check screenshot to see the issue in angular demo page.

## **Issue Linking:**    
- **No issue:** Check uploaded screenshot

## **How to test**  
1. Need to be packed, or released in beta to test
2. Go to angular demo
4. Check out `feat/multibrand-test` branch
5.`npm i @scania/tegel@1.34.0-multibrand-beta.5` or latest beta version.
6. set the`VITE_STORYBOOK_ENV`
7. Go to [Forms page](http://localhost:4200/form/simpleform)

## **Screenshots**  
<img width="612" height="166" alt="image" src="https://github.com/user-attachments/assets/5732c8e6-4537-49e4-82cb-bb2700418ad7" />
