### PR TITLE
feat(card): add support for header-icon slot and styling for card component

### DIFF
--- a/packages/core/src/components/card/card.scss
+++ b/packages/core/src/components/card/card.scss
@@ -22,12 +22,43 @@
     padding: 16px;
     display: flex;
     align-items: center;
+    justify-content: space-between;
 
     slot[name='thumbnail']::slotted(*) {
       width: 36px;
       height: 36px;
       border-radius: 100%;
       margin-right: 16px;
+    }
+
+    .header-subheader {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      gap: 4px;
+      flex: 1;
+
+      .header,
+      slot[name='header'] {
+        color: var(--tds-card-headline);
+      }
+
+      .subheader,
+      slot[name='subheader'] {
+        color: var(--tds-card-sub-headline);
+      }
+    }
+
+    .header-icon-container {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      margin-left: 16px;
+      flex-shrink: 0;
+
+      slot[name='header-icon']::slotted(*) {
+        color: var(--tds-card-icon-color);
+      }
     }
 
     .card-top-header {
@@ -42,23 +73,6 @@
 
     &.below {
       padding-top: 16px;
-    }
-  }
-
-  .header-subheader {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    gap: 4px;
-
-    .header,
-    slot[name='header'] {
-      color: var(--tds-card-headline);
-    }
-
-    .subheader,
-    slot[name='subheader'] {
-      color: var(--tds-card-sub-headline);
     }
   }
 

--- a/packages/core/src/components/card/card.stories.tsx
+++ b/packages/core/src/components/card/card.stories.tsx
@@ -1,6 +1,7 @@
 import CardPlaceholder from '../../stories/assets/image/card-placeholder.png';
 import CardBodyImage from '../../stories/assets/image/card-img.png';
 import formatHtmlPreview from '../../stories/formatHtmlPreview';
+import { iconsNames } from '../icon/iconsArray';
 
 export default {
   title: 'Components/Card',
@@ -97,6 +98,15 @@ export default {
         type: 'text',
       },
     },
+    headerIcon: {
+      name: 'Icon',
+      description:
+        'Sets icon to be displayed on the Card header. Choose "none" to exclude the icon.',
+      control: {
+        type: 'select',
+      },
+      options: ['none', ...iconsNames],
+    },
     clickable: {
       name: 'Clickable',
       description: 'Toggles if the Card is clickable or not.',
@@ -129,6 +139,7 @@ export default {
     bodyContent: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.`,
     bodyDivider: false,
     cardActions: `<tds-icon slot="actions" size="20px" name="arrow_right"></tds-icon>`,
+    headerIcon: ``,
     clickable: false,
     stretch: false,
   },
@@ -144,6 +155,7 @@ const Template = ({
   bodyContent,
   bodyDivider,
   cardActions,
+  headerIcon,
   clickable,
   stretch,
 }) =>
@@ -170,6 +182,7 @@ const Template = ({
         ? `<img slot="thumbnail" src="${CardPlaceholder}" alt="Thumbnail for the card."/>`
         : ''
     }
+    ${headerIcon ? `<tds-icon slot="header-icon" size="20px" name="${headerIcon}"></tds-icon>` : ''}
   ${
     bodyContent
       ? `

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -6,6 +6,7 @@ import hasSlot from '../../utils/hasSlot';
  * @slot header - Slot for the Card header.
  * @slot subheader - Slot for the Card subheader.
  * @slot thumbnail - Slot for the Card thumbnail.
+ * @slot header-icon - Slot for an icon in the top right corner of the header.
  * @slot body - Slot for the body section of the Card.
  * @slot body-image - Slot for the body section of the Card, used for image.
  * @slot actions - Slot for the bottom section of the Card, used for buttons .
@@ -72,6 +73,7 @@ export class TdsCard {
     const usesHeaderSlot = hasSlot('header', this.host);
     const usesSubheaderSlot = hasSlot('subheader', this.host);
     const usesThumbnailSlot = hasSlot('thumbnail', this.host);
+    const usesHeaderIconSlot = hasSlot('header-icon', this.host);
     return (
       <div class="card-header">
         {usesThumbnailSlot && <slot name="thumbnail"></slot>}
@@ -81,6 +83,11 @@ export class TdsCard {
           {this.subheader && <span class="subheader">{this.subheader}</span>}
           {usesSubheaderSlot && <slot name="subheader"></slot>}
         </div>
+        {usesHeaderIconSlot && (
+          <div class="header-icon-container">
+            <slot name="header-icon"></slot>
+          </div>
+        )}
       </div>
     );
   };

--- a/packages/core/src/components/card/readme.md
+++ b/packages/core/src/components/card/readme.md
@@ -30,14 +30,15 @@
 
 ## Slots
 
-| Slot           | Description                                                 |
-| -------------- | ----------------------------------------------------------- |
-| `"actions"`    | Slot for the bottom section of the Card, used for buttons . |
-| `"body"`       | Slot for the body section of the Card.                      |
-| `"body-image"` | Slot for the body section of the Card, used for image.      |
-| `"header"`     | Slot for the Card header.                                   |
-| `"subheader"`  | Slot for the Card subheader.                                |
-| `"thumbnail"`  | Slot for the Card thumbnail.                                |
+| Slot            | Description                                                 |
+| --------------- | ----------------------------------------------------------- |
+| `"actions"`     | Slot for the bottom section of the Card, used for buttons . |
+| `"body"`        | Slot for the body section of the Card.                      |
+| `"body-image"`  | Slot for the body section of the Card, used for image.      |
+| `"header"`      | Slot for the Card header.                                   |
+| `"header-icon"` | Slot for an icon in the top right corner of the header.     |
+| `"subheader"`   | Slot for the Card subheader.                                |
+| `"thumbnail"`   | Slot for the Card thumbnail.                                |
 
 
 ## Dependencies

--- a/packages/core/src/components/card/test/default/index.html
+++ b/packages/core/src/components/card/test/default/index.html
@@ -13,6 +13,7 @@
 
   <body>
     <tds-card header="Header text" subheader="Subheader text">
+      <tds-icon slot="header-icon" size="20px" name="close"></tds-icon>
       <tds-icon svg-title="a right arrow" slot="actions" size="20px" name="arrow_right"></tds-icon>
     </tds-card>
   </body>


### PR DESCRIPTION
## **Describe pull-request**  
We received a request for the possibility to add an icon in the card header. 

## **Issue Linking:**  

- **Teams:** [Teams thread](https://teams.microsoft.com/l/message/19:5e33f67fe502441f914fbcdc6e2548f5@thread.skype/1756797365374?tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac&groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&parentMessageId=1756797365374&teamName=Tegel%20Design%20System&channelName=Development%20support%20-%20Tegel&createdTime=1756797365374)


## **How to test**  
1. Go to the card component in the preview link
2. In the storybook controls, add an icon to the header.
3. Make sure it looks good both in code and design wise.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [x] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [x] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [x] Design/controls/props is aligned with other components 
- [x] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
