### PR TITLE
fix(tl-spinner): change naming of variant

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-spinner/tl-spinner.scss
+++ b/packages/core/src/tegel-lite/components/tl-spinner/tl-spinner.scss
@@ -30,7 +30,7 @@
     --tl-spinner-animation-speed: var(--tl-spinner-speed-lg);
   }
 
-  &--standard {
+  &--default {
     stroke: var(--tl-spinner-background);
   }
 

--- a/packages/core/src/tegel-lite/components/tl-spinner/tl-spinner.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-spinner/tl-spinner.stories.tsx
@@ -23,15 +23,15 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Standard', 'Inverted'],
+      options: ['Default', 'Inverted'],
       table: {
-        defaultValue: { summary: 'Standard' },
+        defaultValue: { summary: 'Default' },
       },
     },
   },
   args: {
     size: 'Large',
-    variant: 'Standard',
+    variant: 'Default',
   },
 };
 
@@ -43,7 +43,7 @@ const Template = ({ size, variant }) => {
     'Extra small': 'xs',
   };
   const variantMap = {
-    Standard: 'standard',
+    Default: 'default',
     Inverted: 'inverted',
   };
   const sizeClass = size ? `tl-spinner--${sizeMap[size]}` : '';


### PR DESCRIPTION
## **Describe pull-request**  
This PR changes the variant name from "Standard" to "Default".

## **Issue Linking:**  
[CDEP-1900](https://jira.scania.com/browse/CDEP-1900)

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to preview link and navigate to Tegel Lite Spinner component
2. Check the Variant settings, options should be "Defualt" and "Inverted"
3. Check the Docs tab of the component and check that the modifier name is tl-spinner**--default**

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
