### PR TITLE
feat(holy-grail): added new branch flag

### DIFF
--- a/.github/workflows/holy-grail.yml
+++ b/.github/workflows/holy-grail.yml
@@ -4,6 +4,12 @@ name: Holy Grail
 on:
   workflow_dispatch:
     inputs:
+      branch:
+        description: 'Branch to create release from'
+        required: true
+        default: 'develop'
+        type: string
+
       version:
         description: 'Release type'
         required: true
@@ -51,7 +57,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: develop
+          ref: ${{ github.event.inputs.branch || 'develop' }}
 
       - name: Set Tegel user
         run: git config --global user.name "Tegel - Scania" && git config --global user.email "tegel.design.system@gmail.com"


### PR DESCRIPTION
## **Describe pull-request**  
Previously, running the Holy Grail workflow as a dry run to validate a remote PR was not reliable.

The reason is that the create-release-branch job always checked out code from the develop branch:

```
with:
  ref: develop
```

This meant that even if you triggered the workflow manually intending to test a specific PR branch, the workflow would still use the state of develop when creating the release branch. As a result, the dry run did not actually reflect the changes in the PR you wanted to verify.

With this change, we introduce a configurable branch input and use it as the reference for the checkout step. This allows the workflow to:

Use develop by default (so scheduled runs still behave as before), and
When triggered manually, target any branch (e.g. a feature or PR branch) so that the created release branch and subsequent steps are based on the correct code.

This makes manual Holy Grail dry runs reliable for testing remote PRs.


JIRA: [CDEP-1804](https://jira.scania.com/browse/CDEP-1804)
