### PR TITLE
refactor(tl-chip): simplify chip structure and use native disabled

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-chip/tl-chip.scss
+++ b/packages/core/src/tegel-lite/components/tl-chip/tl-chip.scss
@@ -58,11 +58,16 @@
     }
   }
 
-  &--disabled {
+  &:disabled {
     cursor: not-allowed;
     pointer-events: none;
     background-color: var(--chip-background-disabled);
     color: var(--chip-text-disabled);
+  }
+
+  &:disabled#{&}--selected {
+    background-color: var(--chip-background-active);
+    color: var(--chip-text-checked-disabled);
   }
 
   &--lg.tl-chip--prefix:not(.tl-chip--suffix) {
@@ -88,22 +93,4 @@
   &--sm.tl-chip--prefix.tl-chip--suffix {
     padding: 0 6px;
   }
-}
-
-.tl-chip--disabled.tl-chip--selected {
-  background-color: var(--chip-background-active);
-  color: var(--chip-text-checked-disabled);
-}
-
-.tl-chip__label {
-  display: inline-flex;
-  align-items: center;
-  padding-top: 2px;
-}
-
-.tl-chip__icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 0;
 }

--- a/packages/core/src/tegel-lite/components/tl-chip/tl-chip.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-chip/tl-chip.stories.tsx
@@ -59,18 +59,13 @@ export default {
 
 const Template = ({ size, label, showIcon, icon, iconPosition, disabled, selected }) => {
   const sizeClass = size === 'Small' ? 'tl-chip--sm' : 'tl-chip--lg';
-  const disabledClass = disabled ? ' tl-chip--disabled' : '';
   const selectedClass = selected ? ' tl-chip--selected' : '';
 
   const hasIcon = Boolean(showIcon && icon && icon !== 'none');
   const prefixMod = hasIcon && iconPosition === 'Prefix' ? ' tl-chip--prefix' : '';
   const suffixMod = hasIcon && iconPosition === 'Suffix' ? ' tl-chip--suffix' : '';
 
-  const iconHtml = hasIcon
-    ? `<span class="tl-chip__icon">
-         <span class="tl-icon tl-icon--${icon} tl-icon--16"></span>
-       </span>`
-    : '';
+  const iconHtml = hasIcon ? `<span class="tl-icon tl-icon--${icon} tl-icon--16"></span>` : '';
 
   return formatHtmlPreview(`
     <!-- Required stylesheets:
@@ -83,20 +78,22 @@ const Template = ({ size, label, showIcon, icon, iconPosition, disabled, selecte
     -->
 
     <div class="demo-wrapper" style="display: flex; gap: 8px; flex-wrap: wrap;">
-      <button class="tl-chip ${sizeClass}${disabledClass}${selectedClass}${prefixMod}${suffixMod}">
-        ${hasIcon && iconPosition === 'Prefix' ? iconHtml : ''}
-        <span class="tl-chip__label">${label} 1</span>
-        ${hasIcon && iconPosition === 'Suffix' ? iconHtml : ''}
+      <button class="tl-chip ${sizeClass}${selectedClass}${prefixMod}${suffixMod}" ${
+    disabled ? 'disabled' : ''
+  }>
+        ${hasIcon && iconPosition === 'Prefix' ? iconHtml : ''}${label} 1${
+    hasIcon && iconPosition === 'Suffix' ? iconHtml : ''
+  }
       </button>
-      <button class="tl-chip ${sizeClass}${disabledClass}${prefixMod}${suffixMod}">
-        ${hasIcon && iconPosition === 'Prefix' ? iconHtml : ''}
-        <span class="tl-chip__label">${label} 2</span>
-        ${hasIcon && iconPosition === 'Suffix' ? iconHtml : ''}
+      <button class="tl-chip ${sizeClass}${prefixMod}${suffixMod}" ${disabled ? 'disabled' : ''}>
+        ${hasIcon && iconPosition === 'Prefix' ? iconHtml : ''}${label} 2${
+    hasIcon && iconPosition === 'Suffix' ? iconHtml : ''
+  }
       </button>
-      <button class="tl-chip ${sizeClass}${disabledClass}${prefixMod}${suffixMod}">
-        ${hasIcon && iconPosition === 'Prefix' ? iconHtml : ''}
-        <span class="tl-chip__label">${label} 3</span>
-        ${hasIcon && iconPosition === 'Suffix' ? iconHtml : ''}
+      <button class="tl-chip ${sizeClass}${prefixMod}${suffixMod}" ${disabled ? 'disabled' : ''}>
+        ${hasIcon && iconPosition === 'Prefix' ? iconHtml : ''}${label} 3${
+    hasIcon && iconPosition === 'Suffix' ? iconHtml : ''
+  }
       </button>
     </div>
 
@@ -109,7 +106,7 @@ const Template = ({ size, label, showIcon, icon, iconPosition, disabled, selecte
         const chips = wrapper.querySelectorAll(".tl-chip");
         chips.forEach((chip) => {
           chip.addEventListener("click", () => {
-            if (chip.classList.contains("tl-chip--disabled")) return;
+            if (chip.disabled) return;
             chips.forEach((c) => {
               c.classList.remove("tl-chip--selected");
             });


### PR DESCRIPTION
## Describe pull-request
Simplifies the Tegel Lite chip component HTML structure by removing unnecessary wrapper elements (__label and __icon) and using native HTML disabled attribute instead of CSS modifier class (--disabled).

**Before:**
```
<button class="tl-chip tl-chip--disabled">
  <span class="tl-chip__icon">
    <span class="tl-icon tl-icon-example tl-icon--16"></span>
  </span>
  <span class="tl-chip__label">Label</span>
</button>
```

**After:**
```
<button class="tl-chip" disabled>
  <span class="tl-icon tl-icon-example tl-icon--16"></span>
  Label
</button>
```

**Changes:**
- Remove tl-chip__label and tl-chip__icon wrapper elements and styles
- Change &--disabled to &:disabled in SCSS
- Add &:disabled#{&}--selected for disabled+selected combination
- Update stories and documentation

**Benefits:**
- Simpler HTML structure
- Better accessibility with native disabled attribute
- Less CSS to maintain
- Consistent with radio button refactoring pattern

## Issue Linking:
Jira: CDEP-1893 https://jira.scania.com/browse/CDEP-1893

## How to test
1. Go to Storybook in preview link and navigate to Tegel Lite > Chip
2. Check all chip variants display correctly without wrapper elements
3. Test disabled state works with native disabled attribute
4. Verify all states work: default, hover, focus, selected, disabled, disabled+selected
5. Check chips with icons (prefix/suffix) render correctly
6. Verify small and large size variants work