### PR TITLE
fix(textarea): added missing disabled vars

### DIFF
--- a/packages/core/src/components/textarea/textarea-vars.scss
+++ b/packages/core/src/components/textarea/textarea-vars.scss
@@ -5,6 +5,9 @@ tds-textarea {
   --textarea-text: var(--color-foreground-text-strong);
 
   // Disabled
+  --textarea-disabled-background-primary: var(--color-background-layer-01);
+  --textarea-disabled-background-secondary: var(--color-background-layer-02);
+  --textarea-disabled-background: var(--textarea-disabled-background-primary);
   --textarea-disabled-text: var(--color-foreground-text-disabled);
   --textarea-disabled-placeholder: var(--color-foreground-text-disabled);
   --textarea-disabled-label: var(--color-foreground-text-disabled);

--- a/packages/core/src/components/textarea/textarea.scss
+++ b/packages/core/src/components/textarea/textarea.scss
@@ -215,6 +215,7 @@
 //Disabled state
 .textarea-disabled {
   cursor: not-allowed;
+  background-color: var(--textarea-disabled-background);
 
   .textarea-input {
     @include box-shadow('disabled');


### PR DESCRIPTION
## **Describe pull-request**  
The background color when textarea is disabled was missing. This PR adds it back.

## **Issue Linking:**  
- **Jira:** `CDEP-1159`: [CDEP-](https://jira.scania.com/browse/CDEP-1159)

## **How to test**  
1. Open preview link below
2. Go to textarea component
3. Set disabled to true
4. Observe the background color of the component and make sure the color is not missing. Switch between the modeVariant, Brand and light modes.
5. Compare to [Figma: textarea](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=26756-59843&p=f&m=dev)

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
