### PR TITLE
fix(tl-table): implement tl-dropdown in tl-table pagination

### DIFF
--- a/packages/core/src/tegel-light/components/tl-table/_footer.scss
+++ b/packages/core/src/tegel-light/components/tl-table/_footer.scss
@@ -12,6 +12,17 @@
   }
 }
 
+.tl-table__footer .tl-dropdown__text {
+  max-width: calc(100% - 20px);
+}
+
+.tl-table__footer
+.tl-dropdown--sm
+:is(.tl-dropdown__button, .tl-dropdown__select, .tl-dropdown__input),
+.tl-table__footer .tl-dropdown__option {
+  height: 29px;
+}
+
 .tl-table__footer-row {
   display: table-row;
   border-bottom: 1px solid var(--table-divider);


### PR DESCRIPTION
## **Describe pull-request**  
This PR is a fix to implement the tegel lite dropdown in the table pagination. 

## **Issue Linking:** 
[CDEP-1739](https://jira.scania.com/browse/CDEP-1739)

## **How to test**  
1. Go to the preview link and navigate to tegel lite -> table -> pagination
2. Check the dropdown in the footer, the dropdown is implemented with tegel lite and therefore might not look exactly like the web components dropdown, but this is intentional. We will go over this design in our design reviewing if needed change.
3. Check dark/light mode
4. Check Scania/Traton theme

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
