### PR TITLE
fix(tl-header): brand symbol rename

### DIFF
--- a/packages/core/src/tegel-light/components/tl-header/_brand.scss
+++ b/packages/core/src/tegel-light/components/tl-header/_brand.scss
@@ -1,7 +1,7 @@
 @use '../../../mixins/box-sizing' as *;
 @use './tl-header-vars' as *;
 
-.tl-header__brand-symbol {
+.tl-header__brand {
   display: block;
   width: var(--header-brand-item-width);
   height: 30px;

--- a/packages/core/src/tegel-light/components/tl-header/_item.scss
+++ b/packages/core/src/tegel-light/components/tl-header/_item.scss
@@ -18,7 +18,7 @@
   align-items: center;
   gap: 8px;
 
-  &:has(.tl-header__brand-symbol) {
+  &:has(.tl-header__brand) {
     padding: 0 19px;
   }
 

--- a/packages/core/src/tegel-light/components/tl-header/tl-header.scss
+++ b/packages/core/src/tegel-light/components/tl-header/tl-header.scss
@@ -8,7 +8,7 @@
 @use 'item' as *;
 @use 'dropdown' as *;
 @use 'title' as *;
-@use 'brand-symbol' as *;
+@use 'brand' as *;
 
 .tl-header {
   display: block;

--- a/packages/core/src/tegel-light/components/tl-header/tl-header.stories.tsx
+++ b/packages/core/src/tegel-light/components/tl-header/tl-header.stories.tsx
@@ -32,7 +32,7 @@ export default {
       if: { arg: 'includeDropdown', truthy: true },
     },
     includeUserProfile: { control: 'boolean', name: 'Include user profile' },
-    includeBrandSymbol: { control: 'boolean', name: 'Include brand symbol' },
+    includeBrand: { control: 'boolean', name: 'Include brand symbol' },
     isHamburgerPressed: {
       control: 'boolean',
       name: 'Hamburger pressed',
@@ -51,7 +51,7 @@ export default {
     isHamburgerSelected: false,
     includeBentoGrid: false,
     includeBentoList: false,
-    includeBrandSymbol: true,
+    includeBrand: true,
     includeDropdown: false,
     isDropdownOpen: false,
     isDropdownSelected: false,
@@ -67,7 +67,7 @@ const Template = ({
   includeHamburger,
   includeBentoGrid,
   includeBentoList,
-  includeBrandSymbol,
+  includeBrand,
   isHamburgerPressed,
   isHamburgerSelected,
   includeDropdown,
@@ -211,8 +211,8 @@ const Template = ({
       }
 
       ${
-        includeBrandSymbol
-          ? `<li class="tl-header__item"><a class="tl-header__item-wrapper"><div class="tl-header__brand-symbol"></div></a></li>`
+        includeBrand
+          ? `<li class="tl-header__item"><a class="tl-header__item-wrapper"><div class="tl-header__brand"></div></a></li>`
           : ''
       }
 

--- a/packages/core/src/tegel-light/components/tl-side-menu/tl-side-menu.stories.tsx
+++ b/packages/core/src/tegel-light/components/tl-side-menu/tl-side-menu.stories.tsx
@@ -130,7 +130,7 @@ const Template = ({ persistent, collapsible, collapsed }) => {
             <li class="tl-header__middle-spacer"></li>
             <li class="tl-header__item">
                <a class="tl-header__item-wrapper">
-                  <div class="tl-header__brand-symbol"></div>
+                  <div class="tl-header__brand"></div>
                </a>
             </li>
          </ul>

--- a/packages/tegel-light/package.json
+++ b/packages/tegel-light/package.json
@@ -33,7 +33,7 @@
     "./tl-chip.css": "./dist/tl-chip.css",
     "./tl-divider.css": "./dist/tl-divider.css",
     "./tl-dropdown.css": "./dist/tl-dropdown.css",
-    "./tl-header-brand-symbol.css": "./dist/tl-header-brand-symbol.css",
+    "./tl-header-brand.css": "./dist/tl-header-brand.css",
     "./tl-header-item.css": "./dist/tl-header-item.css",
     "./tl-header-title.css": "./dist/tl-header-title.css",
     "./tl-header.css": "./dist/tl-header.css",


### PR DESCRIPTION
## **Describe pull-request**  
Change naming of element __brand-symbol to __brand to align with Tegel Lite Footer element structure.

## **Issue Linking:**  
- **Jira:** Add ticket number after `CDEP-1829`: [CDEP-](https://jira.scania.com/browse/CDEP-1829)

## **How to test**  
1. Go to Tegel Lite -> Header component
2. Check that the brand symbol is visible and that the element is called "tl-header__brand" in the inspector tool.
3. Do the same in Side Menu component.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
