### PR TITLE
fix(stepper): added color variable for the checkmark/tick in success step.

### DIFF
--- a/packages/core/src/components/stepper/step/step.scss
+++ b/packages/core/src/components/stepper/step/step.scss
@@ -189,7 +189,7 @@
       &.success {
         background-color: var(--stepper-icon-step-border-success);
         border-color: var(--stepper-icon-step-border-success);
-        color: var(--tds-white);
+        color: var(--steper-icon-step-checkmark);
       }
 
       &.current {

--- a/packages/core/src/components/stepper/stepper-vars.scss
+++ b/packages/core/src/components/stepper/stepper-vars.scss
@@ -7,6 +7,7 @@ tds-stepper {
 
   // Success
   --stepper-icon-step-border-success: var(--component-stepper-success);
+  --steper-icon-step-checkmark: var(--color-foreground-icon-inverse-strong);
 
   // Upcoming
   --stepper-label-text-upcoming: var(--color-foreground-text-disabled);


### PR DESCRIPTION
## **Describe pull-request**  
The checkmark or "tick" icon in dark mode is using a white icon but should rather use a dark one. This PR fixes that.

## **Issue Linking:**  
- **Jira:** : [CDEP-1142](https://jira.scania.com/browse/CDEP-1142)

## **How to test**  
1. Go to the stepper component using the preview link below
2. Switch to dark mode and observe that the "tick" turns dark
3. Switch between both TRATON and Scania to validate.
4. Compare to Figma design [here](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=26693-59848&p=f&m=dev)

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
