### PR TITLE
Feat/dropdown blur

### DIFF
--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -160,8 +160,6 @@ export class TdsDropdownOption {
     if (!this.parentElement) {
       this.tdsBlur.emit(event);
     }
-    // Always prevent the event from bubbling up to avoid interference
-    event.stopPropagation();
   };
 
   render() {

--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -147,11 +147,21 @@ export class TdsDropdownOption {
   };
 
   handleFocus = (event) => {
-    this.tdsFocus.emit(event);
+    // Focus events are now handled by the parent dropdown component
+    // Only emit if this is a standalone option (not within a dropdown)
+    if (!this.parentElement) {
+      this.tdsFocus.emit(event);
+    }
   };
 
   handleBlur = (event) => {
-    this.tdsBlur.emit(event);
+    // Blur events are now handled by the parent dropdown component
+    // Only emit if this is a standalone option (not within a dropdown)
+    if (!this.parentElement) {
+      this.tdsBlur.emit(event);
+    }
+    // Always prevent the event from bubbling up to avoid interference
+    event.stopPropagation();
   };
 
   render() {

--- a/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/packages/core/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -185,6 +185,9 @@ export class TdsDropdownOption {
                 onTdsChange={(event) => {
                   this.handleMultiselect(event);
                 }}
+                onTdsBlur={(event) => {
+                  event.stopPropagation();
+                }}
                 disabled={this.disabled}
                 checked={this.selected}
                 tdsAriaLabel={this.tdsAriaLabel}

--- a/packages/core/src/components/dropdown/dropdown.scss
+++ b/packages/core/src/components/dropdown/dropdown.scss
@@ -5,6 +5,7 @@
 @import '../../mixins/focus-state';
 
 :host {
+  background-color: red;
   display: block;
   position: relative;
   font: var(--tds-detail-02);

--- a/packages/core/src/components/dropdown/dropdown.scss
+++ b/packages/core/src/components/dropdown/dropdown.scss
@@ -5,7 +5,6 @@
 @import '../../mixins/focus-state';
 
 :host {
-  background-color: red;
   display: block;
   position: relative;
   font: var(--tds-detail-02);

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -359,15 +359,12 @@ export class TdsDropdown {
   @Listen('focusout')
   onFocusOut(event: FocusEvent) {
     // Only emit blur if focus is actually leaving the entire dropdown component
-    // Check if the related target (where focus is going) is outside the component
     const relatedTarget = event.relatedTarget as Node;
 
-    if (this.hasFocus && relatedTarget && !this.host.contains(relatedTarget)) {
+    // If relatedTarget is null (focus going to body/window) or outside the component, emit blur
+    if (this.hasFocus && (!relatedTarget || !this.host.contains(relatedTarget))) {
       this.hasFocus = false;
-      this.tdsBlur.emit(event);
-    } else if (this.hasFocus && !relatedTarget) {
-      // If relatedTarget is null (focus going to body or window), emit blur
-      this.hasFocus = false;
+      this.handleBlur();
       this.tdsBlur.emit(event);
     }
   }
@@ -606,8 +603,7 @@ export class TdsDropdown {
   };
 
   private handleBlur = () => {
-    // Blur event is now handled by focusout listener
-    // Only handle internal state changes here
+    // Handle internal state changes when component loses focus
     this.filterFocus = false;
     if (this.multiselect && this.inputElement) {
       this.inputElement.value = this.getValue();
@@ -727,9 +723,6 @@ export class TdsDropdown {
                   value={this.multiselect && this.filterFocus ? '' : this.getValue()}
                   disabled={this.disabled}
                   onInput={(event) => this.handleFilter(event)}
-                  onBlur={() => {
-                    this.handleBlur();
-                  }}
                   onFocus={() => this.handleFocus()}
                   onKeyDown={(event) => {
                     if (event.key === 'Escape') {

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -275,7 +275,7 @@ export class TdsDropdown {
       }
     }
     // Always trigger the focus event to open the dropdown
-    this.handleFocus({});
+    this.handleFocus();
   }
 
   /** Method for closing the Dropdown. */
@@ -588,7 +588,7 @@ export class TdsDropdown {
     this.internalValue = '';
   };
 
-  private handleFocus = (event) => {
+  private handleFocus = () => {
     this.open = true;
     this.filterFocus = true;
     if (this.multiselect && this.inputElement) {
@@ -600,7 +600,7 @@ export class TdsDropdown {
     }
   };
 
-  private handleBlur = (event) => {
+  private handleBlur = () => {
     // Blur event is now handled by focusout listener
     // Only handle internal state changes here
     this.filterFocus = false;
@@ -722,10 +722,10 @@ export class TdsDropdown {
                   value={this.multiselect && this.filterFocus ? '' : this.getValue()}
                   disabled={this.disabled}
                   onInput={(event) => this.handleFilter(event)}
-                  onBlur={(event) => {
-                    this.handleBlur(event);
+                  onBlur={() => {
+                    this.handleBlur();
                   }}
-                  onFocus={(event) => this.handleFocus(event)}
+                  onFocus={() => this.handleFocus()}
                   onKeyDown={(event) => {
                     if (event.key === 'Escape') {
                       this.open = false;

--- a/packages/core/src/components/dropdown/dropdown.tsx
+++ b/packages/core/src/components/dropdown/dropdown.tsx
@@ -358,13 +358,18 @@ export class TdsDropdown {
 
   @Listen('focusout')
   onFocusOut(event: FocusEvent) {
-    // Use setTimeout to check if focus moved to another element within the dropdown
-    setTimeout(() => {
-      if (this.hasFocus && !this.host.contains(document.activeElement)) {
-        this.hasFocus = false;
-        this.tdsBlur.emit(event);
-      }
-    }, 0);
+    // Only emit blur if focus is actually leaving the entire dropdown component
+    // Check if the related target (where focus is going) is outside the component
+    const relatedTarget = event.relatedTarget as Node;
+
+    if (this.hasFocus && relatedTarget && !this.host.contains(relatedTarget)) {
+      this.hasFocus = false;
+      this.tdsBlur.emit(event);
+    } else if (this.hasFocus && !relatedTarget) {
+      // If relatedTarget is null (focus going to body or window), emit blur
+      this.hasFocus = false;
+      this.tdsBlur.emit(event);
+    }
   }
 
   @Listen('keydown')


### PR DESCRIPTION
## **Describe pull-request**  
Updated dropdown so that tdsBlur is only dispatched when the dropdown as a whole loses focus, not when individual dropdown options or the filter input blur.

Ensures consistent behavior whether or not the filter prop is used.

Prevents multiple/unexpected tdsBlur events when interacting with options or navigating with keyboard.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** [CDEP-1444](https://jira.scania.com/browse/CDEP-1444)
- **GitHub:** [[Bug report]: tdsBlur is not behaving as expected in Dropdown component #1423](https://github.com/scania-digital-design-system/tegel/issues/1423)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to [this sandbox environment](https://7t67jg.csb.app/)
2. Install beta release [1.37.1-dropdown-blur-beta.5](https://www.npmjs.com/package/@scania/tegel/v/1.37.1-dropdown-blur-beta.5)
3. Test each scenario, make sure that only the main dropdown emit the event. 

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [x] Events

## **Screenshots**  
https://github.com/user-attachments/assets/36b3d8d6-6217-4b66-999d-943d84017c94

