### PR TITLE
fix(tl-message): fix margin for icon in minimal layout

### DIFF
--- a/packages/core/src/tegel-light/components/tl-message/tl-message.scss
+++ b/packages/core/src/tegel-light/components/tl-message/tl-message.scss
@@ -80,6 +80,10 @@
     border: none;
     padding: 0;
     background-color: transparent;
+
+    &::before {
+      margin-right: 8px;
+    }
   }
 }
 


### PR DESCRIPTION
## **Describe pull-request**  
This is a PR to update the padding of the icon in minimal layout. It should now be 8px acoording to figma.

## **How to test**  
1. Go to preview link and navigate to tegel lite -> message 
2. Set minimal to true
3. Inspect gap between icon and text, it should now be 8px in minimal (16px when minimal = false)

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
