### PR TITLE
feat(tegel-light): added tl-toast component

### DIFF
--- a/packages/core/src/global/tegel-light-components.scss
+++ b/packages/core/src/global/tegel-light-components.scss
@@ -19,3 +19,4 @@
 @import '../tegel-light/components/tl-link/tl-link';
 @import '../tegel-light/components/tl-text-field/tl-text-field';
 @import '../tegel-light/components/tl-breadcrumbs/tl-breadcrumbs';
+@import '../tegel-light/components/tl-toast/tl-toast';

--- a/packages/core/src/tegel-light/components/tl-toast/_tl-toast-vars.scss
+++ b/packages/core/src/tegel-light/components/tl-toast/_tl-toast-vars.scss
@@ -1,0 +1,15 @@
+.tl-toast {
+  // Toast background
+  --toast-background: var(--color-background-inverse-base);
+
+  // Toast text colors
+  --toast-headline: var(--color-foreground-text-inverse-strong);
+  --toast-subheadline: var(--color-foreground-text-inverse-soft);
+  --toast-dismiss: var(--color-foreground-text-inverse-strong);
+
+  // Toast icon colors
+  --toast-icon-error: var(--color-system-danger-default);
+  --toast-icon-success: var(--color-system-success-default);
+  --toast-icon-warning: var(--color-system-warning-default);
+  --toast-icon-info: var(--color-system-info-default);
+}

--- a/packages/core/src/tegel-light/components/tl-toast/tl-toast.scss
+++ b/packages/core/src/tegel-light/components/tl-toast/tl-toast.scss
@@ -1,0 +1,101 @@
+@import './tl-toast-vars';
+@import '../../../mixins/focus-state';
+@import '../../../mixins/z-index';
+@import '../../../../../../typography/utilities/typography-utility';
+
+.tl-toast {
+  z-index: tds-z-index(toast);
+  display: flex;
+  width: calc(352px - 4px);
+  background-color: var(--toast-background);
+  border-radius: 4px;
+
+  &--information {
+    border-left: 4px solid var(--toast-icon-info);
+  }
+
+  &--success {
+    border-left: 4px solid var(--toast-icon-success);
+  }
+
+  &--error {
+    border-left: 4px solid var(--toast-icon-error);
+  }
+
+  &--warning {
+    border-left: 4px solid var(--toast-icon-warning);
+  }
+
+  &__icon {
+    padding: 14px 0 0 12px;
+    color: var(--toast-icon-info);
+    flex-shrink: 0;
+
+    .tl-toast--error & {
+      color: var(--toast-icon-error);
+    }
+
+    .tl-toast--success & {
+      color: var(--toast-icon-success);
+    }
+
+    .tl-toast--warning & {
+      color: var(--toast-icon-warning);
+    }
+  }
+
+  &__content {
+    padding: 16px 0 16px 10px;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    max-width: 250px;
+    word-break: break-word;
+  }
+
+  &__header-subheader {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  &__header {
+    @include headline-07;
+
+    color: var(--toast-headline);
+    margin: 0;
+  }
+
+  &__subheader {
+    @include detail-02;
+
+    color: var(--toast-subheadline);
+    margin: 0;
+  }
+
+  &__actions {
+    padding-top: 12px;
+  }
+
+  &__close {
+    height: 20px;
+    width: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 14px 14px 0 22px;
+    border: none;
+    background: transparent;
+    color: var(--toast-dismiss);
+    cursor: pointer;
+
+    &:focus-visible {
+      @include tds-focus-state;
+    }
+  }
+
+  &--hide {
+    display: none;
+    visibility: hidden;
+  }
+}

--- a/packages/core/src/tegel-light/components/tl-toast/tl-toast.stories.tsx
+++ b/packages/core/src/tegel-light/components/tl-toast/tl-toast.stories.tsx
@@ -1,0 +1,117 @@
+import formatHtmlPreview from '../../../stories/formatHtmlPreview';
+
+export default {
+  title: 'Tegel Light (CSS)/Toast',
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    variant: {
+      name: 'Variant',
+      description: 'Changes the variant of the component.',
+      options: ['information', 'success', 'warning', 'error'],
+      control: {
+        type: 'radio',
+      },
+      table: {
+        defaultValue: { summary: 'information' },
+      },
+    },
+    header: {
+      name: 'Header',
+      description: 'Sets text to be displayed in the header section.',
+      control: {
+        type: 'text',
+      },
+    },
+    subheader: {
+      name: 'Subheader',
+      description: 'Sets text to be displayed in the subheader section.',
+      control: {
+        type: 'text',
+      },
+    },
+    actions: {
+      name: 'Actions slot',
+      description: 'Slot for the bottom part of the Toast, used for links.',
+      control: {
+        type: 'text',
+      },
+    },
+    hidden: {
+      name: 'Hidden',
+      description: 'Hides the Toast.',
+      control: {
+        type: 'boolean',
+      },
+    },
+    closable: {
+      name: 'Closable',
+      description: 'Controls visibility of the close button.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: true },
+      },
+    },
+  },
+  args: {
+    variant: 'information',
+    header: 'Message header',
+    subheader: 'Short subheader',
+    actions:
+      '<tds-link><a href="https://tegel.scania.com/home" target="_blank">Link example</a></tds-link>',
+    hidden: false,
+    closable: true,
+  },
+};
+
+const Template = ({ variant, header, subheader, actions, hidden, closable }) => {
+  const variantClass = `tl-toast--${variant}`;
+  const hiddenClass = hidden ? 'tl-toast--hide' : '';
+
+  // Determine icon based on variant
+  let iconName = '';
+  switch (variant) {
+    case 'error':
+      iconName = 'error';
+      break;
+    case 'success':
+      iconName = 'tick';
+      break;
+    case 'warning':
+      iconName = 'warning';
+      break;
+    case 'information':
+    default:
+      iconName = 'info';
+      break;
+  }
+
+  const iconElement = `<span class="tl-toast__icon"><span class="tl-icon tl-icon--${iconName} tl-icon--20" aria-hidden="true"></span></span>`;
+  const closeButton = closable
+    ? `<button class="tl-toast__close"><span class="tl-icon tl-icon--cross tl-icon--20" aria-hidden="true"></span></button>`
+    : '';
+
+  return formatHtmlPreview(`
+    <!-- Required stylesheets:
+      "@scania/tegel-light/global.css"
+      "@scania/tegel-light/tl-toast.css"
+      "@scania/tegel-light/tl-icon.css"
+    -->
+    <div class="tl-toast ${variantClass} ${hiddenClass}">
+      ${iconElement}
+      <div class="tl-toast__content">
+        <div class="tl-toast__header-subheader">
+          ${header ? `<div class="tl-toast__header">${header}</div>` : ''}
+          ${subheader ? `<div class="tl-toast__subheader">${subheader}</div>` : ''}
+        </div>
+        ${actions ? `<div class="tl-toast__actions">${actions}</div>` : ''}
+      </div>
+      ${closeButton}
+    </div>
+  `);
+};
+
+export const Default = Template.bind({});


### PR DESCRIPTION
## **Describe pull-request**  
A tegel light toast component 

## **Issue Linking:**  
 [CDEP-1185](https://jira.scania.com/browse/CDEP-1185)

## **How to test**  
1. Go to preview link and navigate to tegel light and the toast component
2. Check all settings and dark/light mode
3. Check Traton/Scania
4. Check Docs to see how styles are implemented with classes


## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [x] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events