### PR TITLE
fix: stepper typography and icon issue

### DIFF
--- a/packages/core/src/tegel-light/components/tl-stepper/tl-step.scss
+++ b/packages/core/src/tegel-light/components/tl-stepper/tl-step.scss
@@ -1,6 +1,7 @@
 @import '../../../mixins/box-sizing';
 @import '../../../../../../typography/utilities/typography-utility';
 @import './tl-stepper-vars';
+@import '../tl-icon/tl-icon';
 
 @mixin divider {
   content: ' ';
@@ -202,7 +203,7 @@
 .tl-stepper__node {
   display: flex;
   align-items: center;
-  justify-content: space-around;
+  justify-content: center;
   border-radius: 100px;
   border-width: 1px;
   border-style: solid;
@@ -232,11 +233,18 @@
   .tl-stepper__content--lg & {
     height: 30px;
     min-width: 30px;
+    font-size: 0.875rem;
+    font-weight: normal;
+    line-height: 1;
   }
 
   .tl-stepper__content--sm & {
     height: 24px;
     min-width: 24px;
+    font-size: 0.875rem;
+    font-weight: normal;
+    line-height: 1;
+    padding-top: 1px;
   }
 }
 
@@ -259,7 +267,7 @@
   text-align: center;
 
   &--lg {
-    @include detail-01;
+    @include detail-05;
   }
 
   &--sm {

--- a/packages/core/src/tegel-light/components/tl-text-field/tl-text-field.scss
+++ b/packages/core/src/tegel-light/components/tl-text-field/tl-text-field.scss
@@ -456,10 +456,12 @@
   }
 }
 
-.tl-icon {
-  background-color: var(--text-field-affix);
+.tl-text-field {
+  .tl-icon {
+    background-color: var(--text-field-affix);
+  }
 
-  .tl-text-field--disabled & {
+  &--disabled .tl-icon {
     background-color: var(--text-field-affix-disabled);
   }
 }

--- a/packages/tegel-light/package.json
+++ b/packages/tegel-light/package.json
@@ -57,7 +57,8 @@
     "./tl-popover-canvas.css": "./dist/tl-popover-canvas.css",
     "./tl-popover-menu.css": "./dist/tl-popover-menu.css",
     "./tl-side-menu.css": "./dist/tl-side-menu.css",
-    "./tl-footer.css": "./dist/tl-footer.css"
+    "./tl-footer.css": "./dist/tl-footer.css",
+    "./tl-slider.css": "./dist/tl-slider.css"
   },
   "files": [
     "dist/"


### PR DESCRIPTION
## **Describe pull-request**  
Updated typography and tl-icon fix

## **Issue Linking:**  
[CDEP-1815](https://jira.scania.com/browse/CDEP-1815)

## **How to test**  
1. Go to the preview link and navigate to tegel lite -> stepper
2. Check in all storybook controls
3. Check dark/light mode and Scania/Traton theme 

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [x] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
