### PR TITLE
fix(button): should show pressed state on enter down

### DIFF
--- a/packages/core/src/components/button/button.tsx
+++ b/packages/core/src/components/button/button.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, Host, Prop, State } from '@stencil/core';
+import { Component, Element, h, Host, Listen, Prop, State } from '@stencil/core';
 import hasSlot from '../../utils/hasSlot';
 
 /**
@@ -54,6 +54,20 @@ export class TdsButton {
       console.warn(
         'Tegel button component: please specify the tdsAriaLabel prop when you have the onlyIcon attribute set to true',
       );
+    }
+  }
+
+  @Listen('keydown')
+  handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && !this.disabled) {
+      this.host.querySelector('button').classList.add('active');
+    }
+  }
+
+  @Listen('keyup')
+  handleKeyUp(event: KeyboardEvent) {
+    if (event.key === 'Enter' && !this.disabled) {
+      this.host.querySelector('button').classList.remove('active');
     }
   }
 


### PR DESCRIPTION
## **Describe pull-request**  
Button should show pressed state (active styling) on enter pressed

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:**

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to amplify link
2. Navigate to button and see that it reacts to enter press with its active styling

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors
