### PR TITLE
refactor: remove label-outside modifier and make it default behavior

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.stories.tsx
@@ -37,7 +37,7 @@ export default {
     labelPosition: {
       name: 'Label position',
       control: { type: 'radio' },
-      options: ['No label', 'Inside', 'Outside'],
+      options: ['Outside', 'Inside', 'No label'],
     },
     helper: {
       name: 'Helper text',

--- a/packages/core/src/tegel-lite/components/tl-dropdown/tl-dropdown.scss
+++ b/packages/core/src/tegel-lite/components/tl-dropdown/tl-dropdown.scss
@@ -138,7 +138,7 @@
 }
 
 .tl-dropdown__input-wrapper:has(.tl-dropdown__input[aria-expanded='true']:not(:placeholder-shown))
-  .tl-dropdown__input-clear {
+.tl-dropdown__input-clear {
   display: inline-flex;
 }
 
@@ -159,16 +159,16 @@
 }
 
 .tl-dropdown__input-wrapper:has(
-    .tl-dropdown__input[aria-expanded='true']:not(:placeholder-shown)
-  )::before {
+.tl-dropdown__input[aria-expanded='true']:not(:placeholder-shown)
+)::before {
   opacity: 1;
 }
 
 .tl-dropdown__button::after,
 .tl-dropdown__input-wrapper::after,
 .tl-dropdown:has(.tl-dropdown__select):not(:has(.tl-dropdown__button)):not(
-    :has(.tl-dropdown__input)
-  )::after {
+  :has(.tl-dropdown__input)
+)::after {
   content: '';
   position: absolute;
   right: var(--tds-spacing-element-16);
@@ -193,33 +193,36 @@
 }
 
 .tl-dropdown:has(.tl-dropdown__select:disabled):not(:has(.tl-dropdown__button)):not(
-    :has(.tl-dropdown__input)
-  )::after {
+:has(.tl-dropdown__input)
+)::after {
   background-color: var(--dropdown-disabled);
 }
 
-.tl-dropdown--label-outside:has(.tl-dropdown__select):not(:has(.tl-dropdown__helper))::after {
+// Default behavior (label outside) for select without helper
+.tl-dropdown:not(.tl-dropdown--label-inside):has(.tl-dropdown__select):not(
+:has(.tl-dropdown__helper)
+)::after {
   top: calc(50% + 12.5px);
   transform: translateY(-50%);
 }
 
-.tl-dropdown--lg.tl-dropdown--label-outside:has(.tl-dropdown__select):not(
-    :has(.tl-dropdown__helper)
-  )::after {
+.tl-dropdown--lg:not(.tl-dropdown--label-inside):has(.tl-dropdown__select):not(
+:has(.tl-dropdown__helper)
+)::after {
   top: calc(50% + 12.5px);
   transform: translateY(-50%);
 }
 
-.tl-dropdown--md.tl-dropdown--label-outside:has(.tl-dropdown__select):not(
-    :has(.tl-dropdown__helper)
-  )::after {
+.tl-dropdown--md:not(.tl-dropdown--label-inside):has(.tl-dropdown__select):not(
+:has(.tl-dropdown__helper)
+)::after {
   top: calc(50% + 10px);
   transform: translateY(-50%);
 }
 
-.tl-dropdown--sm.tl-dropdown--label-outside:has(.tl-dropdown__select):not(
-    :has(.tl-dropdown__helper)
-  )::after {
+.tl-dropdown--sm:not(.tl-dropdown--label-inside):has(.tl-dropdown__select):not(
+:has(.tl-dropdown__helper)
+)::after {
   top: calc(50% + 10px);
   transform: translateY(-50%);
 }
@@ -230,34 +233,36 @@
   transform: translateY(-50%);
 }
 
-.tl-dropdown:not(.tl-dropdown--label-outside):has(.tl-dropdown__select):has(
-    .tl-dropdown__helper
-  )::after {
+// Label inside with helper
+.tl-dropdown--label-inside:has(.tl-dropdown__select):has(.tl-dropdown__helper)::after {
   top: calc(50% - 10px);
   transform: translateY(-50%);
 }
 
-.tl-dropdown--label-outside:has(.tl-dropdown__select):has(.tl-dropdown__helper)::after {
+// Default behavior (label outside) for select with helper
+.tl-dropdown:not(.tl-dropdown--label-inside):has(.tl-dropdown__select):has(
+.tl-dropdown__helper
+)::after {
   top: calc(50% + 2.5px);
   transform: translateY(-50%);
 }
 
-.tl-dropdown--md.tl-dropdown--label-outside:has(.tl-dropdown__select):has(
-    .tl-dropdown__helper
-  )::after {
+.tl-dropdown--md:not(.tl-dropdown--label-inside):has(.tl-dropdown__select):has(
+.tl-dropdown__helper
+)::after {
   top: 50%;
   transform: translateY(-50%);
 }
 
-.tl-dropdown--sm.tl-dropdown--label-outside:has(.tl-dropdown__select):has(
-    .tl-dropdown__helper
-  )::after {
+.tl-dropdown--sm:not(.tl-dropdown--label-inside):has(.tl-dropdown__select):has(
+.tl-dropdown__helper
+)::after {
   top: 50%;
   transform: translateY(-50%);
 }
 
 .tl-dropdown:has([aria-expanded='true'])
-  :is(.tl-dropdown__button, .tl-dropdown__input-wrapper)::after {
+:is(.tl-dropdown__button, .tl-dropdown__input-wrapper)::after {
   transform: translateY(-50%) rotate(180deg);
 }
 
@@ -269,7 +274,8 @@
     color: var(--color-foreground-text-disabled);
   }
 
-  .tl-dropdown--label-outside & {
+  // Default behavior: label outside
+  .tl-dropdown:not(.tl-dropdown--label-inside) & {
     @include detail-05;
 
     color: var(--dropdown-text);
@@ -295,15 +301,15 @@
 }
 
 .tl-dropdown--label-inside:has(
-    :is(
-        .tl-dropdown__input:focus,
-        .tl-dropdown__input:not(:placeholder-shown),
-        .tl-dropdown__text:not(:empty)
-      )
-  )
-  .tl-dropdown__label,
+:is(
+  .tl-dropdown__input:focus,
+  .tl-dropdown__input:not(:placeholder-shown),
+  .tl-dropdown__text:not(:empty)
+)
+)
+.tl-dropdown__label,
 .tl-dropdown--label-inside:has(.tl-dropdown__select option:not([value='']):checked)
-  .tl-dropdown__label {
+.tl-dropdown__label {
   @include detail-07;
 
   color: var(--dropdown-label-inside-active, var(--dropdown-label-inside));
@@ -312,91 +318,91 @@
 }
 
 .tl-dropdown--lg.tl-dropdown--label-inside:has(
-    :is(
-        .tl-dropdown__input:focus,
-        .tl-dropdown__input:not(:placeholder-shown),
-        .tl-dropdown__text:not(:empty)
-      )
-  )
-  .tl-dropdown__label,
+:is(
+  .tl-dropdown__input:focus,
+  .tl-dropdown__input:not(:placeholder-shown),
+  .tl-dropdown__text:not(:empty)
+)
+)
+.tl-dropdown__label,
 .tl-dropdown--lg.tl-dropdown--label-inside:has(.tl-dropdown__select option:not([value='']):checked)
-  .tl-dropdown__label {
+.tl-dropdown__label {
   top: 12.5px;
 }
 
 .tl-dropdown--md.tl-dropdown--label-inside:has(
-    :is(
-        .tl-dropdown__input:focus,
-        .tl-dropdown__input:not(:placeholder-shown),
-        .tl-dropdown__text:not(:empty)
-      )
-  )
-  .tl-dropdown__label,
+:is(
+  .tl-dropdown__input:focus,
+  .tl-dropdown__input:not(:placeholder-shown),
+  .tl-dropdown__text:not(:empty)
+)
+)
+.tl-dropdown__label,
 .tl-dropdown--md.tl-dropdown--label-inside:has(.tl-dropdown__select option:not([value='']):checked)
-  .tl-dropdown__label {
+.tl-dropdown__label {
   top: 8.5px;
 }
 
 .tl-dropdown--sm.tl-dropdown--label-inside:has(
-    :is(
-        .tl-dropdown__input:focus,
-        .tl-dropdown__input:not(:placeholder-shown),
-        .tl-dropdown__text:not(:empty)
-      )
-  )
-  .tl-dropdown__label,
+:is(
+  .tl-dropdown__input:focus,
+  .tl-dropdown__input:not(:placeholder-shown),
+  .tl-dropdown__text:not(:empty)
+)
+)
+.tl-dropdown__label,
 .tl-dropdown--sm.tl-dropdown--label-inside:has(.tl-dropdown__select option:not([value='']):checked)
-  .tl-dropdown__label {
+.tl-dropdown__label {
   display: none;
 }
 
 .tl-dropdown--label-inside:not(:has(.tl-dropdown__text:not(:empty))):not(
-    :has(.tl-dropdown__input:focus)
-  ):not(:has(.tl-dropdown__input:not(:placeholder-shown))):not(
-    :has(.tl-dropdown__select option:not([value='']):checked)
-  )
-  .tl-dropdown__label {
+:has(.tl-dropdown__input:focus)
+):not(:has(.tl-dropdown__input:not(:placeholder-shown))):not(
+:has(.tl-dropdown__select option:not([value='']):checked)
+)
+.tl-dropdown__label {
   top: 50%;
   transform: translateY(-50%);
 }
 
 .tl-dropdown--label-inside:has(.tl-dropdown__helper):not(:has(.tl-dropdown__text:not(:empty))):not(
-    :has(.tl-dropdown__input:focus)
-  ):not(:has(.tl-dropdown__input:not(:placeholder-shown))):not(
-    :has(.tl-dropdown__select option:not([value='']):checked)
-  )
-  .tl-dropdown__label {
+:has(.tl-dropdown__input:focus)
+):not(:has(.tl-dropdown__input:not(:placeholder-shown))):not(
+:has(.tl-dropdown__select option:not([value='']):checked)
+)
+.tl-dropdown__label {
   top: calc(50% - 9.5px);
 }
 
 :is(.tl-dropdown--md, .tl-dropdown--lg).tl-dropdown--label-inside:has(
-    :is(.tl-dropdown__input:focus, .tl-dropdown__input:not(:placeholder-shown))
-  )
-  .tl-dropdown__input {
+:is(.tl-dropdown__input:focus, .tl-dropdown__input:not(:placeholder-shown))
+)
+.tl-dropdown__input {
   padding-top: 10px;
 }
 
 :is(.tl-dropdown--md, .tl-dropdown--lg).tl-dropdown--label-inside:has(
-    .tl-dropdown__text:not(:empty)
-  )
-  .tl-dropdown__text {
+.tl-dropdown__text:not(:empty)
+)
+.tl-dropdown__text {
   padding-top: 10px;
 }
 
 .tl-dropdown--label-inside:has(.tl-dropdown__select option:not([value='']):checked)
-  .tl-dropdown__select {
+.tl-dropdown__select {
   padding-top: 12.5px;
 }
 
 :is(.tl-dropdown--md, .tl-dropdown--lg).tl-dropdown--label-inside:has(
-    .tl-dropdown__select option:not([value='']):checked
-  )
-  .tl-dropdown__select {
+.tl-dropdown__select option:not([value='']):checked
+)
+.tl-dropdown__select {
   padding-top: 10px;
 }
 
 .tl-dropdown--sm.tl-dropdown--label-inside:has(.tl-dropdown__select option:not([value='']):checked)
-  .tl-dropdown__select {
+.tl-dropdown__select {
   padding-top: 2px;
 }
 
@@ -447,9 +453,9 @@
 }
 
 .tl-dropdown:has(.tl-dropdown__helper):has(.tl-dropdown__button[aria-expanded='true'])
-  .tl-dropdown__list,
+.tl-dropdown__list,
 .tl-dropdown:has(.tl-dropdown__helper):has(.tl-dropdown__input[aria-expanded='true'])
-  .tl-dropdown__list {
+.tl-dropdown__list {
   transform: translateY(-20px) scaleY(1);
 }
 
@@ -462,18 +468,19 @@
   transform: translateY(-2px) scaleY(1);
 }
 
-.tl-dropdown.tl-dropdown--dropup.tl-dropdown--label-outside .tl-dropdown__list {
+// Default behavior (label outside) for dropup
+.tl-dropdown.tl-dropdown--dropup:not(.tl-dropdown--label-inside) .tl-dropdown__list {
   transform: translateY(18px) scaleY(0);
 }
 
-.tl-dropdown.tl-dropdown--dropup.tl-dropdown--label-outside:has(
-    .tl-dropdown__button[aria-expanded='true']
-  )
-  .tl-dropdown__list,
-.tl-dropdown.tl-dropdown--dropup.tl-dropdown--label-outside:has(
-    .tl-dropdown__input[aria-expanded='true']
-  )
-  .tl-dropdown__list {
+.tl-dropdown.tl-dropdown--dropup:not(.tl-dropdown--label-inside):has(
+.tl-dropdown__button[aria-expanded='true']
+)
+.tl-dropdown__list,
+.tl-dropdown.tl-dropdown--dropup:not(.tl-dropdown--label-inside):has(
+.tl-dropdown__input[aria-expanded='true']
+)
+.tl-dropdown__list {
   transform: translateY(18px) scaleY(1);
 }
 

--- a/packages/core/src/tegel-lite/components/tl-dropdown/tl-dropdown.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-dropdown/tl-dropdown.stories.tsx
@@ -266,9 +266,8 @@ function getDropdownMarkup(props: TemplateProps, optionOrder: readonly string[])
 
   if (isInside) {
     classesList.push('tl-dropdown--label-inside');
-  } else if (showLabel) {
-    classesList.push('tl-dropdown--label-outside');
   }
+  // Note: label-outside is now the default behavior, no class needed
 
   if (error) {
     classesList.push('tl-dropdown--error');
@@ -293,7 +292,7 @@ function getDropdownMarkup(props: TemplateProps, optionOrder: readonly string[])
 
   return `
 ${stylesheetsComment}
-<div class="${classes}" style="width: 208px;">
+<div class="${classes}">
   ${fieldMarkup}
   ${showHelper && helper ? getHelper(helper) : ''}
 </div>

--- a/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.scss
+++ b/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.scss
@@ -45,7 +45,8 @@
     z-index: 1;
   }
 
-  &--label-outside#{&}--readonly:not(&--disabled):not(&--hide-readonly-icon)::before {
+  // Default behavior (label outside) - readonly icon position adjustment
+  &:not(&--label-inside)#{&}--readonly:not(&--disabled):not(&--hide-readonly-icon)::before {
     top: calc(50% + 24px);
   }
 
@@ -94,7 +95,7 @@
   }
 
   .tl-text-field--success:not(.tl-text-field--readonly):not(.tl-text-field--disabled)
-    &:not(:focus) {
+  &:not(:focus) {
     box-shadow: inset var(--text-field-box-shadow-success);
   }
 
@@ -174,13 +175,15 @@
     color: transparent !important;
   }
 
-  .tl-text-field--label-outside &:disabled::placeholder {
+  // Default behavior (label outside) - disabled placeholder color
+  .tl-text-field:not(.tl-text-field--label-inside) &:disabled::placeholder {
     color: var(--text-field-placeholder-disabled) !important;
   }
 }
 
 .tl-text-field__label {
-  .tl-text-field--label-outside & {
+  // Default behavior (label outside)
+  .tl-text-field:not(.tl-text-field--label-inside) & {
     @include detail-05;
 
     display: block;
@@ -213,10 +216,10 @@
   // Focus and filled state for lg and md
   .tl-text-field--label-inside.tl-text-field--lg:has(.tl-text-field__input:focus) &,
   .tl-text-field--label-inside.tl-text-field--lg:has(.tl-text-field__input:not(:placeholder-shown))
-    &,
+  &,
   .tl-text-field--label-inside.tl-text-field--md:has(.tl-text-field__input:focus) &,
   .tl-text-field--label-inside.tl-text-field--md:has(.tl-text-field__input:not(:placeholder-shown))
-    & {
+  & {
     @include detail-07;
 
     top: 8px;
@@ -226,47 +229,47 @@
 
   // Keep prefix offset when focused for lg and md
   .tl-text-field--label-inside.tl-text-field--lg:has(.tl-text-field__prefix--icon):has(
-      .tl-text-field__input:focus
-    )
-    &,
+  .tl-text-field__input:focus
+)
+  &,
   .tl-text-field--label-inside.tl-text-field--lg:has(.tl-text-field__prefix--icon):has(
-      .tl-text-field__input:not(:placeholder-shown)
-    )
-    &,
+  .tl-text-field__input:not(:placeholder-shown)
+)
+  &,
   .tl-text-field--label-inside.tl-text-field--md:has(.tl-text-field__prefix--icon):has(
-      .tl-text-field__input:focus
-    )
-    &,
+  .tl-text-field__input:focus
+)
+  &,
   .tl-text-field--label-inside.tl-text-field--md:has(.tl-text-field__prefix--icon):has(
-      .tl-text-field__input:not(:placeholder-shown)
-    )
-    & {
+  .tl-text-field__input:not(:placeholder-shown)
+)
+  & {
     left: calc(16px + 20px + 8px);
   }
 
   .tl-text-field--label-inside.tl-text-field--lg:has(.tl-text-field__prefix--text):has(
-      .tl-text-field__input:focus
-    )
-    &,
+  .tl-text-field__input:focus
+)
+  &,
   .tl-text-field--label-inside.tl-text-field--lg:has(.tl-text-field__prefix--text):has(
-      .tl-text-field__input:not(:placeholder-shown)
-    )
-    &,
+  .tl-text-field__input:not(:placeholder-shown)
+)
+  &,
   .tl-text-field--label-inside.tl-text-field--md:has(.tl-text-field__prefix--text):has(
-      .tl-text-field__input:focus
-    )
-    &,
+  .tl-text-field__input:focus
+)
+  &,
   .tl-text-field--label-inside.tl-text-field--md:has(.tl-text-field__prefix--text):has(
-      .tl-text-field__input:not(:placeholder-shown)
-    )
-    & {
+  .tl-text-field__input:not(:placeholder-shown)
+)
+  & {
     left: calc(16px + var(--text-field-affix-width-text) + 8px);
   }
 
   // Focus and filled state for sm - label disappears
   .tl-text-field--label-inside.tl-text-field--sm:has(.tl-text-field__input:focus) &,
   .tl-text-field--label-inside.tl-text-field--sm:has(.tl-text-field__input:not(:placeholder-shown))
-    & {
+  & {
     opacity: 0;
     visibility: hidden;
   }
@@ -276,7 +279,8 @@
     color: var(--text-field-label-disabled);
   }
 
-  .tl-text-field--label-outside.tl-text-field--disabled & {
+  // Default behavior (label outside) - disabled state
+  .tl-text-field:not(.tl-text-field--label-inside).tl-text-field--disabled & {
     color: var(--text-field-label-disabled);
   }
 }
@@ -363,8 +367,9 @@
     z-index: 1;
   }
 
-  .tl-text-field--label-outside &--text,
-  .tl-text-field--label-outside &--icon {
+  // Default behavior (label outside) - prefix position adjustment
+  .tl-text-field:not(.tl-text-field--label-inside) &--text,
+  .tl-text-field:not(.tl-text-field--label-inside) &--icon {
     transform: translateY(calc(-50% + 24px));
   }
 
@@ -398,8 +403,9 @@
     z-index: 1;
   }
 
-  .tl-text-field--label-outside &--text,
-  .tl-text-field--label-outside &--icon {
+  // Default behavior (label outside) - suffix position adjustment
+  .tl-text-field:not(.tl-text-field--label-inside) &--text,
+  .tl-text-field:not(.tl-text-field--label-inside) &--icon {
     transform: translateY(calc(-50% + 24px));
   }
 
@@ -425,8 +431,9 @@
   padding-right: 0;
   z-index: 1;
 
-  .tl-text-field--label-outside &--text,
-  .tl-text-field--label-outside &--icon {
+  // Default behavior (label outside) - suffix position adjustment
+  .tl-text-field:not(.tl-text-field--label-inside) &--text,
+  .tl-text-field:not(.tl-text-field--label-inside) &--icon {
     transform: translateY(calc(-50% + 24px));
   }
 

--- a/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.stories.tsx
@@ -33,7 +33,7 @@ export default {
     labelPosition: {
       name: 'Label position',
       control: { type: 'radio' },
-      options: ['No label', 'Inside', 'Outside'],
+      options: ['Outside', 'Inside', 'No label'],
     },
     placeholderText: {
       name: 'Placeholder',
@@ -96,7 +96,7 @@ export default {
     type: 'Text',
     size: 'Large',
     label: 'Label',
-    labelPosition: 'No label',
+    labelPosition: 'Outside',
     placeholderText: 'Placeholder',
     helper: 'Helper text',
     prefix: false,
@@ -140,7 +140,7 @@ const Template = ({
     size === 'Medium' && 'tl-text-field--md',
     size === 'Small' && 'tl-text-field--sm',
     labelPosition === 'Inside' && 'tl-text-field--label-inside',
-    labelPosition === 'Outside' && 'tl-text-field--label-outside',
+    // Note: label-outside is now the default behavior, no class needed
     noMinWidth && 'tl-text-field--no-min-width',
     disabled && 'tl-text-field--disabled',
     readonly && 'tl-text-field--readonly',

--- a/packages/core/src/tegel-lite/components/tl-textarea/tl-textarea.scss
+++ b/packages/core/src/tegel-lite/components/tl-textarea/tl-textarea.scss
@@ -34,7 +34,8 @@
     z-index: 1;
   }
 
-  &--label-outside#{&}--readonly:not(&--disabled):not(&--hide-readonly-icon)::before {
+  // Default behavior (label outside) - readonly icon position adjustment
+  &:not(&--label-inside)#{&}--readonly:not(&--disabled):not(&--hide-readonly-icon)::before {
     top: 44px;
   }
 
@@ -59,21 +60,20 @@
     right: 4px;
   }
 
-  &--label-outside::after {
+  // Default behavior (label outside) - resize icon position adjustment
+  &:not(&--label-inside)::after {
     bottom: 7px;
   }
 
-  .traton &--label-outside::after {
+  .traton &:not(&--label-inside)::after {
     bottom: 9px;
   }
 
-  &:has(.tl-textarea__bottom)::after,
-  &--label-outside:has(.tl-textarea__bottom)::after {
+  &:has(.tl-textarea__bottom)::after {
     bottom: 25px;
   }
 
-  .traton &:has(.tl-textarea__bottom)::after,
-  .traton &--label-outside:has(.tl-textarea__bottom)::after {
+  .traton &:has(.tl-textarea__bottom)::after {
     bottom: 27px;
   }
 
@@ -172,7 +172,8 @@
 }
 
 .tl-textarea__label {
-  .tl-textarea--label-outside & {
+  // Default behavior (label outside)
+  .tl-textarea:not(.tl-textarea--label-inside) & {
     @include detail-05;
 
     display: block;
@@ -202,7 +203,8 @@
     transform: translateY(0);
   }
 
-  .tl-textarea--label-outside.tl-textarea--disabled & {
+  // Default behavior (label outside) - disabled state
+  .tl-textarea:not(.tl-textarea--label-inside).tl-textarea--disabled & {
     color: var(--textarea-label-disabled);
   }
 }

--- a/packages/core/src/tegel-lite/components/tl-textarea/tl-textarea.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-textarea/tl-textarea.stories.tsx
@@ -27,7 +27,7 @@ export default {
     labelPosition: {
       name: 'Label Position',
       control: { type: 'radio' },
-      options: ['No label', 'Inside', 'Outside'],
+      options: ['Outside', 'Inside', 'No label'],
       description: 'Where to position the label',
     },
     placeholder: {
@@ -86,7 +86,7 @@ export default {
     state: 'Default',
 
     label: 'Label',
-    labelPosition: 'No label',
+    labelPosition: 'Outside',
     placeholder: 'Placeholder',
     helper: '',
 
@@ -121,7 +121,7 @@ const Template = ({
     modeVariant !== 'Inherit from parent' && `tl-textarea--${modeVariant.toLowerCase()}`,
     state !== 'Default' && `tl-textarea--${state.toLowerCase()}`,
     labelPosition === 'Inside' && 'tl-textarea--label-inside',
-    labelPosition === 'Outside' && 'tl-textarea--label-outside',
+    // Note: label-outside is now the default behavior, no class needed
     disabled && 'tl-textarea--disabled',
     readonly && 'tl-textarea--readonly',
     readonly && hideReadonlyIcon && 'tl-textarea--hide-readonly-icon',


### PR DESCRIPTION
## **Describe pull-request**

Removes the `--label-outside` modifier from `tl-dropdown`, `tl-text-field`, and `tl-textarea` components and makes label-outside the default behavior. This simplifies the API by eliminating an unnecessary modifier since label-outside is the most common use case. Already used in datetime component

**Changes:**
- Removed `--label-outside` CSS class from SCSS files
- Updated Storybook stories and controls to reflect "Outside" as default
- Maintains consistency with `tl-datetime` which already works this way

## **Issue Linking:**

**Jira:** [CDEP-1910](https://jira.scania.com/browse/CDEP-1910)

## **How to test**

1. Go to Preview → Tegel Lite → Dropdown/Text Field/Textarea
2. Confirm "Outside" is default and label appears outside input
3. Check HTML has NO `--label-outside` class