### PR TITLE
fix(tl-toast): rename header-subheader to text element

### DIFF
--- a/packages/core/src/tegel-light/components/tl-toast/tl-toast.scss
+++ b/packages/core/src/tegel-light/components/tl-toast/tl-toast.scss
@@ -48,7 +48,7 @@
   word-break: break-word;
 }
 
-.tl-toast__header-subheader {
+.tl-toast__text {
   display: flex;
   flex-direction: column;
   gap: 4px;

--- a/packages/core/src/tegel-light/components/tl-toast/tl-toast.stories.tsx
+++ b/packages/core/src/tegel-light/components/tl-toast/tl-toast.stories.tsx
@@ -103,7 +103,7 @@ const Template = ({ variant, header, subheader, actions, hidden, closable }) => 
     <div class="tl-toast ${variantClass} ${hiddenClass}">
       ${iconElement}
       <div class="tl-toast__content">
-        <div class="tl-toast__header-subheader">
+        <div class="tl-toast__text">
           ${header ? `<div class="tl-toast__header">${header}</div>` : ''}
           ${subheader ? `<div class="tl-toast__subheader">${subheader}</div>` : ''}
         </div>


### PR DESCRIPTION
## **Describe pull-request**  
This PR aligns the Toast component structure with the Banner component by renaming the `tl-toast__header-subheader` element to `tl-toast__text`. This ensures consistent naming across similar components that display header and subheader content.

The element serves as a wrapper for the header and subheader elements, and now follows the same naming convention as Banner which uses `tl-banner__text` for the same purpose.

## **Issue Linking:**  
- **Jira:** [CDEP-1834](https://jira.scania.com/browse/CDEP-1834)

## **How to test**  
1. Go to preview → tl-toast
2. Test all toast variants (information, success, warning, error)
6. Compare structure with Banner component - should be aligned

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
