### PR TITLE
fix(link): font and hover styling

### DIFF
--- a/packages/core/.storybook/preview.css
+++ b/packages/core/.storybook/preview.css
@@ -15,7 +15,7 @@ h5,
 h6,
 p,
 ul > li,
-a {
+a:not(tds-link *) {
   font-family: 'Scania Sans', arial, helvetica, sans-serif;
 }
 

--- a/packages/core/src/components/link/link.scss
+++ b/packages/core/src/components/link/link.scss
@@ -9,6 +9,25 @@
     text-decoration: underline;
   }
 
+  ::slotted(*:hover) {
+    color: var(--tds-link-hover);
+    text-decoration: none;
+  }
+
+  .no-underline {
+    ::slotted(*) {
+      text-decoration: none;
+    }
+  }
+
+  .no-underline {
+    ::slotted(*:hover) {
+      color: var(--tds-link-hover);
+      text-decoration: underline;
+      text-decoration-color: var(--tds-link-hover);
+    }
+  }
+
   ::slotted(*:focus-visible) {
     color: var(--tds-link-focus);
     text-decoration: none;
@@ -20,12 +39,6 @@
     color: var(--tds-link);
     text-decoration: underline;
     text-decoration-color: var(--tds-link);
-  }
-
-  ::slotted(*:hover) {
-    color: var(--tds-link-hover);
-    text-decoration: underline;
-    text-decoration-color: var(--tds-link-hover);
   }
 
   ::slotted(*:visited) {
@@ -40,20 +53,6 @@
     color: var(--tds-link-disabled);
     text-decoration-color: var(--tds-link-disabled);
     pointer-events: none;
-  }
-}
-
-.no-underline {
-  ::slotted(*) {
-    text-decoration: none;
-  }
-}
-
-.no-underline {
-  &:hover {
-    ::slotted(*) {
-      text-decoration: none;
-    }
   }
 }
 

--- a/packages/core/src/components/link/link.scss
+++ b/packages/core/src/components/link/link.scss
@@ -31,8 +31,7 @@
   ::slotted(*:focus-visible) {
     color: var(--tds-link-focus);
     text-decoration: none;
-    outline: 2px solid var(--tds-link-focus);
-    outline-offset: -2px;
+    box-shadow: 0 0 0 1px var(--tds-white), 0 0 0 3px var(--tds-link-focus);
   }
 
   ::slotted(*:active) {

--- a/packages/core/src/components/link/link.scss
+++ b/packages/core/src/components/link/link.scss
@@ -18,9 +18,6 @@
     ::slotted(*) {
       text-decoration: none;
     }
-  }
-
-  .no-underline {
     ::slotted(*:hover) {
       color: var(--tds-link-hover);
       text-decoration: underline;


### PR DESCRIPTION
## **Describe pull-request**  
This PR fixes the hover styling so that if the link has an underline it disappears and if it doesn't have one it appears. Also updated the storybook file preview.css to not override the styling in tds-link components to be able to set the font where the link is used.

## **Issue Linking:**  
- **Jira:** [CDEP-1213](https://jira.scania.com/browse/CDEP-1213)

## **How to test** 
1. Go to https://pr-1473.d3fazya28914g3.amplifyapp.com/?path=/story/components-link--standalone-link
2. Inspect and verify that the standalone link has the Scania Sans Semi Condensed font
3. Toggle the underline setting and verify that, when hovering, when there isn't an underline it appears and when there is one it disappears

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
None

## **Additional context**  
None
