### PR TITLE
fix(tl-tooltip): move modifiers to main element

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-tooltip/tl-tooltip.scss
+++ b/packages/core/src/tegel-lite/components/tl-tooltip/tl-tooltip.scss
@@ -28,77 +28,77 @@
     pointer-events: auto;
   }
 
-  &--bottom {
+  .tl-tooltip--bottom & {
     top: calc(100% + var(--tl-tooltip-offset-distance, 8px));
     left: 50%;
     transform: translateX(-50%);
     border-radius: 4px;
   }
 
-  &--bottom-end {
+  .tl-tooltip--bottom-end & {
     top: calc(100% + var(--tl-tooltip-offset-distance, 8px));
     right: var(--tl-tooltip-offset-skidding, 0);
     border-radius: 4px 0 4px 4px;
   }
 
-  &--bottom-start {
+  .tl-tooltip--bottom-start & {
     top: calc(100% + var(--tl-tooltip-offset-distance, 8px));
     left: var(--tl-tooltip-offset-skidding, 0);
     border-radius: 0 4px 4px;
   }
 
-  &--left {
+  .tl-tooltip--left & {
     right: calc(100% + var(--tl-tooltip-offset-distance, 8px));
     top: 50%;
     transform: translateY(-50%);
     border-radius: 4px;
   }
 
-  &--left-end {
+  .tl-tooltip--left-end & {
     right: calc(100% + var(--tl-tooltip-offset-distance, 8px));
     bottom: 0;
     border-radius: 4px 4px 0;
   }
 
-  &--left-start {
+  .tl-tooltip--left-start & {
     right: calc(100% + var(--tl-tooltip-offset-distance, 8px));
     top: 0;
     border-radius: 4px 0 4px 4px;
   }
 
-  &--right {
+  .tl-tooltip--right & {
     left: calc(100% + var(--tl-tooltip-offset-distance, 8px));
     top: 50%;
     transform: translateY(-50%);
     border-radius: 4px;
   }
 
-  &--right-end {
+  .tl-tooltip--right-end & {
     left: calc(100% + var(--tl-tooltip-offset-distance, 8px));
     bottom: 0;
     border-radius: 4px 4px 4px 0;
   }
 
-  &--right-start {
+  .tl-tooltip--right-start & {
     left: calc(100% + var(--tl-tooltip-offset-distance, 8px));
     top: 0;
     border-radius: 0 4px 4px;
   }
 
-  &--top {
+  .tl-tooltip--top & {
     bottom: calc(100% + var(--tl-tooltip-offset-distance, 8px));
     left: 50%;
     transform: translateX(-50%);
     border-radius: 4px;
   }
 
-  &--top-end {
+  .tl-tooltip--top-end & {
     bottom: calc(100% + var(--tl-tooltip-offset-distance, 8px));
     right: var(--tl-tooltip-offset-skidding, 0);
     border-radius: 4px 4px 0;
   }
 
-  &--top-start {
+  .tl-tooltip--top-start & {
     bottom: calc(100% + var(--tl-tooltip-offset-distance, 8px));
     left: var(--tl-tooltip-offset-skidding, 0);
     border-radius: 4px 4px 4px 0;

--- a/packages/core/src/tegel-lite/components/tl-tooltip/tl-tooltip.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-tooltip/tl-tooltip.stories.tsx
@@ -102,18 +102,16 @@ const Template = ({ position, label, trigger, triggerElement, offsetSkidding, of
       "@scania/tegel-lite/tl-tooltip.css"
       "@scania/tegel-lite/tl-icon.css"
     -->
-    <div>
-      <div class="tl-tooltip">
+      <div class="tl-tooltip tl-tooltip--${positionLookup[position]}">
         ${renderTrigger(triggerElement, trigger.toLowerCase() === 'click')}
         <div
           id="tooltip-id"
-          class="tl-tooltip__popup tl-tooltip__popup--${positionLookup[position]}"
+          class="tl-tooltip__popup"
           role="tooltip"
         >
           ${label}
         </div>
       </div>
-    </div>
 
     <style>
       .tl-tooltip__popup {


### PR DESCRIPTION
## **Describe pull-request**  
This PR moves the modifiers to the main element. 

## **Issue Linking:**  
[CDEP-1852](https://jira.scania.com/browse/CDEP-1852)

## **How to test**  
1. Go to preview link and navigate to tegel lite -> tooltip
2. Change the position setting and look in the docs tab.
3. Check that the modifier is added on the main element (where the tl-tooltip class is)

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
