### PR TITLE
fix(popover-menu): set default background color to primary mode variant

### DIFF
--- a/packages/core/src/components/popover-menu/popover-menu-vars.scss
+++ b/packages/core/src/components/popover-menu/popover-menu-vars.scss
@@ -10,7 +10,7 @@
 
 .tds-mode-dark {
   --tds-popover-menu-color: var(--tds-white);
-  --tds-popover-menu-background: var(--tds-grey-800);
+  --tds-popover-menu-background: var(--tds-grey-850);
   --tds-popover-menu-background-hover: var(--tds-grey-700);
   --tds-popover-menu-divider-color: var(--tds-grey-500);
   --tds-popover-menu-divider-disabled-color: var(--tds-grey-500);


### PR DESCRIPTION
## **Describe pull-request**  
When working with popover-canvas, I noticed that when not setting the mode variant of the popover-menu, it used the background color for secondary mode variant. This PR changes it to use the primary mode variant background color.

## **Issue Linking:**  
None

## **How to test**  
Nothing to test

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
None
