### PR TITLE
fix(tl-card): fix the direction of the expandable icon

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-card/tl-card.scss
+++ b/packages/core/src/tegel-lite/components/tl-card/tl-card.scss
@@ -114,8 +114,12 @@
     flex-grow: 1;
   }
 
-  .tl-card--expanded .tl-card__body & {
+  .tl-card--expandable .tl-card__body & {
     display: none;
+  }
+
+  .tl-card--expanded .tl-card__body & {
+    display: block;
   }
 }
 


### PR DESCRIPTION
## **Describe pull-request**  
This PR is to adress the issue with the expandable icon in tl-card. The icon's direction was opposite of expanded true/false. 

## **Issue Linking:**  
[CDEP-1735](https://jira.scania.com/browse/CDEP-1735)

## **How to test**  
1. Go to the preview link and navigate to tegel lite and the card component
2. Set expandable to true
3. Check that the expandable icon matches the expanded true/false (arrow down when false, arrow up when true)

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
