### PR TITLE
fix(ci): dry run option true as default

### DIFF
--- a/.github/workflows/holy-grail.yml
+++ b/.github/workflows/holy-grail.yml
@@ -33,7 +33,7 @@ on:
         description: 'Dry version'
         required: false
         type: boolean
-        default: false
+        default: true
 
   schedule:
     - cron: '0 3 * * 1-5' #3AM every weekday


### PR DESCRIPTION
## **Describe pull-request**  
You now should have to unselect `try version` when running holy-grail action to run a live version.

