### PR TITLE
feat: accordion expand on click

### DIFF
--- a/packages/core/src/components/accordion/accordion-item/accordion-item.scss
+++ b/packages/core/src/components/accordion/accordion-item/accordion-item.scss
@@ -99,12 +99,20 @@
     &.active {
       @include tds-disabled-style;
     }
+
+    // Override expanded cursor when disabled
+    &.expanded {
+      .tds-accordion-panel {
+        cursor: not-allowed;
+      }
+    }
   }
 
   &.expanded {
     .tds-accordion-panel {
       display: block;
       padding-bottom: 31px;
+      cursor: pointer;
     }
 
     .tds-accordion-icon {

--- a/packages/core/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/packages/core/src/components/accordion/accordion-item/accordion-item.tsx
@@ -80,16 +80,20 @@ export class TdsAccordionItem {
     expanded: boolean;
   }>;
 
-  private readonly handlePanelClick = () => {
+  private readonly handlePanelClick = (e: MouseEvent) => {
+    if (e.target !== e.currentTarget) return;
     if (!this.disabled) {
       this.toggleAccordionItem();
     }
   };
 
   private readonly handlePanelKeyDown = (e: KeyboardEvent) => {
+    if (e.target !== e.currentTarget) return;
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      this.handlePanelClick();
+      if (!this.disabled) {
+        this.toggleAccordionItem();
+      }
     }
   };
 

--- a/packages/core/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/packages/core/src/components/accordion/accordion-item/accordion-item.tsx
@@ -80,6 +80,12 @@ export class TdsAccordionItem {
     expanded: boolean;
   }>;
 
+  private handlePanelClick = () => {
+    if (!this.disabled) {
+      this.toggleAccordionItem();
+    }
+  };
+
   render() {
     const primaryElementId = generateUniqueId();
     const secondaryElementId = generateUniqueId();
@@ -125,6 +131,7 @@ export class TdsAccordionItem {
             class={`tds-accordion-panel
             ${this.paddingReset ? 'tds-accordion-panel--padding-reset ' : ''}
             `}
+            onClick={this.handlePanelClick}
           >
             <slot></slot>
           </div>

--- a/packages/core/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/packages/core/src/components/accordion/accordion-item/accordion-item.tsx
@@ -80,9 +80,16 @@ export class TdsAccordionItem {
     expanded: boolean;
   }>;
 
-  private handlePanelClick = () => {
+  private readonly handlePanelClick = () => {
     if (!this.disabled) {
       this.toggleAccordionItem();
+    }
+  };
+
+  private readonly handlePanelKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this.handlePanelClick();
     }
   };
 
@@ -132,6 +139,7 @@ export class TdsAccordionItem {
             ${this.paddingReset ? 'tds-accordion-panel--padding-reset ' : ''}
             `}
             onClick={this.handlePanelClick}
+            onKeyDown={this.handlePanelKeyDown}
           >
             <slot></slot>
           </div>


### PR DESCRIPTION
## **Describe pull-request**  
This PR makes it possible for the user to close the accordion by clicking on the whole accordion item. Not just the header.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-1209](https://jira.scania.com/browse/CDEP-1209)


## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to [the accordion component](https://pr-1435.d3fazya28914g3.amplifyapp.com/?path=/story/components-accordion--default) in the preview link
2. Expand and close the accordion and make sure that you can click on the whole accordion to expand/close

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [x] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
https://github.com/user-attachments/assets/d5a31329-d817-40fa-bbd4-e4336b0ac354

