### PR TITLE
chore: suppressed no-unused-vars for h import need to build jsx

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -62,7 +62,7 @@
     "no-useless-escape": "warn",
     "no-await-in-loop": "warn",
     "curly": "warn",
-    "no-unused-vars": "warn",
+    "no-unused-vars": ["warn", { "varsIgnorePattern": "^h$" }],
     "no-nested-ternary": "warn",
     "import/order": "warn",
     "no-restricted-syntax": "warn", // TODO: check this - disables for-in related error
@@ -81,6 +81,7 @@
     "function-paren-newline": "off",
     "dot-notation": "off",
     "no-plusplus": "off",
-    "no-param-reassign": ["error", { "props": false }]
+    "no-param-reassign": ["error", { "props": false }],
+    "@typescript-eslint/no-unused-vars": ["warn", { "varsIgnorePattern": "^h$" }]
   }
 }


### PR DESCRIPTION
## **Describe pull-request**  
Adding eslint rules to suppress warning & error for `import { h } from '@stencil/core';` that is used for building jsx.

When running `npm run lint` these should not be present anymore:

<img width="528" height="29" alt="Screenshot 2025-12-03 at 10 44 05" src="https://github.com/user-attachments/assets/fa7ae2d1-3d08-4b6b-8dfe-c873abf48ab8" />

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. `git fetch`
2. `git checkout build/suppress-no-unused-vars-h`
3.  `npm run build:all && npm run lint`
