### PR TITLE
fix(card): improve css structure

### DIFF
--- a/packages/core/src/components/card/card-vars.scss
+++ b/packages/core/src/components/card/card-vars.scss
@@ -1,80 +1,16 @@
 tds-card {
-  --card-background: var(--tds-white);
-  --card-background-primary: var(--component-card-primary);
-  --card-background-secondary: var(--component-card-secondary);
-  --card-box-primary: 0 3px 3px rgb(0 0 0 / 15%), 0 -1px 1px rgb(0 0 0 / 1%);
-  --card-box-secondary: 0 -1px 1px rgb(0 0 0 / 5%), 0 3px 3px rgb(0 0 0 / 10%);
-  --card-box: var(--card-box-primary); //box shadow
-  --card-box-hover: 0 -1px 1px rgb(0 0 0 / 5%), 0 3px 3px rgb(0 0 0 / 20%);
-  --card-box-pressed: 0 -1px 1px rgb(0 0 0 / 5%), 0 1px 3px rgb(0 0 0 / 20%);
+  --card-background: var(--component-card-background);
+  --card-box: var(--component-card-box); //box shadow
+  --card-box-hover: var(--component-card-box-hover);
+  --card-box-pressed: var(--component-card-box-pressed);
   --card-headline: var(--color-foreground-text-strong);
   --card-sub-headline: var(--color-foreground-text-subtle);
   --card-body-color: var(--color-foreground-text-defined);
   --card-divider: var(--color-foreground-border-discrete);
   --card-icon-color: var(--color-foreground-icon-strong);
-}
-
-tds-card,
-.scania tds-card {
-  /* Paddings */
-  --card-body-padding: 0 16px;
-  --card-header-padding: 16px;
-  --card-slotted-padding: 16px;
-
-  &.tds-mode-variant-primary {
-    --card-box: var(--card-box-primary);
-  }
-
-  &.tds-mode-variant-secondary {
-    --card-box: var(--card-box-secondary);
-  }
-}
-
-.tds-mode-dark {
-  --card-background-primary: var(--tds-grey-900);
-  --card-background-secondary: var(--tds-grey-850);
-
-  tds-card {
-    --card-background: var(--card-background-primary);
-  }
-
-  .tds-mode-variant-primary {
-    --card-box: var(--card-box-primary);
-    --card-background: var(--card-background-primary);
-  }
-
-  .tds-mode-variant-secondary {
-    --card-box: var(--card-box-secondary);
-    --card-background: var(--card-background-secondary);
-  }
-}
-
-.traton {
-  .tds-mode-dark tds-card {
-    &.tds-mode-variant-primary {
-      --card-background: var(--color-background-base);
-    }
-  }
-}
-
-.traton tds-card {
-  --card-box: none;
-  --card-background: transparent;
-  --card-box-hover: none;
-  --card-box-pressed: none;
 
   /* Paddings */
-  --card-body-padding: 0;
-  --card-header-padding: 16px 16px 16px 0;
-  --card-slotted-padding: 16px 16px 16px 0;
-
-  &.tds-mode-variant-primary {
-    --card-box: none;
-    --card-background: var(--card-background-secondary);
-  }
-
-  &.tds-mode-variant-secondary {
-    --card-box: none;
-    --card-background: var(--card-background-primary);
-  }
+  --card-body-padding: var(--component-card-body-padding);
+  --card-header-padding: var(--component-card-header-padding);
+  --card-slotted-padding: var(--component-card-slotted-padding);
 }

--- a/tokens/scss/component/card.scss
+++ b/tokens/scss/component/card.scss
@@ -31,51 +31,46 @@ tds-card,
   }
 }
 
