### PR TITLE
fix(dropdown): only reset filter query on clear

### DIFF
--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -99,6 +99,8 @@ export class TdsDropdown {
 
   @State() private selectedOptions: string[] = [];
 
+  @State() filterQuery: string = '';
+
   private dropdownList: HTMLDivElement;
 
   private inputElement: HTMLInputElement;
@@ -555,6 +557,7 @@ export class TdsDropdown {
   private handleFilter = (event) => {
     this.tdsInput.emit(event);
     const query = event.target.value.toLowerCase();
+    this.filterQuery = query;
     /* Check if the query is empty, and if so, show all options */
     const children = this.getChildren();
 
@@ -582,7 +585,10 @@ export class TdsDropdown {
   };
 
   private handleFilterReset = () => {
-    this.reset();
+    // only reset selected values when filterquery is blank
+    if (!this.filterQuery.length) {
+      this.reset();
+    }
     this.inputElement.value = '';
     this.handleFilter({ target: { value: '' } });
     this.inputElement.focus();
@@ -593,7 +599,7 @@ export class TdsDropdown {
   private handleFocus = () => {
     this.open = true;
     this.filterFocus = true;
-    if (this.multiselect && this.inputElement) {
+    if (this.inputElement) {
       this.inputElement.value = '';
     }
     // Focus event is now handled by focusin listener
@@ -605,7 +611,7 @@ export class TdsDropdown {
   private handleBlur = () => {
     // Handle internal state changes when component loses focus
     this.filterFocus = false;
-    if (this.multiselect && this.inputElement) {
+    if (this.inputElement) {
       this.inputElement.value = this.getValue();
     }
   };
@@ -720,7 +726,7 @@ export class TdsDropdown {
                   }}
                   type="text"
                   placeholder={this.filterFocus ? '' : this.placeholder}
-                  value={this.multiselect && this.filterFocus ? '' : this.getValue()}
+                  value={this.multiselect && this.filterFocus ? this.filterQuery : this.getValue()}
                   disabled={this.disabled}
                   onInput={(event) => this.handleFilter(event)}
                   onFocus={() => this.handleFocus()}


### PR DESCRIPTION
## **Describe pull-request**  
Only reset filter query on clear, if filter is present selected value should not be effected

## **Issue Linking:**  
_Choose one of the following options_
- **GitHub:** https://github.com/scania-digital-design-system/tegel/issues/1331

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to amplify link and go to dropdown component
2. Select `multiselect` & `filter`
3. Make some selections and then type in filter, now clear that filter
4. Selected values should remain.
5. you can compare this flow and behavior with production to see that whenever you clear filter, the selected value/values also get cleared

## **Checklist before submission*
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

