### PR TITLE
ci: remove Angular as release target

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -29,15 +29,6 @@ on:
           - 'true'
           - 'false'
 
-      includeAngular:
-        description: 'Include Angular package?'
-        required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
-
       includeReact:
         description: 'Include React package?'
         required: false
@@ -200,82 +191,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public --tag beta
-
-    outputs:
-      version: ${{ steps.set-version.outputs.PACKAGE_VERSION }}
-      version_exists: ${{ env.VERSION_EXISTS }}
-
-  beta-release-angular:
-    if: ${{ github.event.inputs.includeAngular == 'true' }}
-    needs: beta-release-core
-    runs-on: ubuntu-latest
-    env:
-      WORKING_DIRECTORY: packages/angular
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.branch }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ inputs.nodeVersion }}
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Configure Git user
-        run: |
-          git config --global user.name "Tegel - Scania"
-          git config --global user.email "tegel.design.system@gmail.com"
-
-      - name: Install root dependencies
-        run: npm install
-
-      - name: Install Core dependencies
-        working-directory: packages/core
-        run: npm install
-
-      - name: Update Angular package version and dependency
-        id: set-version
-        working-directory: packages/angular
-        run: |
-          echo "Updating Angular package version and dependency"
-          current_version=$(jq -r '.version' package.json | sed 's/-[a-zA-Z0-9.\-]*$//')
-          beta_version_suffix="${{ inputs.betaVersionSuffix }}"
-          new_version="${current_version}-${beta_version_suffix}"
-          echo "Setting new version: $new_version"
-          jq ".version = \"$new_version\" | .dependencies[\"@scania/tegel\"] = \"${{ needs.beta-release-core.outputs.version }}\"" package.json > package.tmp.json
-          mv package.tmp.json package.json
-          echo "PACKAGE_VERSION=$new_version" >> $GITHUB_OUTPUT
-
-      - name: Install Angular dependencies
-        working-directory: packages/angular
-        run: npm install
-
-      - name: Build Angular package
-        run: npm run build:angular
-
-      - name: Check if Angular version already exists
-        id: check-version
-        working-directory: packages/angular
-        run: |
-          PACKAGE_NAME=$(jq -r '.name' package.json)
-          PACKAGE_VERSION=${{ steps.set-version.outputs.PACKAGE_VERSION }}
-          if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version > /dev/null 2>&1; then
-            echo "Version $PACKAGE_VERSION already exists. Skipping publish."
-            echo "VERSION_EXISTS=true" >> $GITHUB_ENV
-          else
-            echo "VERSION_EXISTS=false" >> $GITHUB_ENV
-          fi
-          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Publish Angular package to NPM
-        if: env.VERSION_EXISTS != 'true'
-        working-directory: packages/angular
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --tag beta
 
     outputs:
       version: ${{ steps.set-version.outputs.PACKAGE_VERSION }}

--- a/.github/workflows/holy-grail.yml
+++ b/.github/workflows/holy-grail.yml
@@ -67,11 +67,6 @@ jobs:
         working-directory: packages/core
         run: npm version ${{ github.event.inputs.version || env.VERSION }} --no-git-tag-version
 
-      - name: Angular - Bump version
-        id: angular-version
-        working-directory: packages/angular
-        run: npm version ${{ github.event.inputs.version || env.VERSION }} --no-git-tag-version
-
       - name: Angular 17 - Bump version
         id: angular-17-version
         working-directory: packages/angular-17/projects/components
@@ -223,12 +218,6 @@ jobs:
           path: core-tarball
           extract: true
 
