### PR TITLE
fix(table): remove hover from dropdown pagination

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option-vars.scss
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option-vars.scss
@@ -24,6 +24,6 @@ tds-dropdown-option {
 tds-table-footer {
   --dropdown-option-border: var(--color-foreground-border-discrete);
   --dropdown-option-background: var(--color-background-layer-01);
-  --dropdown-option-background-hover: var(--color-background-surface-500);
-  --dropdown-option-background-selected: var(--color-background-surface-400);
+  --dropdown-option-background-hover: var(--color-background-surface-100);
+  --dropdown-option-background-selected: var(--color-background-surface-300);
 }


### PR DESCRIPTION
## **Describe pull-request**  

Jira ticket description: Hover behavior in the table pagination is not defined in design yet and should be removed for now until we've had time to have a look at it.

What i did in this PR is to make the pagination dropdown hover look have exactly the same behaviour as our normal dropdown hover state does.

## **Issue Linking:**  
- **Jira:** `CDEP-1144`: [CDEP-1144](https://jira.scania.com/browse/CDEP-1144)

## **How to test**  
1. Open preview link below
2. Open up table/pagination
3. Open up the dropdown from the table footer, right after "rows per page".
4. Compare the hover state to the normal dropdown component (have them open side by side or compare to [Figma design:dropdown](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=26537-59509&p=f&m=dev) ), it should look exactly the same.
5. Try in both Scania/Traton, light and dark mode

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
