### PR TITLE
fix(tl-card): remove unused top-header element

### DIFF
--- a/packages/core/src/tegel-light/components/tl-card/tl-card.scss
+++ b/packages/core/src/tegel-light/components/tl-card/tl-card.scss
@@ -61,16 +61,6 @@
   margin-right: 16px;
 }
 
-.tl-card__top-header {
-  padding-left: 16px;
-  display: flex;
-  flex-direction: column;
-
-  &--no-header-img {
-    padding-left: 0;
-  }
-}
-
 .tl-card__headings {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## **Describe pull-request**  
Removed unused SCSS element `.tl-card__top-header` and its modifier `.tl-card__top-header--no-header-img` from the Card component. These CSS rules were defined but never used in the component's story.

## **Issue Linking:**  
- **Jira:** [CDEP-1822](https://jira.scania.com/browse/CDEP-1822)

## **How to test**  
1. Go to preview file → Tegel Light (CSS) → Card
2. Check all Card variations (with/without thumbnail, different image placements, clickable, expandable, etc.)
3. Verify that all cards render correctly without visual changes

## **Checklist before submission**
- [ ] Designer approves new design (if applicable) - N/A, no visual changes
- [ ] No accessibility violations in Storybook - N/A
- [ ] I have added unit tests for my changes (if applicable) - N/A
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable) - N/A
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable) - N/A
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) - Visual inspection recommended
- [ ] Keyboard operability - N/A
- [ ] Interactive elements have labels - N/A
- [x] Storybook controls - Verify all Card variations work
- [ ] Design/controls/props is aligned with other components - N/A
- [x] Dark/light mode and variants - Check both Scania and Traton modes
- [ ] Input fields – values should be displayed properly - N/A
- [ ] Events - N/A

## **Screenshots**  
No visual changes expected. This PR only removes unused CSS that was never applied to any elements.

## **Additional context**  
### Investigation findings:
- `.tl-card__top-header` defined in `tl-card.scss` (lines 64-71)
- `.tl-card__top-header--no-header-img` modifier also defined
- Neither class is used in `tl-card.stories.tsx` or any other component files
- No visual or functional impact from removal

### Files changed:
- `tl-card.scss` - Removed 10 lines of unused CSS
