### PR TITLE
fix(tl-divider): vertical mode not showing up

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-popover-menu/tl-popover-menu.scss
+++ b/packages/core/src/tegel-lite/components/tl-popover-menu/tl-popover-menu.scss
@@ -10,11 +10,6 @@
   padding: 16px 0;
 }
 
-.tl-popover-menu .tl-divider {
-  width: calc(100% - 12px);
-  margin: 6px;
-}
-
 .tl-popover-menu__item {
   @include detail-02;
 
@@ -97,5 +92,10 @@
   &--visible.tl-popover-menu--animation-fade {
     opacity: 1;
     transform: translateY(0);
+  }
+
+  .tl-divider {
+    width: calc(100% - 12px);
+    margin: 6px;
   }
 }


### PR DESCRIPTION
## **Describe pull-request**  
The divider doesn't show up/appear in vertical mode

Scoped the popover menu’s divider styling to .tl-popover-menu .tl-divider so it no longer overwrites the base divider width globally.

## **Issue Linking:**  
- **Jira:** [CDEP-1846](https://jira.scania.com/browse/CDEP-1846)

## **How to test**  
1. Open up the divider component in tegel lite
2. Set orientation to vertical and the divider should show up

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
