### PR TITLE
fix(dropdown-filter): apply disabled option styles correctly

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-filter.scss
+++ b/packages/core/src/components/dropdown/dropdown-filter.scss
@@ -25,7 +25,9 @@
     &.disabled {
       @include box-shadow('disabled');
 
-      color: var(--dropdown-disabled);
+      .value-wrapper input {
+        color: var(--dropdown-disabled);
+      }
     }
 
     .value-wrapper {

--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.scss
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.scss
@@ -20,10 +20,6 @@
       background-color: var(--dropdown-option-background-selected);
     }
 
-    &.disabled {
-      color: var(--dropdown-option-disabled);
-    }
-
     & button:focus {
       @include tds-focus-state;
 


### PR DESCRIPTION
## **Describe pull-request**  
fix disabled option text

## **Issue Linking:**  
- **Jira:** `fix disabled option text` [CDEP-1137](https://jira.scania.com/browse/CDEP-1137)

## **How to test**  
1. Go to dropdown in storybook
2. Toggle filter
3. Toggle disabled
4. Set a default option
5. The option value should now have the disabled grey color