### PR TITLE
refactor(tl-breadcrumbs): simplify API by removing BEM classes

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-breadcrumbs/tl-breadcrumbs.scss
+++ b/packages/core/src/tegel-lite/components/tl-breadcrumbs/tl-breadcrumbs.scss
@@ -5,62 +5,62 @@
 
 .tl-breadcrumbs {
   @include tds-box-sizing;
-}
 
-.tl-breadcrumbs__list {
-  @include detail-02;
+  ol {
+    @include detail-02;
 
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  list-style-type: none;
-}
-
-.tl-breadcrumbs__breadcrumb {
-  display: inline-block;
-
-  &::after {
-    content: '\203A';
-    color: var(--breadcrumb-separator-color);
-    margin-right: var(--breadcrumb-separator-margin);
-    margin-left: var(--breadcrumb-separator-margin);
-    display: inline-block;
-    width: var(--breadcrumb-separator-width);
-    height: var(--breadcrumb-separator-height);
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    list-style-type: none;
   }
 
-  &--current {
+  li {
+    display: inline-block;
+
     &::after {
-      display: none;
+      content: '\203A';
+      color: var(--breadcrumb-separator-color);
+      margin-right: var(--breadcrumb-separator-margin);
+      margin-left: var(--breadcrumb-separator-margin);
+      display: inline-block;
+      width: var(--breadcrumb-separator-width);
+      height: var(--breadcrumb-separator-height);
+    }
+
+    &:has([aria-current]) {
+      &::after {
+        display: none;
+      }
     }
   }
-}
 
-.tl-breadcrumbs__breadcrumb-link {
-  @include detail-02;
+  a {
+    @include detail-02;
 
-  color: var(--breadcrumb-label);
-  text-decoration: none;
-  transition: color 0.2s ease;
-
-  &:hover {
-    color: var(--breadcrumb-hover);
-    text-decoration: underline;
-  }
-
-  &:focus-visible {
-    @include tds-focus-state;
-  }
-
-  .tl-breadcrumbs__breadcrumb--current & {
-    pointer-events: none;
-    cursor: default;
-    color: var(--breadcrumb-current);
+    color: var(--breadcrumb-label);
+    text-decoration: none;
+    transition: color 0.2s ease;
 
     &:hover {
-      text-decoration: none;
-      cursor: not-allowed;
+      color: var(--breadcrumb-hover);
+      text-decoration: underline;
+    }
+
+    &:focus-visible {
+      @include tds-focus-state;
+    }
+
+    &[aria-current='page'] {
+      pointer-events: none;
+      cursor: default;
+      color: var(--breadcrumb-current);
+
+      &:hover {
+        text-decoration: none;
+        cursor: not-allowed;
+      }
     }
   }
 }

--- a/packages/core/src/tegel-lite/components/tl-breadcrumbs/tl-breadcrumbs.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-breadcrumbs/tl-breadcrumbs.stories.tsx
@@ -15,16 +15,10 @@ const Template = () =>
       "@scania/tegel-lite/tl-breadcrumbs.css"
     -->
     <nav class="tl-breadcrumbs">
-      <ol class="tl-breadcrumbs__list">
-        <li class="tl-breadcrumbs__breadcrumb">
-          <a class="tl-breadcrumbs__breadcrumb-link" href="#">Home</a>
-        </li>
-        <li class="tl-breadcrumbs__breadcrumb">
-          <a class="tl-breadcrumbs__breadcrumb-link" href="#">Products</a>
-        </li>
-        <li class="tl-breadcrumbs__breadcrumb tl-breadcrumbs__breadcrumb--current">
-          <a class="tl-breadcrumbs__breadcrumb-link" href="#" aria-current="page">Current Page</a>
-        </li>
+      <ol>
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Products</a></li>
+        <li><a href="#" aria-current="page">Current Page</a></li>
       </ol>
     </nav>
       `,


### PR DESCRIPTION
## Describe pull-request
Simplifies tl-breadcrumbs API by removing verbose BEM classes. Users now only need to apply the tl-breadcrumbs class to the nav element, with standard HTML elements (ol, li, a) inside. Current page detection is handled automatically via the aria-current attribute.

## Issue Linking:
**Jira:** [CDEP-1876](https://jira.scania.com/browse/CDEP-1876)

## How to test
1. Go to Storybook → Tegel Lite (CSS) → Breadcrumbs
2. Check that breadcrumbs render correctly with simplified HTML structure
3. Verify separators (›) appear between items automatically
4. Verify last item (with aria-current="page") has no separator
5. Test hover and focus states on links
6. Verify current page link is disabled and styled differently