### PR TITLE
fix(tl-link): fix font rules and focus state

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-link/_tl-link-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-link/_tl-link-vars.scss
@@ -6,6 +6,7 @@
   --link-focus-outline-width: 2px;
   --link-visited: var(--color-foreground-text-accent-visited);
   --link-disabled: var(--color-foreground-text-disabled);
+  --link-focus-outline-color: var(--color-foreground-border-accent-focus);
 }
 
 .tl-banner .tl-link {

--- a/packages/core/src/tegel-lite/components/tl-link/tl-link.scss
+++ b/packages/core/src/tegel-lite/components/tl-link/tl-link.scss
@@ -2,6 +2,10 @@
 @use '../../../mixins/focus-state' as *;
 @use './tl-link-vars' as *;
 
+.tl-link-text {
+  @include detail-02;
+}
+
 .tl-link {
   display: inline-flex;
   color: var(--link);
@@ -15,9 +19,8 @@
   font: inherit;
 
   &:focus-visible {
-    @include tds-focus-state;
-
-    outline-width: var(--link-focus-outline-width);
+    outline: var(--link-focus-outline-width) solid var(--link-focus-outline-color);
+    outline-offset: 1px;
     text-decoration: none;
   }
 

--- a/packages/core/src/tegel-lite/components/tl-link/tl-link.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-link/tl-link.stories.tsx
@@ -1,6 +1,13 @@
 import formatHtmlPreview from '../../../stories/formatHtmlPreview';
 import { iconsNames } from '../../../components/icon/iconsArray';
 
+//Reorder of iconsNames to have download and redirect first for UX reasons
+const orderedIconsNames = [...iconsNames].sort((a, b) => {
+  if (a === 'download' || a === 'placeholder') return -1;
+  if (b === 'download' || b === 'placeholder') return 1;
+  return 0;
+});
+
 export default {
   title: 'Tegel Lite (CSS)/Link',
   parameters: {
@@ -14,7 +21,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: false },
+        defaultValue: { summary: true },
       },
     },
     disabled: {
@@ -27,49 +34,27 @@ export default {
         defaultValue: { summary: false },
       },
     },
-    standalone: {
-      name: 'Standalone',
-      description: 'Makes the link standalone with different typography.',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: false },
-      },
-    },
-    icon: {
-      name: 'Icon',
-      description: 'Sets icon to be displayed on the Link.',
-      control: {
-        type: 'select',
-      },
-      options: iconsNames,
-      table: {
-        defaultValue: { summary: 'placeholder' },
-      },
-    },
   },
   args: {
-    underline: false,
+    underline: true,
     disabled: false,
-    standalone: false,
-    icon: 'placeholder',
   },
 };
 
-const LinkTemplate = ({ underline, disabled, standalone, icon }) => {
+//Standalone Link
+const standaloneLinkTemplate = ({ disabled, underline, iconEnabled, icon }) => {
   const underlineClass = underline ? 'tl-link--underline' : '';
   const disabledClass = disabled ? 'tl-link--disabled' : '';
-  const standaloneClass = standalone ? 'tl-link--standalone' : '';
 
   return formatHtmlPreview(`
     <!-- Required stylesheet 
       "@scania/tegel-lite/tl-link.css"
+      ${iconEnabled ? '"@scania/tegel-lite/tl-icon.css"' : ''}
     -->
-    <a href="https://tegel.scania.com" target="_blank" class="tl-link ${standaloneClass} ${underlineClass} ${disabledClass}">
+    <a href="https://tegel.scania.com" target="_blank" class="tl-link tl-link--standalone ${underlineClass} ${disabledClass}">
       Tegel
       ${
-        icon
+        iconEnabled && icon
           ? `<span class="tl-link__icon"><span class="tl-icon tl-icon--${icon} tl-icon--16" aria-hidden="true"></span></span>`
           : ''
       }
@@ -77,10 +62,60 @@ const LinkTemplate = ({ underline, disabled, standalone, icon }) => {
   `);
 };
 
-export const Default = LinkTemplate.bind({});
-Default.args = {
+//Link within text
+const linkWithinTextTemplate = ({ disabled, underline }) => {
+  const underlineClass = underline ? 'tl-link--underline' : '';
+  const disabledClass = disabled ? 'tl-link--disabled' : '';
+
+  return formatHtmlPreview(`
+    <!-- Required stylesheet 
+      "@scania/tegel-lite/tl-link.css"
+    -->
+    <p class="tl-link-text">The 
+      <a href="https://tegel.scania.com" target="_blank" class="tl-link ${underlineClass} ${disabledClass}">Tegel</a> 
+      Design System is for digital products and services at Scania.
+      It enables an efficient development process and ensures a premium experience across all of Scania's digital touchpoints.    
+    </p>
+  `);
+};
+
+export const StandaloneLink = standaloneLinkTemplate.bind({});
+StandaloneLink.args = {
   underline: false,
   disabled: false,
-  standalone: false,
+  iconEnabled: true,
   icon: 'placeholder',
+};
+
+// Additional argTypes for Standalone Link only
+StandaloneLink.argTypes = {
+  iconEnabled: {
+    name: 'Icon Enabled',
+    description: 'Toggle to enable or disable the icon as suffix.',
+    control: {
+      type: 'boolean',
+    },
+    table: {
+      defaultValue: { summary: false },
+    },
+  },
+  icon: {
+    name: 'Icon',
+    description:
+      'Sets icon to be displayed on the Link. Proposed icons are <code>download</code> and <code>redirect</code>.',
+    control: {
+      type: 'select',
+    },
+    options: orderedIconsNames,
+    table: {
+      defaultValue: { summary: 'placeholder' },
+    },
+    if: { arg: 'iconEnabled', truthy: true },
+  },
+};
+
+export const LinkWithinText = linkWithinTextTemplate.bind({});
+LinkWithinText.args = {
+  underline: true,
+  disabled: false,
 };


### PR DESCRIPTION
## **Describe pull-request**  
This PR fixes the following issues in Tegel Lite link component: 

- Add correct fonts for Scania and Traton.
- Add a true/false condition for icon
- Add another story example to display the default & standalone link separately. 

Bonus not in the original ticket:
- Updated focus states to correct colors and border width 

## **Issue Linking:**  
 [CDEP-1899](https://jira.scania.com/browse/CDEP-1899)

## **How to test**  
1. Go to the preview link and navigate to tegel lite -> link
2. Check that the font-family updates with the Scania/Traton switch (previously there was only scania fonts.)
3. Check that there is a control for icon (this is in the standalone story)
4. Check that there are now two separate story files for link within a text and standalone link
5. Check that the focus states align with figma

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
