### PR TITLE
feat(card): added expandable prop

### DIFF
--- a/packages/core/src/components/button/readme.md
+++ b/packages/core/src/components/button/readme.md
@@ -30,6 +30,19 @@
 | `"label"` | Slot for the text injection. Serves as alternative to text prop. |
 
 
+## Dependencies
+
+### Used by
+
+ - [tds-card](../card)
+
+### Graph
+```mermaid
+graph TD;
+  tds-card --> tds-button
+  style tds-button fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/core/src/components/card/card.scss
+++ b/packages/core/src/components/card/card.scss
@@ -147,6 +147,6 @@ button {
   }
 }
 
-:host([expandable]:not([expanded])) .card-body slot {
+:host([expandable]:not([expanded])) .card-body slot[name='body'] {
   display: none;
 }

--- a/packages/core/src/components/card/card.scss
+++ b/packages/core/src/components/card/card.scss
@@ -43,6 +43,18 @@
     &.below {
       padding-top: 16px;
     }
+
+    &.expandable {
+      tds-icon {
+        cursor: pointer;
+        margin-left: auto;
+        transition: transform 160ms ease-in-out, opacity 120ms ease-in-out;
+
+        &.rotated {
+          transform: rotate(180deg);
+        }
+      }
+    }
   }
 
   .header-subheader {
@@ -133,4 +145,8 @@ button {
       flex-grow: 1;
     }
   }
+}
+
+:host([expandable]:not([expanded])) .card-body slot {
+  display: none;
 }

--- a/packages/core/src/components/card/card.stories.tsx
+++ b/packages/core/src/components/card/card.stories.tsx
@@ -143,7 +143,7 @@ export default {
     bodyImg: false,
     bodyContent: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.`,
     bodyDivider: false,
-    cardActions: `<div slot="actions" style="display: flex; gap: 16px;"><tds-button type="button" variant="primary" size="sm" text="Button text" animation="none" tds-aria-label="undefined" name="" value=""></tds-button><tds-button type="button" variant="secondary" size="sm" text="Button text" animation="none" tds-aria-label="undefined" name="" value=""></tds-button></div>`,
+    cardActions: `<div slot="actions" style="display: flex; gap: 16px;"><tds-button type="button" variant="primary" size="sm" text="Button text" animation="none" tds-aria-label="A button component" name="" value=""></tds-button><tds-button type="button" variant="secondary" size="sm" text="Button text" animation="none" tds-aria-label="A button component" name="" value=""></tds-button></div>`,
     clickable: false,
     stretch: false,
     expandable: false,

