### PR TITLE
refactor(tl-accordion): move --less-padding modifier to __item element

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-accordion/_tl-accordion-item.scss
+++ b/packages/core/src/tegel-lite/components/tl-accordion/_tl-accordion-item.scss
@@ -49,6 +49,12 @@
       background-color: transparent;
     }
   }
+
+  &--less-padding {
+    .tl-accordion__panel {
+      padding-right: var(--tds-spacing-element-16);
+    }
+  }
 }
 
 .tl-accordion__title {
@@ -75,10 +81,6 @@
   p {
     margin: 0;
     padding: 0;
-  }
-
-  &--less-padding {
-    padding-right: var(--tds-spacing-element-16);
   }
 
   .tl-accordion__item--disabled & {

--- a/packages/core/src/tegel-lite/components/tl-accordion/tl-accordion.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-accordion/tl-accordion.stories.tsx
@@ -76,7 +76,7 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant, hideLastB
   const iconPositionClass =
     iconPosition === 'start' ? 'tl-accordion__item--icon-start' : 'tl-accordion__item--icon-end';
   const disabledClass = disabled ? 'tl-accordion__item--disabled' : '';
-  const paddingClass = paddingReset ? 'tl-accordion__panel--less-padding' : '';
+  const paddingClass = paddingReset ? 'tl-accordion__item--less-padding' : '';
   const expandedClass = 'tl-accordion__item--expanded';
 
   return formatHtmlPreview(`
@@ -88,7 +88,7 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant, hideLastB
     
     <div style="width: 100%; margin: 0 auto;">
       <div class="tl-accordion ${modeVariantClass} ${hideLastBorderClass}">
-        <div class="tl-accordion__item ${iconPositionClass} ${disabledClass}">
+        <div class="tl-accordion__item ${iconPositionClass} ${disabledClass} ${paddingClass}">
           <button class="tl-accordion__header-icon-${iconPosition}">
             ${
               iconPosition === 'start'
@@ -102,13 +102,13 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant, hideLastB
                 : ''
             }
           </button>
-          <div class="tl-accordion__panel ${paddingClass}">
+          <div class="tl-accordion__panel">
             This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header.
             Lorem ipsum doler sit amet.
           </div>
         </div>
         
-        <div class="tl-accordion__item ${iconPositionClass} ${disabledClass} ${expandedClass}">
+        <div class="tl-accordion__item ${iconPositionClass} ${disabledClass} ${expandedClass} ${paddingClass}">
           <button class="tl-accordion__header-icon-${iconPosition}">
             ${
               iconPosition === 'start'
@@ -122,7 +122,7 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant, hideLastB
                 : ''
             }
           </button>
-          <div class="tl-accordion__panel ${paddingClass}">
+          <div class="tl-accordion__panel">
             This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header.
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis laoreet vestibulum fermentum.
           </div>


### PR DESCRIPTION
## **Describe pull-request**

Refactor tl-accordion: Move --less-padding modifier from __panel to __item element to follow BEM conventions where item-level modifiers should be on the item element.

Changes:
- Moved modifier in SCSS from __panel to __item
- Updated documentation and Storybook examples
- Same visual behavior maintained

Breaking Change: Yes - class name changed from tl-accordion__panel--less-padding to tl-accordion__item--less-padding

## **Issue Linking:**

**Jira:** [CDEP-1867](https://jira.scania.com/browse/CDEP-1867)

## **How to test**

1. Go to Storybook preview
2. Navigate to Tegel Light (CSS) > Accordion
3. Toggle "Padding reset" control
4. Verify padding behavior works correctly
5. Inspect HTML to confirm modifier is on __item element