-      - name: Angular wrapper – install Core tarball (dry run)
-        if: github.event.inputs.dryVersion == 'true' || github.event_name == 'schedule'
-        working-directory: packages/angular
-        run: |
-          npm install ../../core-tarball/*.tgz
-
       - name: Angular 17 wrapper – install Core tarball (dry run)
         if: github.event.inputs.dryVersion == 'true' || github.event_name == 'schedule'
         working-directory: packages/angular-17
@@ -246,11 +235,6 @@ jobs:
         working-directory: packages/react
         run: |
           npm install ../../core-tarball/*.tgz
-
-      - name: Angular - Install latest tegel package
-        if: github.event.inputs.dryVersion != 'true' && github.event_name != 'schedule'
-        working-directory: packages/angular
-        run: npm install @scania/tegel@${{ needs.create-release-branch.outputs.version }}
 
       - name: Angular 17 - Install latest tegel package
         if: github.event.inputs.dryVersion != 'true' && github.event_name != 'schedule'
@@ -276,46 +260,6 @@ jobs:
           else
             echo "No changes to commit"
           fi
-
-  #RELEASE ANGULAR
-  release-angular:
-    needs: [create-release-branch, release-core, bump-wrappers-to-new-version]
-    runs-on: ubuntu-latest
-    env:
-      WORKING_DIRECTORY: packages/angular
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.create-release-branch.outputs.branch }}
-          fetch-depth: 1 # Fetch just the release branch
-
-      - name: Set up node
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ github.event.inputs.nodeVersion || env.NODE_VERSION }}
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Install dependencies in root
-        run: npm ci
-
-      - name: Core - Install
-        working-directory: packages/core
-        run: npm ci
-
-      - name: Angular - Install
-        working-directory: packages/angular
-        run: npm ci
-
-      - name: Angular - Run build
-        run: npm run build:angular
-
-      - name: Angular - Publish
-        if: github.event.inputs.dryVersion != 'true' && github.event_name != 'schedule'
-        working-directory: packages/angular
-        run: npm publish --tag ${{ github.event.inputs.tags }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   #RELEASE ANGULAR 17
   release-angular-17:
@@ -408,9 +352,9 @@ jobs:
 
   #ON FAILURE
   on-failure:
-    needs: [create-release-branch, release-core, release-angular, release-angular-17, release-react]
+    needs: [create-release-branch, release-core, release-angular-17, release-react]
     runs-on: ubuntu-latest
-    if: github.event.inputs.dryVersion != 'true' && github.event_name != 'schedule' && (needs.create-release-branch.result == 'failure' || needs.release-core.result == 'failure' || needs.release-angular.result == 'failure' || needs.release-angular-17.result == 'failure' || needs.release-react.result == 'failure')
+    if: github.event.inputs.dryVersion != 'true' && github.event_name != 'schedule' && (needs.create-release-branch.result == 'failure' || needs.release-core.result == 'failure' || needs.release-angular-17.result == 'failure' || needs.release-react.result == 'failure')
     steps:
       - name: Download version
         uses: actions/download-artifact@v4
@@ -423,9 +367,9 @@ jobs:
 
   #MERGE RELEASE BRANCH TO DEVELOP
   merge-release-branch-into-develop:
-    needs: [create-release-branch, release-core, release-angular, release-angular-17, release-react]
+    needs: [create-release-branch, release-core, release-angular-17, release-react]
     runs-on: ubuntu-latest
-    if: github.event.inputs.dryVersion != 'true' && github.event_name != 'schedule' && (needs.create-release-branch.result == 'success' && needs.release-core.result == 'success' && needs.release-angular.result == 'success' && needs.release-angular-17.result == 'success' && needs.release-react.result == 'success')
+    if: github.event.inputs.dryVersion != 'true' && github.event_name != 'schedule' && (needs.create-release-branch.result == 'success' && needs.release-core.result == 'success' && needs.release-angular-17.result == 'success' && needs.release-react.result == 'success')
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -523,7 +467,6 @@ jobs:
         create-release-branch,
         release-core,
         bump-wrappers-to-new-version,
-        release-angular,
         release-angular-17,
         release-react,
       ]
@@ -539,7 +482,6 @@ jobs:
           if [ "${{ needs.create-release-branch.result }}" == "failure" ] || \
              [ "${{ needs.release-core.result }}" == "failure" ] || \
              [ "${{ needs.bump-wrappers-to-new-version.result }}" == "failure" ] || \
-             [ "${{ needs.release-angular.result }}" == "failure" ] || \
              [ "${{ needs.release-angular-17.result }}" == "failure" ] || \
              [ "${{ needs.release-react.result }}" == "failure" ]; then
             status="🔴 *Tegel Release ${version}* failed"


### PR DESCRIPTION
## **Describe pull-request**  
Removed Angular release in actions

## **How to test**  
You can run actions from this branch by selecting `ci/modly-grail` in **Use workflow from**.
In **Beta-release** action we can confirm that Angular output no longer is present to confirm that we are running from this branch.

<img width="356" height="595" alt="Screenshot 2025-12-04 at 10 00 11" src="https://github.com/user-attachments/assets/5cf6fb2c-6c4c-498e-abb1-923e6897c849" />

Angular not in **Holy-grail** flow anymore:
https://github.com/scania-digital-design-system/tegel/actions/runs/19923248635 

