### PR TITLE
refactor(tl-block): automatic alternating backgrounds and typography

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-block/tl-block-nested.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-block/tl-block-nested.stories.tsx
@@ -34,22 +34,16 @@ const Template = ({ outerModeVariant, componentTag }) =>
       "@scania/tegel-lite/tl-block.css"
     -->
     <div class="tl-block tl-block--${outerModeVariant.toLowerCase()}">
-        <${componentTag} class="tl-block tl-block--even">
-          <h2>Outer Block (${componentTag})</h2>
-          <p>This block is now structured using a <code>&lt;${componentTag}&gt;</code>.</p>
-          <div class="tl-block tl-block--odd tl-block--nested">
-            <aside>
-              <h3>Middle Block (Aside)</h3>
-              <p>Nested content inside an <code>&lt;aside&gt;</code> element.</p>
-              <div class="tl-block tl-block--even tl-block--nested-inner">
-                <${componentTag}>
-                  <h4>Inner Block (Section)</h4>
-                  <p>Ensuring meaningful content structure with semantic HTML.</p>
-                </${componentTag}>
-              </div>
-            </aside>
-          </div>
-        </${componentTag}>
+      <h2>Outer Block</h2>
+      <p>Nested blocks automatically alternate backgrounds and adjust typography.</p>
+      <${componentTag} class="tl-block">
+        <h3>Middle Block (${componentTag})</h3>
+        <p>Nested content inside a <code>&lt;${componentTag}&gt;</code> element.</p>
+        <article class="tl-block">
+          <h4>Inner Block (Article)</h4>
+          <p>Ensuring meaningful content structure with semantic HTML.</p>
+        </article>
+      </${componentTag}>
     </div>
   `);
 

--- a/packages/core/src/tegel-lite/components/tl-block/tl-block.scss
+++ b/packages/core/src/tegel-lite/components/tl-block/tl-block.scss
@@ -26,43 +26,62 @@
   &--secondary {
     background-color: var(--block-background-mode-secondary);
   }
-
-  &--even {
-    .tl-block--primary & {
-      background-color: var(--block-background-even);
-    }
-
-    .tl-block--secondary & {
-      background-color: var(--block-background-odd);
-    }
-  }
-
-  &--odd {
-    .tl-block--primary & {
-      background-color: var(--block-background-odd);
-    }
-
-    .tl-block--secondary & {
-      background-color: var(--block-background-even);
-    }
-  }
 }
 
-h3 {
-  .tl-block--nested & {
+// Automatic alternating backgrounds for nested blocks in primary mode
+.tl-block--primary .tl-block {
+  background-color: var(--block-background-odd);
+}
+
+.tl-block--primary .tl-block .tl-block {
+  background-color: var(--block-background-even);
+}
+
+.tl-block--primary .tl-block .tl-block .tl-block {
+  background-color: var(--block-background-odd);
+}
+
+.tl-block--primary .tl-block .tl-block .tl-block .tl-block {
+  background-color: var(--block-background-even);
+}
+
+// Automatic alternating backgrounds for nested blocks in secondary mode
+.tl-block--secondary .tl-block {
+  background-color: var(--block-background-even);
+}
+
+.tl-block--secondary .tl-block .tl-block {
+  background-color: var(--block-background-odd);
+}
+
+.tl-block--secondary .tl-block .tl-block .tl-block {
+  background-color: var(--block-background-even);
+}
+
+.tl-block--secondary .tl-block .tl-block .tl-block .tl-block {
+  background-color: var(--block-background-odd);
+}
+
+// Nested block typography (first level)
+.tl-block--primary .tl-block,
+.tl-block--secondary .tl-block {
+  h3 {
     @include headline-04;
   }
-}
 
-h4 {
-  .tl-block--nested-inner & {
-    @include headline-06;
+  p {
+    @include detail-03;
   }
 }
 
-p {
-  .tl-block--nested &,
-  .tl-block--nested-inner & {
+// Deeply nested block typography (second level)
+.tl-block--primary .tl-block .tl-block,
+.tl-block--secondary .tl-block .tl-block {
+  h4 {
+    @include headline-06;
+  }
+
+  p {
     @include detail-03;
   }
 }


### PR DESCRIPTION
## Describe pull-request
Refactors tl-block to use automatic alternating backgrounds and typography based on nesting level, removing the need for manual --even, --odd, --nested, and --nested-inner modifiers.

Current tl-block requires users to manually apply modifiers which is error-prone and inconsistent with tds-block web component. This PR implements automatic CSS-based alternation using descendant selectors, supporting up to 4 nesting levels.

## Issue Linking:
**Jira:** [CDEP-1875](https://jira.scania.com/browse/CDEP-1875)

## How to test
1. Go to Storybook → Tegel Lite (CSS) → Block → Nested
2. Check that nested blocks automatically alternate backgrounds without --even/--odd classes
3. Verify typography automatically adjusts (h2 → h3 → h4) without --nested/--nested-inner modifiers
4. Test with both --primary and --secondary parent modes
5. Verify up to 4 nesting levels work correctly