### PR TITLE
fix(beta-release): sonarcloud security issue

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -64,8 +64,8 @@ jobs:
         env:
           INPUT_BETA_VERSION_SUFFIX: ${{ inputs.betaVersionSuffix }}
         run: |
-          if ! echo "$INPUT_BETA_VERSION_SUFFIX" | grep -qE '^[a-zA-Z0-9.\-]{1,50}$'; then
-            echo "Error: betaVersionSuffix must contain only alphanumeric characters, dots, and hyphens, and be 1-50 characters long"
+          if ! printf '%s' "$INPUT_BETA_VERSION_SUFFIX" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9.\-]{0,20}$'; then
+            echo "Invalid betaVersionSuffix: $INPUT_BETA_VERSION_SUFFIX" >&2
             exit 1
           fi
           echo "BETA_VERSION_SUFFIX=$INPUT_BETA_VERSION_SUFFIX" >> $GITHUB_ENV
@@ -143,8 +143,8 @@ jobs:
         env:
           INPUT_BETA_VERSION_SUFFIX: ${{ inputs.betaVersionSuffix }}
         run: |
-          if ! echo "$INPUT_BETA_VERSION_SUFFIX" | grep -qE '^[a-zA-Z0-9.\-]{1,50}$'; then
-            echo "Error: betaVersionSuffix must contain only alphanumeric characters, dots, and hyphens, and be 1-50 characters long"
+          if ! printf '%s' "$INPUT_BETA_VERSION_SUFFIX" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9.\-]{0,20}$'; then
+            echo "Invalid betaVersionSuffix: $INPUT_BETA_VERSION_SUFFIX" >&2
             exit 1
           fi
           echo "BETA_VERSION_SUFFIX=$INPUT_BETA_VERSION_SUFFIX" >> $GITHUB_ENV
@@ -242,8 +242,8 @@ jobs:
         env:
           INPUT_BETA_VERSION_SUFFIX: ${{ inputs.betaVersionSuffix }}
         run: |
-          if ! echo "$INPUT_BETA_VERSION_SUFFIX" | grep -qE '^[a-zA-Z0-9.\-]{1,50}$'; then
-            echo "Error: betaVersionSuffix must contain only alphanumeric characters, dots, and hyphens, and be 1-50 characters long"
+          if ! printf '%s' "$INPUT_BETA_VERSION_SUFFIX" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9.\-]{0,20}$'; then
+            echo "Invalid betaVersionSuffix: $INPUT_BETA_VERSION_SUFFIX" >&2
             exit 1
           fi
           echo "BETA_VERSION_SUFFIX=$INPUT_BETA_VERSION_SUFFIX" >> $GITHUB_ENV


### PR DESCRIPTION
## **Describe pull-request**  
SonarCloud flagged a security issue(see screenshot below): “Change this workflow to not use user-controlled data directly in a run block.” The workflow previously interpolated the user-provided input betaVersionSuffix directly into shell commands, which is vulnerable to command injection and supply-chain compromise.

What was changed

- Introduced a dedicated validation step in all beta release jobs (core, Angular 17, React).
- User input betaVersionSuffix is now:
- Passed into the workflow via env (not interpolated directly in run: blocks)
- Strictly validated using a regex:
- Starts with an alphanumeric character
- Contains only [A–Z a–z 0–9 . -]
- The validated value is exported via $GITHUB_ENV as BETA_VERSION_SUFFIX.
- All version calculations now reference "$BETA_VERSION_SUFFIX" instead of ${{ inputs.betaVersionSuffix }}.

## **Issue Linking:**  
- **Jira:** [CDEP-1714](https://jira.scania.com/browse/CDEP-1714)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to...
2. Check in...
3. Run ...

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
<img width="971" height="214" alt="image" src="https://github.com/user-attachments/assets/f3e0352b-851c-44c6-bdd9-62ec58b54088" />



## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
