### PR TITLE
fix(tl-header): remove unused tl-link__icon rule

### DIFF
--- a/packages/core/src/tegel-light/components/tl-header/_item.scss
+++ b/packages/core/src/tegel-light/components/tl-header/_item.scss
@@ -45,13 +45,3 @@
     border-bottom-color: var(--header-nav-item-border-pressed);
   }
 }
-
-// Modifier styles in affected elements
-.tl-link__icon {
-  .tl-header__item-wrapper & {
-    position: relative;
-    margin-left: -6px;
-    left: 3px;
-    transition: background 0.2s ease-in-out, color 0.2s ease-in-out;
-  }
-}


### PR DESCRIPTION
## **Describe pull-request**  
This PR removes unused CSS rule for `tl-link__icon` from the Header component's `_item.scss` file. The rule was defined to style link icons when used inside `tl-header__item-wrapper`, but there are no instances of this pattern being used in the codebase - header items use buttons or direct icons instead of the separate tl-link component.

## **Issue Linking:**  
- **Jira:** [CDEP-1827](https://jira.scania.com/browse/CDEP-1827)

## **How to test**  
1. Go to Storybook → Tegel Light (CSS) → Header
2. Check that header item icons still have correct positioning

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

