### PR TITLE
fix(tl-badge): add missing font

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-badge/tl-badge.scss
+++ b/packages/core/src/tegel-lite/components/tl-badge/tl-badge.scss
@@ -37,5 +37,6 @@
 .tl-badge__text {
   font-size: 12px;
   color: var(--badge-color-text);
+  font-family: var(--detail-01-font-family);
   font-weight: bold;
 }


### PR DESCRIPTION
## **Describe pull-request**  
The Tegel Lite badge component was missing a font-family. Therefore the font didn't change with scania/traton. 

## **Issue Linking:**  
_Choose one of the following options_
[CDEP-1866](https://jira.scania.com/browse/CDEP-1866)

## **How to test**  
1. Go to the preview link and navigate to Tegel Lite -> Badge component
2. Inspect the number and check for the font-family variable
3. Change between scania and traton and check that the font-family changes accordingly 

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
