### PR TITLE
feat(tegel-light): added tl-radiobutton

### DIFF
--- a/packages/core/src/global/tegel-light-components.scss
+++ b/packages/core/src/global/tegel-light-components.scss
@@ -22,3 +22,4 @@
 @import '../tegel-light/components/tl-breadcrumbs/tl-breadcrumbs';
 @import '../tegel-light/components/tl-toast/tl-toast';
 @import '../tegel-light/components/tl-banner/tl-banner';
+@import '../tegel-light/components/tl-radiobutton/tl-radiobutton';

--- a/packages/core/src/tegel-light/components/tl-radiobutton/_tl-radiobutton-vars.scss
+++ b/packages/core/src/tegel-light/components/tl-radiobutton/_tl-radiobutton-vars.scss
@@ -1,0 +1,17 @@
+.tl-radiobutton {
+  // Default colors
+  --radio-button-background-hover: var(--color-foreground-border-discrete);
+  --radio-button-background-inverse: var(--color-foreground-icon-inverse-strong);
+  --radio-button-background-disabled: var(--color-background-accent-primary-disabled);
+  --radio-button-border: var(--color-foreground-border-strong);
+  --radio-button-label: var(--color-foreground-text-strong);
+  --radio-button-label-disabled: var(--color-foreground-text-disabled);
+
+  // Active (checked)
+  --radio-button-focus: var(--color-foreground-border-accent-focus);
+  --radio-button-checked-disabled: var(--color-foreground-icon-disabled);
+
+  // Units
+  --radio-button-spacing-4: var(--tds-spacing-element-4) 0 var(--tds-spacing-element-4)
+    var(--tds-spacing-element-4);
+}

--- a/packages/core/src/tegel-light/components/tl-radiobutton/tl-radiobutton.scss
+++ b/packages/core/src/tegel-light/components/tl-radiobutton/tl-radiobutton.scss
@@ -1,0 +1,168 @@
+@import '../../../mixins/box-sizing';
+@import './_tl-radiobutton-vars';
+@import '../../../../../../typography/utilities/typography-utility';
+
+/* Block */
+.tl-radiobutton {
+  @include tds-box-sizing;
+  @include detail-02;
+
+  color: var(--radio-button-label);
+  display: flex;
+  align-items: center;
+  margin-left: -4px;
+}
+
+/* ─────────────────────────────
+   Elements (top-level)
+   ───────────────────────────── */
+
+/* INPUT — semantic control (hidden visually) */
+.tl-radiobutton__input {
+  appearance: none;
+  outline: none;
+  margin: 0;
+  border: 0;
+  inline-size: 24px;
+  block-size: 24px;
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  border-radius: 50%;
+
+  /* Focus: pulse + thin outline on visual control */
+  &:focus + .tl-radiobutton__control {
+    &::before {
+      background-color: var(--radio-button-focus);
+      animation: rb-focus 0.4s cubic-bezier(0.65, 0.05, 0.38, 0.95) forwards;
+    }
+
+    &::after {
+      outline: 1px solid var(--tds-radio-button-interaction-outline);
+    }
+  }
+
+  /* Checked: thicker border to create dot effect */
+  &:checked + .tl-radiobutton__control {
+    &::after {
+      border: 4px solid var(--radio-button-border);
+    }
+  }
+
+  /* Checked + focus: thicker outline on inner circle */
+  &:checked:focus + .tl-radiobutton__control {
+    &::after {
+      outline: 4px solid var(--radio-button-focus);
+    }
+  }
+
+  /* Checked + disabled tweaks (scoped to element) */
+  .tl-radiobutton--disabled & {
+    &:checked + .tl-radiobutton__control {
+      &::before {
+        border: 1px solid var(--radio-button-border-disabled);
+        display: block;
+        inline-size: 16px;
+        block-size: 16px;
+        left: 3px;
+        top: 3px;
+        box-sizing: content-box;
+      }
+
+      &::after {
+        border: 4px solid var(--radio-button-background-disabled);
+        background-color: var(--radio-button-checked-disabled);
+        left: 4px;
+        top: 4px;
+      }
+    }
+  }
+}
+
+/* CONTROL — visual ring + inner circle */
+.tl-radiobutton__control {
+  inline-size: 24px;
+  block-size: 24px;
+  border-radius: 50%;
+  position: relative;
+  cursor: pointer;
+  flex-shrink: 0;
+  align-self: flex-start;
+  box-sizing: border-box;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    box-sizing: border-box;
+  }
+
+  /* focus “pulse” background holder */
+  &::before {
+    inline-size: 22px;
+    block-size: 22px;
+    left: 1px;
+    top: 1px;
+  }
+
+  /* base inner circle + ring */
+  &::after {
+    background-color: var(--radio-button-background-inverse);
+    border: 1px solid var(--radio-button-border);
+    inline-size: 16px;
+    block-size: 16px;
+    left: 4px;
+    top: 4px;
+  }
+
+  /* Hover outline (only when not disabled) */
+  .tl-radiobutton:not(.tl-radiobutton--disabled):hover & {
+    &::after {
+      outline: 2px solid var(--radio-button-background-hover);
+    }
+  }
+
+  /* Disabled visuals */
+  .tl-radiobutton--disabled & {
+    cursor: not-allowed;
+
+    &::before {
+      outline: 1px solid var(--radio-button-border-disabled);
+      outline-offset: -4px;
+    }
+
+    &::after {
+      background-color: var(--radio-button-background-disabled);
+      border-color: var(--radio-button-background-disabled);
+
+      /* prevent hover outline when disabled */
+      outline: none;
+    }
+  }
+}
+
+/* LABEL — spacing & disabled color */
+.tl-radiobutton__label {
+  padding: var(--radio-button-spacing-4);
+  cursor: pointer;
+
+  .tl-radiobutton--disabled & {
+    color: var(--radio-button-label-disabled);
+    cursor: not-allowed;
+  }
+}
+
+/* ─────────────────────────────
+   Focus animation (same as WC)
+   ───────────────────────────── */
+@keyframes rb-focus {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}

