### PR TITLE
chore: update to codeowners 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add all team members as default reviewers for all files
-* @ckrook @theJohnnyMe @EmelieLitwin @nathalielindqvist @Lunkan89 @timrombergjakobsson @max-umain @augustinescania @patrik-nyfeldt @NordbergAnna
+* @scania-digital-design-system/developers


### PR DESCRIPTION
## **Description of PR**  
Found this feature when researching the `CODEOWNERS` file, could be quite handy when people are joining and leaving the team. Just make sure they have proper access to the group of reviewers (in this case, the `@scania-digital-design-system/developers` group). 

Found it here:
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

_*First and foremost*_ — let me know if you think this is a good idea or not, and we can take it from there! 🤞 

---

## **Issue Linking:**  
- **No issue:** See description above!

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to the file in the branch
2. Check that the file is marked as verified and valid
3. Open a draft PR to confirm that the team is added as reviewers