### PR TITLE
fix(message): added overflow-wrap to handle long words

### DIFF
--- a/packages/core/src/components/message/message.scss
+++ b/packages/core/src/components/message/message.scss
@@ -68,7 +68,7 @@
     flex-direction: column;
     gap: 4px;
     color: var(--foreground-text-strong);
-    padding: 2px 24px 0 0;
+    padding: 2px 24px 2px 0;
     overflow-wrap: anywhere;
 
     .header {


### PR DESCRIPTION
## **Describe pull-request**  
When a word is to long inside a message with a set max-width. The word would normally grow outside the message component. This PR will fix that by adding a overflow-wrap.
Also added some the missing padding to the right to add up to 40 px (was 16px before).

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to [message component in preview link](https://pr-1517.d3fazya28914g3.amplifyapp.com/?path=/story/components-message--default)
2. Make sure that the tecxt content inside the component does not break the actual component

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
<img width="2002" height="591" alt="Frame 1" src="https://github.com/user-attachments/assets/8122055f-eec8-4e8b-845a-1b6b9796700c" />