--- a/packages/core/src/components/card/card.stories.tsx
+++ b/packages/core/src/components/card/card.stories.tsx
@@ -171,6 +171,7 @@ const Template = ({
     /* demo-wrapper is for demonstration purposes only*/
     .demo-wrapper {
         max-width: 600px;
+        ${expanded ? 'width: 368px;' : ''}
     }
     </style>
     <div class="demo-wrapper">

--- a/packages/core/src/components/card/card.stories.tsx
+++ b/packages/core/src/components/card/card.stories.tsx
@@ -103,6 +103,7 @@ export default {
       control: {
         type: 'boolean',
       },
+      if: { arg: 'expandable', eq: false },
       table: {
         defaultValue: { summary: false },
       },
@@ -117,6 +118,20 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    expandable: {
+      name: 'Expandable',
+      description: 'Toggles if the Card can expand/collapse its content.',
+      control: 'boolean',
+      if: { arg: 'clickable', eq: false },
+      table: { defaultValue: { summary: false } },
+    },
+    expanded: {
+      name: 'Expanded',
+      description: 'Controls the initial expanded state when expandable is enabled.',
+      control: 'boolean',
+      if: { arg: 'expandable', eq: true },
+      table: { defaultValue: { summary: false } },
+    },
   },
 
   args: {
@@ -128,9 +143,11 @@ export default {
     bodyImg: false,
     bodyContent: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.`,
     bodyDivider: false,
-    cardActions: `<tds-icon slot="actions" size="20px" name="arrow_right"></tds-icon>`,
+    cardActions: `<div slot="actions" style="display: flex; gap: 16px;"><tds-button type="button" variant="primary" size="sm" text="Button text" animation="none" tds-aria-label="undefined" name="" value=""></tds-button><tds-button type="button" variant="secondary" size="sm" text="Button text" animation="none" tds-aria-label="undefined" name="" value=""></tds-button></div>`,
     clickable: false,
     stretch: false,
+    expandable: false,
+    expanded: true,
   },
 };
 
@@ -146,6 +163,8 @@ const Template = ({
   cardActions,
   clickable,
   stretch,
+  expandable,
+  expanded,
 }) =>
   formatHtmlPreview(
     `<style>
@@ -164,6 +183,8 @@ const Template = ({
     ${clickable ? 'clickable' : ''}
     ${bodyDivider ? 'body-divider' : ''}
     ${stretch ? 'stretch' : ''}
+    ${expandable ? 'expandable' : ''}
+    ${expanded ? 'expanded' : ''}
     >
     ${
       thumbnail

--- a/packages/core/src/components/card/card.stories.tsx
+++ b/packages/core/src/components/card/card.stories.tsx
@@ -171,7 +171,7 @@ const Template = ({
     /* demo-wrapper is for demonstration purposes only*/
     .demo-wrapper {
         max-width: 600px;
-        ${expanded ? 'width: 368px;' : ''}
+        ${expandable ? 'width: 368px;' : ''}
     }
     </style>
     <div class="demo-wrapper">

--- a/packages/core/src/components/card/card.stories.tsx
+++ b/packages/core/src/components/card/card.stories.tsx
@@ -171,7 +171,12 @@ const Template = ({
     /* demo-wrapper is for demonstration purposes only*/
     .demo-wrapper {
         max-width: 600px;
-        ${expandable ? 'width: 368px;' : ''}
+        ${
+          expandable
+            ? `width: 368px;
+        height: 416px;`
+            : ''
+        }
     }
     </style>
     <div class="demo-wrapper">

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -101,12 +101,20 @@ export class TdsCard {
           {usesSubheaderSlot && <slot name="subheader"></slot>}
         </div>
         {this.expandable && (
-          <tds-icon
-            name="chevron_down"
-            size="16px"
-            class={{ 'chevron-icon': true, 'rotated': this.expanded }}
+          <tds-button
+            type="button"
+            variant="ghost"
+            size="sm"
+            tds-aria-label="Icon button"
             onClick={this.toggleExpand}
-          ></tds-icon>
+          >
+            <tds-icon
+              slot="icon"
+              size="16px"
+              name="chevron_down"
+              class={{ rotated: this.expanded }}
+            ></tds-icon>
+          </tds-button>
         )}
       </div>
     );

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -105,7 +105,7 @@ export class TdsCard {
             type="button"
             variant="ghost"
             size="sm"
-            tds-aria-label="Icon button"
+            tds-aria-label="Toggle card content"
             onClick={this.toggleExpand}
           >
             <tds-icon

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -51,6 +51,17 @@ export class TdsCard {
    */
   @Prop() cardId: string = generateUniqueId();
 
+  /**
+   * Enables expandable behaviour.
+   * When true, clicking the header toggles content visibility.
+   */
+  @Prop() expandable: boolean = false;
+
+  /**
+   * Tracks the current expanded state when expandable is enabled.
+   */
+  @Prop({ mutable: true, reflect: true }) expanded: boolean = false;
+
   /** Sends unique Card identifier when the Card is clicked, if clickable=true */
   @Event({
     eventName: 'tdsClick',
@@ -61,6 +72,13 @@ export class TdsCard {
   tdsClick: EventEmitter<{
     cardId: string;
   }>;
+
+  private toggleExpand = () => {
+    if (this.expandable) {
+      this.expanded = !this.expanded;
+      console.log(this.expanded);
+    }
+  };
 
   handleClick = () => {
     this.tdsClick.emit({
@@ -73,7 +91,9 @@ export class TdsCard {
     const usesSubheaderSlot = hasSlot('subheader', this.host);
     const usesThumbnailSlot = hasSlot('thumbnail', this.host);
     return (
-      <div class="card-header">
+      <div
+        class={{ 'card-header': true, 'expandable': this.expandable, 'expanded': this.expanded }}
+      >
         {usesThumbnailSlot && <slot name="thumbnail"></slot>}
         <div class="header-subheader" id={`header-${this.cardId}`}>
           {this.header && <span class="header">{this.header}</span>}
@@ -81,6 +101,14 @@ export class TdsCard {
           {this.subheader && <span class="subheader">{this.subheader}</span>}
           {usesSubheaderSlot && <slot name="subheader"></slot>}
         </div>
+        {this.expandable && (
+          <tds-icon
+            name="chevron_down"
+            size="16px"
+            class={{ 'chevron-icon': true, 'rotated': this.expanded }}
+            onClick={this.toggleExpand}
+          ></tds-icon>
+        )}
       </div>
     );
   };

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -106,12 +106,14 @@ export class TdsCard {
             variant="ghost"
             size="sm"
             tds-aria-label="Toggle card content"
+            aria-expanded={this.expanded ? 'true' : 'false'}
             onClick={this.toggleExpand}
           >
             <tds-icon
               slot="icon"
               size="16px"
               name="chevron_down"
+              svgTitle="Chevron Down"
               class={{ rotated: this.expanded }}
             ></tds-icon>
           </tds-button>

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -76,7 +76,6 @@ export class TdsCard {
   private toggleExpand = () => {
     if (this.expandable) {
       this.expanded = !this.expanded;
-      console.log(this.expanded);
     }
   };
 

--- a/packages/core/src/components/card/readme.md
+++ b/packages/core/src/components/card/readme.md
@@ -46,12 +46,14 @@
 
 ### Depends on
 
+- [tds-button](../button)
 - [tds-icon](../icon)
 - [tds-divider](../divider)
 
 ### Graph
 ```mermaid
 graph TD;
+  tds-card --> tds-button
   tds-card --> tds-icon
   tds-card --> tds-divider
   style tds-card fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/core/src/components/card/readme.md
+++ b/packages/core/src/components/card/readme.md
@@ -14,6 +14,8 @@
 | `bodyImgAlt`     | `body-img-alt`    | Alt text for the body image                                                                                                                                                                           | `string`                           | `undefined`          |
 | `cardId`         | `card-id`         | ID for the Card, must be unique.  **NOTE**: If you're listening for Card events, you need to set this ID yourself to identify the Card, as the default ID is random and will be different every time. | `string`                           | `generateUniqueId()` |
 | `clickable`      | `clickable`       | Makes the Card clickable.                                                                                                                                                                             | `boolean`                          | `false`              |
+| `expandable`     | `expandable`      | Enables expandable behaviour. When true, clicking the header toggles content visibility.                                                                                                              | `boolean`                          | `false`              |
+| `expanded`       | `expanded`        | Tracks the current expanded state when expandable is enabled.                                                                                                                                         | `boolean`                          | `false`              |
 | `header`         | `header`          | Text in the header                                                                                                                                                                                    | `string`                           | `undefined`          |
 | `imagePlacement` | `image-placement` | Placement of the header                                                                                                                                                                               | `"above-header" \| "below-header"` | `'below-header'`     |
 | `modeVariant`    | `mode-variant`    | Variant of the Card based on the theme used.                                                                                                                                                          | `"primary" \| "secondary"`         | `null`               |
@@ -44,11 +46,13 @@
 
 ### Depends on
 
+- [tds-icon](../icon)
 - [tds-divider](../divider)
 
 ### Graph
 ```mermaid
 graph TD;
+  tds-card --> tds-icon
   tds-card --> tds-divider
   style tds-card fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/core/src/components/icon/readme.md
+++ b/packages/core/src/components/icon/readme.md
@@ -20,6 +20,7 @@
 
  - [tds-accordion-item](../accordion/accordion-item)
  - [tds-banner](../banner)
+ - [tds-card](../card)
  - [tds-datetime](../datetime)
  - [tds-dropdown](../dropdown)
  - [tds-dropdown-option](../dropdown/dropdown-option)
@@ -50,6 +51,7 @@
 graph TD;
   tds-accordion-item --> tds-icon
   tds-banner --> tds-icon
+  tds-card --> tds-icon
   tds-datetime --> tds-icon
   tds-dropdown --> tds-icon
   tds-dropdown-option --> tds-icon


### PR DESCRIPTION
## **Describe pull-request**  
The Card component has a design variant that supports an expandable behaviour. This allows users to hide the card content under a dropdown-like interaction, toggled via a chevron icon in the header.

Until now, this functionality existed in design (Figma) but was missing in code. This PR adds that functionality

(I also added two action buttons for demo purpose that alligns with the current figma design)

## **Issue Linking:**  
- **Jira:** `[CDEP-1522](https://jira.scania.com/browse/CDEP-1522)

## **How to test**  
1. Go to preview link and open up the card component
2. Set the expandable prop to true
3. Click on the chevron that appears on the component and test the expand functionality.
4. Try the expanded prop via storybook control
5. Try having different options on at the same time (eg. body image, stretched etc..)
6. Compare to figma design [here](https://www.figma.com/design/d8bTgEx7h694MSesi2CTLF/Tegel-UI-Library?node-id=26478-59506&p=f&m=dev)

## **Checklist before submission**
- [x] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
