### PR TITLE
fix(tl-stepper): update font size for label & step digit

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-stepper/tl-step.scss
+++ b/packages/core/src/tegel-lite/components/tl-stepper/tl-step.scss
@@ -226,6 +226,7 @@
   .tl-stepper--lg .tl-stepper__content & {
     height: 30px;
     min-width: 30px;
+    font-size: 14px;
   }
 
   .tl-stepper--sm .tl-stepper__content & {
@@ -247,6 +248,8 @@
 
   .tl-stepper--lg & {
     @include detail-01;
+
+    font-size: 14px;
   }
 
   .tl-stepper--sm & {


### PR DESCRIPTION
## **Describe pull-request**  
This PR changes the font size of the stepper label and digit in large variant from 16 px -> 14 px.

## **Issue Linking:**  
- **Jira:** [CDEP-1912](https://jira.scania.com/browse/CDEP-1912)

## **How to test**  
1. Go to [preview link](https://pr-1653.d3fazya28914g3.amplifyapp.com/)
2. Open up the stepper component in tegel lite
3. Make sure that the font size of the label and digit in inside the bubble is 14 px by inspecting the elements.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
