### PR TITLE
fix(footer-group): show border-bottom also when expanded

### DIFF
--- a/packages/core/src/components/footer/footer-group/footer-group.scss
+++ b/packages/core/src/components/footer/footer-group/footer-group.scss
@@ -33,12 +33,8 @@
       margin: 0;
     }
 
-    &.expanded {
-      border-bottom: none;
-
-      tds-icon {
-        transform: rotateZ(180deg);
-      }
+    &.expanded tds-icon {
+      transform: rotateZ(180deg);
     }
 
     &:hover {


### PR DESCRIPTION
## **Describe pull-request**  
This PR fixes so that the border-bottom is also shown when a footer-group is expanded in mobile view.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** `CDEP-`: [CDEP-1138](https://jira.scania.com/browse/CDEP-1138)

## **How to test**  
1. Go to https://pr-1371.d3fazya28914g3.amplifyapp.com/?path=/story/components-footer--default
2. Make the screen narrow so that the footer groups are expandable
3. Click e.g. "Title 1"
4. Verify that there's a border between "Title 1" and "Link 1"

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
None