-.tds-mode-dark {
-  --card-background-primary: var(--tds-grey-900);
-  --card-background-secondary: var(--tds-grey-850);
+.tds-mode-dark tds-card {
+  --component-card-background: var(--tds-grey-900);
 
-  tds-card {
-    --component-card-background: var(--card-background-primary);
-  }
-
-  .tds-mode-variant-primary {
+  &.tds-mode-variant-primary {
     --component-card-box: var(--card-box-primary);
-    --component-card-background: var(--card-background-primary);
+    --component-card-background: var(--tds-grey-900);
   }
 
-  .tds-mode-variant-secondary {
+  &.tds-mode-variant-secondary {
     --component-card-box: var(--card-box-secondary);
-    --component-card-background: var(--card-background-secondary);
+    --component-card-background: var(--tds-grey-850);
   }
 }
 
 .traton {
+  tds-card {
+    --component-card-box: none;
+    --component-card-background: transparent;
+    --component-card-box-hover: none;
+    --component-card-box-pressed: none;
+
+    /* Paddings */
+    --component-card-body-padding: 0;
+    --component-card-header-padding: 16px 16px 16px 0;
+    --component-card-slotted-padding: 16px 16px 16px 0;
+
+    &.tds-mode-variant-primary {
+      --component-card-box: none;
+      --component-card-background: var(--component-card-secondary);
+    }
+
+    &.tds-mode-variant-secondary {
+      --component-card-box: none;
+      --component-card-background: var(--component-card-primary);
+    }
+  }
+
   .tds-mode-dark tds-card {
     &.tds-mode-variant-primary {
       --component-card-background: var(--color-background-base);
     }
-  }
-}
-
-.traton tds-card {
-  --component-card-box: none;
-  --component-card-background: transparent;
-  --component-card-box-hover: none;
-  --component-card-box-pressed: none;
-
-  /* Paddings */
-  --component-card-body-padding: 0;
-  --component-card-header-padding: 16px 16px 16px 0;
-  --component-card-slotted-padding: 16px 16px 16px 0;
-
-  &.tds-mode-variant-primary {
-    --component-card-box: none;
-    --component-card-background: var(--component-card-secondary);
-  }
-
-  &.tds-mode-variant-secondary {
-    --component-card-box: none;
-    --component-card-background: var(--component-card-primary);
   }
 }

--- a/tokens/scss/component/card.scss
+++ b/tokens/scss/component/card.scss
@@ -7,4 +7,75 @@ tds-card {
   --component-card-secondary: var(--color-background-layer-02);
   --component-card-primary: var(--color-background-layer-01);
   --component-card-padding-padding: var(--scania-unit-16);
+  --card-box-primary: 0 3px 3px rgb(0 0 0 / 15%), 0 -1px 1px rgb(0 0 0 / 1%);
+  --card-box-secondary: 0 -1px 1px rgb(0 0 0 / 5%), 0 3px 3px rgb(0 0 0 / 10%);
+  --component-card-box-hover: 0 -1px 1px rgb(0 0 0 / 5%), 0 3px 3px rgb(0 0 0 / 20%);
+  --component-card-box-pressed: 0 -1px 1px rgb(0 0 0 / 5%), 0 1px 3px rgb(0 0 0 / 20%);
+  --component-card-background: var(--tds-white);
+}
+
+tds-card,
+.scania tds-card {
+  /* Paddings */
+  --component-card-body-padding: 0 16px;
+  --component-card-header-padding: 16px;
+  --component-card-slotted-padding: 16px;
+  --component-card-box: var(--card-box-primary);
+
+  &.tds-mode-variant-primary {
+    --component-card-box: var(--card-box-primary);
+  }
+
+  &.tds-mode-variant-secondary {
+    --component-card-box: var(--card-box-secondary);
+  }
+}
+
+.tds-mode-dark {
+  --card-background-primary: var(--tds-grey-900);
+  --card-background-secondary: var(--tds-grey-850);
+
+  tds-card {
+    --component-card-background: var(--card-background-primary);
+  }
+
+  .tds-mode-variant-primary {
+    --component-card-box: var(--card-box-primary);
+    --component-card-background: var(--card-background-primary);
+  }
+
+  .tds-mode-variant-secondary {
+    --component-card-box: var(--card-box-secondary);
+    --component-card-background: var(--card-background-secondary);
+  }
+}
+
+.traton {
+  .tds-mode-dark tds-card {
+    &.tds-mode-variant-primary {
+      --component-card-background: var(--color-background-base);
+    }
+  }
+}
+
+.traton tds-card {
+  --component-card-box: none;
+  --component-card-background: transparent;
+  --component-card-box-hover: none;
+  --component-card-box-pressed: none;
+
+  /* Paddings */
+  --component-card-body-padding: 0;
+  --component-card-header-padding: 16px 16px 16px 0;
+  --component-card-slotted-padding: 16px 16px 16px 0;
+
+  &.tds-mode-variant-primary {
+    --component-card-box: none;
+    --component-card-background: var(--component-card-secondary);
+  }
+
+  &.tds-mode-variant-secondary {
+    --component-card-box: none;
+    --component-card-background: var(--component-card-primary);
+  }
 }


### PR DESCRIPTION
## **Describe pull-request**  
This PR restructures the css code for the card component, as specified in the Jira ticket.

Note: I needed to move two "--card-..." variables, as well as move many other variables (and rename them to "--component-..."), to tokens/scss/component/card.scss, which I assumed is ok to do.

## **Issue Linking:**  
- **Jira:** [CDEP-1119](https://jira.scania.com/browse/CDEP-1119)

## **How to test**  
1. Go to https://pr-1369.d3fazya28914g3.amplifyapp.com/?path=/story/components-card--default
2. Switch between lightmode and darkmode as well as the brand, and compare with the Card component in https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=26478-59506&p=f&m=dev

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
None