--- a/packages/core/src/tegel-light/components/tl-radiobutton/tl-radiobutton.stories.tsx
+++ b/packages/core/src/tegel-light/components/tl-radiobutton/tl-radiobutton.stories.tsx
@@ -1,0 +1,102 @@
+import formatHtmlPreview from '../../../stories/formatHtmlPreview';
+
+export default {
+  title: 'Tegel Light (CSS)/Radio Button',
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    label: {
+      name: 'Label text',
+      control: {
+        type: 'text',
+      },
+      table: {
+        defaultValue: {
+          summary: 'Label text',
+        },
+      },
+    },
+    checkedIndex: {
+      name: 'Checked index',
+      control: {
+        type: 'radio',
+      },
+      options: [0, 1, 'none'],
+      table: {
+        defaultValue: {
+          summary: 0,
+        },
+      },
+    },
+    disabled: {
+      name: 'Disabled',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
+    name: {
+      name: 'Group name',
+      control: {
+        type: 'text',
+      },
+      table: {
+        defaultValue: {
+          summary: 'rb-example',
+        },
+      },
+    },
+  },
+  args: {
+    label: 'Label text',
+    checkedIndex: 0,
+    disabled: false,
+    name: 'rb-example',
+  },
+};
+
+const Template = ({ label, checkedIndex, disabled, name }) =>
+  formatHtmlPreview(`
+<!-- Required stylesheet 
+  "@scania/tegel-light/tl-radiobutton.css";
+-->
+
+<style>
+  .demo-fieldset-reset { border: 0; margin: 0; padding: 0; }
+</style>
+
+<fieldset class="demo-fieldset-reset">
+    <label class="tl-radiobutton ${disabled ? 'tl-radiobutton--disabled' : ''}">
+      <input
+        class="tl-radiobutton__input"
+        type="radio"
+        name="${name}"
+        value="option-1"
+        ${checkedIndex === 0 ? 'checked' : ''}
+        ${disabled ? 'disabled' : ''}
+      />
+      <span class="tl-radiobutton__control"></span>
+      <span class="tl-radiobutton__label">${label} 1</span>
+    </label>
+
+    <label class="tl-radiobutton ${disabled ? 'tl-radiobutton--disabled' : ''}">
+      <input
+        class="tl-radiobutton__input"
+        type="radio"
+        name="${name}"
+        value="option-2"
+        ${checkedIndex === 1 ? 'checked' : ''}
+        ${disabled ? 'disabled' : ''}
+      />
+      <span class="tl-radiobutton__control"></span>
+      <span class="tl-radiobutton__label">${label} 2</span>
+    </label>
+</fieldset>
+`);
+
+export const Default = Template.bind({});


### PR DESCRIPTION
## **Describe pull-request**  
A tegel light radio button component.

## **Issue Linking:**  
 [CDEP-1326](https://jira.scania.com/browse/CDEP-1326)

## **How to test**  
1. Go to preview link and navigate to tegel light and the radiobutton component
2. Check all settings and dark/light mode
3. Check Traton/Scania
4. Check Docs to see how styles are implemented with classes
5. Compare to [Figma](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=26693-59844&p=f&m=dev)


## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [x] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
