### PR TITLE
fix(tl-button): change fullwidth modifier to full-width

### DIFF
--- a/packages/core/src/tegel-light/components/tl-button/tl-button.scss
+++ b/packages/core/src/tegel-light/components/tl-button/tl-button.scss
@@ -237,7 +237,7 @@
   }
 
   /* Full width */
-  &--fullwidth {
+  &--full-width {
     width: 100%;
   }
 }

--- a/packages/core/src/tegel-light/components/tl-button/tl-button.stories.tsx
+++ b/packages/core/src/tegel-light/components/tl-button/tl-button.stories.tsx
@@ -13,7 +13,7 @@ export default {
       control: { type: 'select' },
       options: ['xs', 'sm', 'md', 'lg'],
     },
-    fullwidth: {
+    fullWidth: {
       control: { type: 'boolean' },
     },
     disabled: {
@@ -37,14 +37,14 @@ export default {
   args: {
     variant: 'primary',
     size: 'md',
-    fullwidth: false,
+    fullWidth: false,
     disabled: false,
     onlyIcon: false,
     icon: 'none',
   },
 };
 
-const Template = ({ variant, size, fullwidth, disabled, onlyIcon, icon }) => {
+const Template = ({ variant, size, fullWidth, disabled, onlyIcon, icon }) => {
   // Disable icon functionality for xs size
   const isXs = size === 'xs';
   const iconClass = !isXs && icon !== 'none' ? `tl-button--icon` : '';
@@ -64,7 +64,7 @@ const Template = ({ variant, size, fullwidth, disabled, onlyIcon, icon }) => {
       "@scania/tegel-light/tl-icon.css";
     -->
       <button class="tl-button ${onlyIconClass} tl-button--${variant} tl-button--${size} 
-        ${fullwidth ? 'tl-button--fullwidth' : ''} 
+        ${fullWidth ? 'tl-button--full-width' : ''} 
         ${disabled ? 'tl-button--disabled' : ''}
         ${iconClass}"
         ${disabled ? 'disabled' : ''}${ariaLabel}>


### PR DESCRIPTION
## **Describe pull-request**  
The tl-button component uses the modifier "fullwidth" to control the width. To align with the use of "no-min-width" and correct english grammar it should be changed.

## **Issue Linking:**  
 [CDEP-1820](https://jira.scania.com/browse/CDEP-1820)


## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to preview link and check button fullwidth
2. Check code for class name changes

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
