### PR TITLE
fix(tl-stepper): remove unused index-container rule 

### DIFF
--- a/packages/core/src/tegel-light/components/tl-stepper/tl-step.scss
+++ b/packages/core/src/tegel-light/components/tl-stepper/tl-step.scss
@@ -240,13 +240,6 @@
   }
 }
 
-.tl-stepper__index-container {
-  .tl-stepper__content--sm & {
-    vertical-align: -webkit-baseline-middle;
-    vertical-align: -moz-middle-with-baseline;
-  }
-}
-
 .tl-icon {
   .tl-stepper__content--sm & {
     vertical-align: -webkit-baseline-middle;


### PR DESCRIPTION
## **Describe pull-request**  
This PR removes unused CSS rule for `tl-stepper__index-container` from the Stepper component's `tl-step.scss` file. The rule was defined to adjust vertical alignment for small stepper content, but there is no element with the class `tl-stepper__index-container` in the markup - stepper nodes display their index directly inside `tl-stepper__node` without a wrapper.

## **Issue Linking:**  
- **Jira:** [CDEP-1830](https://jira.scania.com/browse/CDEP-1830)

## **How to test**  
1. Go to Storybook → Tegel Light (CSS) → Stepper
2. Test all stepper variants (horizontal, vertical, small, large)
3. Test all step states (current, completed, upcoming, error)
4. Verify step numbers/icons display correctly with proper vertical alignment
5. Inspect elements in DevTools - confirm no `tl-stepper__index-container` elements exist

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
