### PR TITLE
fix(tl-card): update conditions of expandable settings

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-card/tl-card.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-card/tl-card.stories.tsx
@@ -131,14 +131,14 @@ export default {
       name: 'Expandable',
       description: 'Toggles if the Card can expand/collapse its content.',
       control: 'boolean',
-      if: { arg: 'clickable', eq: false },
+      if: { arg: 'imagePlacement', neq: 'Below' },
       table: { defaultValue: { summary: false } },
     },
     expanded: {
       name: 'Expanded',
       description: 'Controls the initial expanded state when expandable is enabled.',
       control: 'boolean',
-      if: { arg: 'expandable', eq: true },
+      if: { arg: 'imagePlacement', neq: 'Below' },
       table: { defaultValue: { summary: false } },
     },
     showIcon: {
@@ -208,10 +208,13 @@ const Template = ({
     placementClass = 'tl-card--image-below-header';
   }
 
-  const clickableClass = clickable ? 'tl-card--clickable' : '';
   const stretchClass = stretch ? 'tl-card--stretch' : '';
-  const expandableClass = expandable ? 'tl-card--expandable' : '';
-  const expandedClass = expandable && expanded ? 'tl-card--expanded' : '';
+  const effectiveClickable = clickable && !expandable;
+  const clickableClass = effectiveClickable ? 'tl-card--clickable' : '';
+  const isExpandableDisabled = effectiveClickable || (bodyImg && imagePlacement === 'Below');
+  const effectiveExpandable = expandable && !isExpandableDisabled;
+  const expandableClass = effectiveExpandable ? 'tl-card--expandable' : '';
+  const expandedClass = effectiveExpandable && expanded ? 'tl-card--expanded' : '';
 
   const headerHtml = `
     <div class="tl-card__header">
@@ -223,7 +226,7 @@ const Template = ({
         ${subheader ? `<div class="tl-card__subtitle">${subheader}</div>` : ''}
       </div>
       ${
-        expandable
+        effectiveExpandable
           ? `<button
   class="tl-button tl-button--only-icon tl-button--ghost tl-button--sm tl-button--icon">
   <span class="tl-icon tl-icon--chevron_down tl-icon--16"></span>
@@ -272,18 +275,18 @@ const Template = ({
       "@scania/tegel-lite/global.css"
       "@scania/tegel-lite/tl-card.css";
       ${
-        expandable
+        effectiveExpandable
           ? `"@scania/tegel-lite/tl-button.css"; 
       "@scania/tegel-lite/tl-icon.css";`
           : ''
       }
-      ${showIcon && !expandable ? `"@scania/tegel-lite/tl-icon.css";` : ''}
+      ${showIcon && !effectiveExpandable ? `"@scania/tegel-lite/tl-icon.css";` : ''}
     -->
     <style>
       .demo-wrapper { 
         max-width: 600px; 
         ${
-          expandable
+          effectiveExpandable
             ? `width: 336px;
         max-height: 152px;`
             : ''


### PR DESCRIPTION
## **Describe pull-request**  
This PR fixes conditions of the storybook settings to adress an issue with image positioned below and expandable being true at the same time. According to figma the expandable prop should only work when image is positioned **above** . This also caused the need to update the "clickable" condition. Clickable should never be true at the same time as expandable is true.

## **Issue Linking:**  
[CDEP-1863](https://jira.scania.com/browse/CDEP-1863)

## **How to test** 
1. Go to the preview link and navigate to the Tegel Lite Card component. 
2. Set the Body Image to true and Body Image placement to "Below"
3. Check that the Expandable setting is not visible
4. Chang Body Image placement to "Above"
5. Check that the Expandable setting is visible
8. When Expandable is true, the setting for Clickable should not be visible. Change Expandable to False and check that you now have a setting for Clickable.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
