### PR TITLE
fix(tl-modal): add size modifier to buttons

### DIFF
--- a/packages/core/src/tegel-light/components/tl-modal/tl-modal.stories.tsx
+++ b/packages/core/src/tegel-light/components/tl-modal/tl-modal.stories.tsx
@@ -105,8 +105,8 @@ const ModalTemplate = ({ actionsPosition, size, headerText, bodyContent, showMod
           ${bodyContent}
         </>
         <div class="tl-modal__actions">
-          <button class="tl-button tl-button--primary">Button Text</>
-          <button class="tl-button tl-button--secondary">Button Text</>
+          <button class="tl-button tl-button--md tl-button--primary">Button Text</>
+          <button class="tl-button tl-button--md tl-button--secondary">Button Text</>
         </>
       </>
     </>


### PR DESCRIPTION
## **Describe pull-request**  
Buttons on tegel light modal component was looking off, missing a size modifier. 

## **Issue Linking:**  
- **No issue:** 

## **How to test**  
1. Go to preview link and the tegel light modal component
2. Check that the buttons look OK

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
<img width="1108" height="371" alt="Screenshot 2025-09-15 at 15 24 56" src="https://github.com/user-attachments/assets/e1b77c06-d676-44b3-8128-9c434120fed0" />
<img width="1084" height="365" alt="Screenshot 2025-09-15 at 15 25 10" src="https://github.com/user-attachments/assets/edab4722-de95-4737-8695-ea1490c8cb4d" />
