### PR TITLE
refactor(tl-tabs): align structure and naming across variants

### DIFF
--- a/packages/core/src/tegel-light/components/tl-tabs/tl-folder-tabs/_tl-folder-tabs-vars.scss
+++ b/packages/core/src/tegel-light/components/tl-tabs/tl-folder-tabs/_tl-folder-tabs-vars.scss
@@ -8,12 +8,11 @@
 .tl-folder-tabs__tab {
   --folder-tab-surface: var(--color-background-surface-200);
   --folder-tab-surface-selected: var(--color-background-layer-01);
-  --folder-tab-text: var(--color-foreground-text-soft);
   --folder-tab-surface-hover: var(--color-background-surface-300);
   --folder-tab-border-selected: var(--color-foreground-border-accent-focus);
-  --folder-tab-divider-text: var(--color-foreground-icon-discrete);
-  --folder-tab-item-text: var(--color-foreground-text-soft);
-  --folder-tab-item-text-disabled: var(--color-foreground-text-disabled);
+  --folder-tab-divider: var(--color-foreground-icon-discrete);
+  --folder-tab-text: var(--color-foreground-text-soft);
+  --folder-tab-text-disabled: var(--color-foreground-text-disabled);
 }
 
 .tl-folder-tabs--primary .tl-folder-tabs__tab {

--- a/packages/core/src/tegel-light/components/tl-tabs/tl-folder-tabs/tl-folder-tab.scss
+++ b/packages/core/src/tegel-light/components/tl-tabs/tl-folder-tabs/tl-folder-tab.scss
@@ -21,10 +21,10 @@
   border-left: 1px solid transparent;
   border-top: 2px solid var(--folder-tab-surface);
   background-color: var(--folder-tab-surface);
-  color: var(--folder-tab-item-text);
+  color: var(--folder-tab-text);
 
   & + .tl-folder-tabs__tab {
-    border-left-color: var(--folder-tab-divider-text);
+    border-left-color: var(--folder-tab-divider);
   }
 
   &:focus-visible {
@@ -57,7 +57,7 @@
   }
 
   &--disabled {
-    color: var(--folder-tab-item-text-disabled);
+    color: var(--folder-tab-text-disabled);
     cursor: not-allowed;
     user-select: none;
 

--- a/packages/core/src/tegel-light/components/tl-tabs/tl-inline-tabs/tl-inline-tab.scss
+++ b/packages/core/src/tegel-light/components/tl-tabs/tl-inline-tabs/tl-inline-tab.scss
@@ -2,15 +2,9 @@
 @use '../../../../../../../typography/mixins/type-styles' as *;
 
 .tl-inline-tabs__tab {
-  @include tds-box-sizing;
-
-  display: block;
-  position: relative;
-}
-
-.tl-inline-tabs__tab-item {
   all: unset;
   margin-right: 32px;
+  @include tds-box-sizing;
   @include headline-07;
 
   color: var(--inline-tabs-tab);

--- a/packages/core/src/tegel-light/components/tl-tabs/tl-inline-tabs/tl-inline-tabs.stories.tsx
+++ b/packages/core/src/tegel-light/components/tl-tabs/tl-inline-tabs/tl-inline-tabs.stories.tsx
@@ -54,17 +54,15 @@ const Template = ({ modeVariant, selectedIndex, leftPadding, showLeftButton, sho
       const isSelected = i === Number(selectedIndex) && !isDisabled;
 
       const buttonClasses = [
-        'tl-inline-tabs__tab-item',
-        isSelected ? 'tl-inline-tabs__tab-item--selected' : '',
-        isDisabled ? 'tl-inline-tabs__tab-item--disabled' : '',
+        'tl-inline-tabs__tab',
+        isSelected ? 'tl-inline-tabs__tab--selected' : '',
+        isDisabled ? 'tl-inline-tabs__tab--disabled' : '',
       ]
         .filter(Boolean)
         .join(' ');
 
       return `
-        <div class="tl-inline-tabs__tab">
-          <button class="${buttonClasses}">${label}</button>
-        </div>
+        <button class="${buttonClasses}">${label}</button>
       `;
     })
     .join('');
@@ -104,12 +102,12 @@ const Template = ({ modeVariant, selectedIndex, leftPadding, showLeftButton, sho
         const container = containers[containers.length - 1];
         if (!container) return;
 
-        const tabs = container.querySelectorAll('.tl-inline-tabs__tab-item');
+        const tabs = container.querySelectorAll('.tl-inline-tabs__tab');
         tabs.forEach(tab => {
           tab.addEventListener('click', () => {
-            if (tab.classList.contains('tl-inline-tabs__tab-item--disabled')) return;
-            tabs.forEach(t => t.classList.remove('tl-inline-tabs__tab-item--selected'));
-            tab.classList.add('tl-inline-tabs__tab-item--selected');
+            if (tab.classList.contains('tl-inline-tabs__tab--disabled')) return;
+            tabs.forEach(t => t.classList.remove('tl-inline-tabs__tab--selected'));
+            tab.classList.add('tl-inline-tabs__tab--selected');
           });
         });
       })();

--- a/packages/core/src/tegel-light/components/tl-tabs/tl-navigation-tabs/tl-navigation-tab.scss
+++ b/packages/core/src/tegel-light/components/tl-tabs/tl-navigation-tabs/tl-navigation-tab.scss
@@ -3,15 +3,9 @@
 @use './tl-navigation-tabs-vars' as *;
 
 .tl-navigation-tabs__tab {
-  @include tds-box-sizing;
-
-  display: block;
-  position: relative;
-}
-
-.tl-navigation-tabs__tab-item {
   all: unset;
   margin-right: 32px;
+  @include tds-box-sizing;
   @include headline-07;
 
   color: var(--navigation-tabs-tab);

--- a/packages/core/src/tegel-light/components/tl-tabs/tl-navigation-tabs/tl-navigation-tabs.stories.tsx
+++ b/packages/core/src/tegel-light/components/tl-tabs/tl-navigation-tabs/tl-navigation-tabs.stories.tsx
@@ -54,17 +54,15 @@ const Template = ({ modeVariant, selectedIndex, leftPadding, showLeftButton, sho
       const isSelected = i === Number(selectedIndex) && !isDisabled;
 
       const buttonClasses = [
-        'tl-navigation-tabs__tab-item',
-        isSelected ? 'tl-navigation-tabs__tab-item--selected' : '',
-        isDisabled ? 'tl-navigation-tabs__tab-item--disabled' : '',
+        'tl-navigation-tabs__tab',
+        isSelected ? 'tl-navigation-tabs__tab--selected' : '',
+        isDisabled ? 'tl-navigation-tabs__tab--disabled' : '',
       ]
         .filter(Boolean)
         .join(' ');
 
       return `
-        <div class="tl-navigation-tabs__tab">
-          <button class="${buttonClasses}">${label}</button>
-        </div>
+        <button class="${buttonClasses}">${label}</button>
       `;
     })
     .join('');
@@ -104,12 +102,12 @@ const Template = ({ modeVariant, selectedIndex, leftPadding, showLeftButton, sho
         const container = containers[containers.length - 1];
         if (!container) return;
 
-        const tabs = container.querySelectorAll('.tl-navigation-tabs__tab-item');
+        const tabs = container.querySelectorAll('.tl-navigation-tabs__tab');
         tabs.forEach(tab => {
           tab.addEventListener('click', () => {
-            if (tab.classList.contains('tl-navigation-tabs__tab-item--disabled')) return;
-            tabs.forEach(t => t.classList.remove('tl-navigation-tabs__tab-item--selected'));
-            tab.classList.add('tl-navigation-tabs__tab-item--selected');
+            if (tab.classList.contains('tl-navigation-tabs__tab--disabled')) return;
+            tabs.forEach(t => t.classList.remove('tl-navigation-tabs__tab--selected'));
+            tab.classList.add('tl-navigation-tabs__tab--selected');
           });
         });
       })();


### PR DESCRIPTION
## Describe pull-request

Aligns structure and naming across all tegel light tab variants (folder, inline, navigation) for better consistency.

Changes:
- Removed wrapper div from inline and navigation tabs
- Renamed __tab-item to __tab to match folder tabs
- Cleaned up folder tabs variable names

Breaking Changes:
- Markup: <button class="tl-inline-tabs__tab"> instead of <div><button class="__tab-item">
- CSS: __tab-item → __tab
- Variables: --folder-tab-item-text → --folder-tab-text (and similar)

## Issue Linking

Jira: [CDEP-1831](https://jira.scania.com/browse/CDEP-1831)

## How to test

1. Go to Storybook tabs section
2. Test folder, inline, and navigation tabs
3. Verify click interaction, disabled states, and focus states

## Checklist before submission

- [ ] Designer approves new design
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes
- [x] All existing tests pass
- [ ] I have updated the documentation
- [ ] Not breaking production behavior (BREAKING CHANGE)
- [ ] Behavior available in Storybook with documented descriptions
- [x] npm run build:all without errors

## Suggested test steps

- [ ] Browser testing
- [ ] Keyboard operability
- [ ] Interactive elements have labels
- [x] Storybook controls
- [x] Design/controls/props is aligned with other components
- [x] Dark/light mode and variants
- [ ] Events