### PR TITLE
fix(tl-popover-menu): ensure typography styles are not overwritten

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-popover-menu/tl-popover-menu.scss
+++ b/packages/core/src/tegel-lite/components/tl-popover-menu/tl-popover-menu.scss
@@ -11,8 +11,6 @@
 }
 
 .tl-popover-menu__item {
-  @include detail-02;
-
   all: unset;
   width: 100%;
   display: flex;
@@ -22,6 +20,7 @@
   color: var(--popover-menu-text);
   position: relative;
   transition: background-color var(--tds-motion-duration-fast-02) var(--tds-motion-easing-easy);
+  @include detail-02;
 
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
## **Describe pull-request**  
Fixed an issue where the TRATON typography in the Tegel Lite Popover Menu was overridden by all: unset by applying the typography mixin after the reset to ensure the correct font is displayed.

## **Issue Linking:**  
- **Jira:** [CDEP-1906](https://jira.scania.com/browse/CDEP-1906)

## **How to test**  
1. Go to [preview link](https://pr-1654.d3fazya28914g3.amplifyapp.com/)
2. Open up the popover menu component in tegel lite.
3. Make sure that the TRATON typography is now being used by inspecting the "tl-popover-menu__item" element. The font should be "TRATON Type Text, verdana"

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
