### PR TITLE
fix(tl-card): remove unused stretch element

### DIFF
--- a/packages/core/src/tegel-light/components/tl-card/tl-card.scss
+++ b/packages/core/src/tegel-light/components/tl-card/tl-card.scss
@@ -143,13 +143,6 @@
   align-self: stretch;
 }
 
-.tl-card__stretch {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  inline-size: 100%;
-}
-
 .tl-icon {
   .tl-card--expandable .tl-card__body .tl-card__header & {
     transition: transform 160ms ease-in-out, opacity 120ms ease-in-out;


### PR DESCRIPTION
## **Describe pull-request**  
Removed unused SCSS element `.tl-card__stretch` from the Card component. The Card component has both a modifier `--stretch` and an element `__stretch` with the same name. The modifier has styling and is used in stories, while the element has styling but is never used anywhere in the codebase.

## **Issue Linking:**  
- **Jira:** [CDEP-1823](https://jira.scania.com/browse/CDEP-1823)

## **How to test**  
1. Go to Storybook → Tegel Light (CSS) → Card
2. Toggle the "Stretch card body" control
3. Verify that the stretch functionality works correctly (card should fill 100% height and width)
4. Check all Card variations to ensure no visual regressions
5. Run `npm run build:tegel-light` to ensure no build errors

## **Checklist before submission**
- [ ] Designer approves new design (if applicable) - N/A, no visual changes
- [ ] No accessibility violations in Storybook - N/A
- [ ] I have added unit tests for my changes (if applicable) - N/A
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable) - N/A
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable) - N/A
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) - Visual inspection recommended
- [ ] Keyboard operability - N/A
- [ ] Interactive elements have labels - N/A
- [x] Storybook controls - Verify "Stretch card body" toggle works
- [ ] Design/controls/props is aligned with other components - N/A
- [x] Dark/light mode and variants - Check both Scania and Traton modes
- [ ] Input fields – values should be displayed properly - N/A
- [ ] Events - N/A

## **Screenshots**  
No visual changes expected. The modifier `--stretch` remains functional.
