### PR TITLE
fix: removed rowsPerPageValue state

### DIFF
--- a/packages/core/src/components/table/table-footer/table-footer.tsx
+++ b/packages/core/src/components/table/table-footer/table-footer.tsx
@@ -10,6 +10,7 @@ import {
   Element,
 } from '@stencil/core';
 import { InternalTdsTablePropChange } from '../table/table';
+import { TdsDropdownCustomEvent } from '../../../components';
 
 const relevantTableProps: InternalTdsTablePropChange['changed'] = [
   'compactDesign',
@@ -19,6 +20,8 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
 function removeShakeAnimation(e: AnimationEvent & { target: HTMLElement }) {
   e.target.classList.remove('tds-table__page-selector-input--shake');
 }
+
+type RowsPerPageEvent = TdsDropdownCustomEvent<{ name: string; value: string | null }>;
 
 @Component({
   tag: 'tds-table-footer',
@@ -55,8 +58,6 @@ export class TdsTableFooter {
   @State() tableId: string = '';
 
   @State() horizontalScrollWidth: string = null;
-
-  @State() rowsPerPageValue: number = this.rowsPerPageValues[0];
 
   @Element() host: HTMLElement;
 
@@ -115,19 +116,18 @@ export class TdsTableFooter {
     }
   }
 
-  private emitTdsPagination = () => {
-    if (this.rowsperpage) {
-      this.tdsPagination.emit({
-        tableId: this.tableId,
-        paginationValue: Number(this.paginationValue),
-        rowsPerPage: this.rowsPerPageValue,
-      });
-    } else {
-      this.tdsPagination.emit({
-        tableId: this.tableId,
-        paginationValue: Number(this.paginationValue),
-      });
+  private emitTdsPagination = (event?: RowsPerPageEvent) => {
+    let rowsPerPage;
+
+    if (event?.detail?.value) {
+      rowsPerPage = parseInt(event.detail.value);
     }
+
+    this.tdsPagination.emit({
+      tableId: this.tableId,
+      paginationValue: Number(this.paginationValue),
+      rowsPerPage,
+    });
   };
 
   /* Function to store last valid input */
@@ -184,12 +184,11 @@ export class TdsTableFooter {
     this.storeLastCorrectValue(this.paginationValue);
   }
 
-  private rowsPerPageChange(event) {
-    this.rowsPerPageValue = parseInt(event.detail.value);
+  private rowsPerPageChange(event: RowsPerPageEvent) {
     if (this.paginationValue > this.pages) {
       this.paginationValue = this.pages;
     }
-    this.emitTdsPagination();
+    this.emitTdsPagination(event);
   }
 
   private getStyles(): Record<string, string> {


### PR DESCRIPTION
## **Describe pull-request**  
[One of our users](https://teams.microsoft.com/l/message/19:5e33f67fe502441f914fbcdc6e2548f5@thread.skype/1760967472923?tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac&groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&parentMessageId=1760967472923&teamName=Tegel%20Design%20System&channelName=Development%20support%20-%20Tegel&createdTime=1760967472923) are having issue with our table footer component where the rowsPerPage defaults back to 10 since we are not watching the prop and updating it. This PR adress that.

## **Issue Linking:**  
- **Jira:** [CDEP-1737](https://jira.scania.com/browse/CDEP-1737)

## **How to test**  
1. Go to [demo page where the beta-release is installed](https://pr-265.d2vh2lmnzgzrkl.amplifyapp.com/about).
2. Make sure that the table does not default back to 10 when changing page.
3. Review implemented code.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
