### PR TITLE
fix(link): updated icon

### DIFF
--- a/packages/core/src/components/link/link.stories.tsx
+++ b/packages/core/src/components/link/link.stories.tsx
@@ -91,7 +91,7 @@ StandaloneLink.args = {
   underline: false,
   disabled: false,
   iconEnabled: true,
-  icon: 'redirect',
+  icon: 'placeholder',
 };
 
 // Additional argTypes for Standalone Link only


### PR DESCRIPTION
## **Describe pull-request**  
The link icon is using default icon as default in code. Update so that it's using placeholder icon instead. 

## **Issue Linking:**  
- **Jira:**`update link icon`[CDEP-1139](https://jira.scania.com/browse/CDEP-1139)

## **How to test**  
1. Open amplify link, go to Link -> standalone
2. Check that it uses placeholder icon instead of redirect icon