### PR TITLE
fix(tl-accordion): added disabled styling to chevron icon

### DIFF
--- a/packages/core/src/tegel-light/components/tl-accordion/_tl-accordion-item.scss
+++ b/packages/core/src/tegel-light/components/tl-accordion/_tl-accordion-item.scss
@@ -97,8 +97,10 @@
   transition: transform 0.15s ease-in-out;
   color: var(--accordion-icon);
 
-  .tl-accordion__item--disabled & {
-    color: var(--accordion-icon-disabled);
+  .tl-icon {
+    .tl-accordion__item--disabled & {
+      color: var(--accordion-text-disabled);
+    }
   }
 
   .tl-accordion__item--expanded & {


### PR DESCRIPTION
## **Describe pull-request**  
The issues is that the chevron icons on tl-accordion didn't have disable color when disable=true. This small PR adds the disabled color to the chevron icons.

## **Issue Linking:**  
[CDEP-1734](https://jira.scania.com/browse/CDEP-1734)

## **How to test**  
1. Go to preview link and open up tl-accordion in tegel lite
2. Set disabled to true
3. Observe that the chevron icons get the disabled color.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
