### PR TITLE
fix(tl-checkbox): show focus ring when checked

### DIFF
--- a/packages/core/src/tegel-light/components/tl-checkbox/tl-checkbox.scss
+++ b/packages/core/src/tegel-light/components/tl-checkbox/tl-checkbox.scss
@@ -54,7 +54,7 @@
     background-color: var(--checkbox-border-hover);
   }
 
-  &:focus::before {
+  &:focus-visible::before {
     background-color: var(--checkbox-border-focus);
     transition: opacity 0.2s ease-in-out;
   }
@@ -97,7 +97,7 @@
       background-position: center;
     }
 
-    &:focus::before {
+    &:focus-visible::before {
       width: 22px;
       height: 22px;
       left: 1px;


### PR DESCRIPTION
## **Describe pull-request**  
Resize ::before pseudo element when checked to show focus ring.

## **Issue Linking:**  
- **Jira:** [CDEP-1655](https://jira.scania.com/browse/CDEP-1665)

## **How to test**  
1. Go to preview link below
2. Check in Tegel Light -> Checkbox -> Default
3. Focus the input element both when the element is unchecked and checked
4. The focus ring should be visible on both occasions.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
