### PR TITLE
fix(tl-side-menu): close-button to close

### DIFF
--- a/packages/core/src/tegel-light/components/tl-side-menu/_tl-side-menu-vars.scss
+++ b/packages/core/src/tegel-light/components/tl-side-menu/_tl-side-menu-vars.scss
@@ -19,7 +19,7 @@
 .scania {
   .tl-side-menu {
     --side-menu-bottom-menu-border-top-collapsed: 1px solid var(--color-foreground-border-discrete);
-    --side-menu-close-wrapper-height: auto;
+    --side-menu-close-button-wrapper-height: auto;
     --side-menu-collapsed-button-size: 68px;
     --side-menu-collapsed-dropdown-background-active: var(--color-background-surface-100);
     --side-menu-collapsed-dropdown-background-hover: var(--color-background-layer-01);
@@ -37,7 +37,7 @@
 .traton {
   .tl-side-menu {
     --side-menu-bottom-menu-border-top-collapsed: none;
-    --side-menu-close-wrapper-height: 64px;
+    --side-menu-close-button-wrapper-height: 64px;
     --side-menu-collapsed-button-size: 72px;
     --side-menu-collapsed-dropdown-background-active: var(--color-background-surface-200);
     --side-menu-collapsed-dropdown-background-hover: var(--color-background-surface-100);

--- a/packages/core/src/tegel-light/components/tl-side-menu/tl-side-menu.scss
+++ b/packages/core/src/tegel-light/components/tl-side-menu/tl-side-menu.scss
@@ -54,7 +54,7 @@
 .tl-side-menu__close {
   margin: 0 var(--component-side-menu-space-top-level-left);
   border-bottom: 1px solid var(--side-menu-bottom-menu-border-top);
-  height: var(--side-menu-close-wrapper-height);
+  height: var(--side-menu-close-button-wrapper-height);
   opacity: 0;
 
   .tl-side-menu__wrapper--open & {


### PR DESCRIPTION
## **Describe pull-request**  
Changed class name from __close-button to __close in tl-side-menu to align with other components

## **Issue Linking:**  
[CDEP-1819](https://jira.scania.com/browse/CDEP-1819)

## **How to test**  
1. Go to preview link and check that close button work in side menu
2. Check naming in code

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

