### PR TITLE
fix(tl-breadcrumbs): focus state

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-breadcrumbs/_tl-breadcrumbs-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-breadcrumbs/_tl-breadcrumbs-vars.scss
@@ -9,4 +9,8 @@
   --breadcrumb-separator-margin: 4px;
   --breadcrumb-separator-width: 4px;
   --breadcrumb-separator-height: 8px;
+
+  // Focus
+  --breadcrumb-focus-outline-color: var(--color-foreground-border-accent-focus);
+  --breadcrumb-focus-outline-width: 2px;
 }

--- a/packages/core/src/tegel-lite/components/tl-breadcrumbs/tl-breadcrumbs.scss
+++ b/packages/core/src/tegel-lite/components/tl-breadcrumbs/tl-breadcrumbs.scss
@@ -49,7 +49,7 @@
     }
 
     &:focus-visible {
-      @include tds-focus-state;
+      outline: var(--breadcrumb-focus-outline-width) solid var(--breadcrumb-focus-outline-color);
     }
 
     &[aria-current='page'] {


### PR DESCRIPTION
## **Describe pull-request**  
This PR updates the focus state of the tegel lite breadcrumbs component. The focus state is now implemented using variables and should align with the [Traton UI figma. ](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=26408-59510&p=f&m=dev)

## **Issue Linking:**  
[CDEP-1905](https://jira.scania.com/browse/CDEP-1905)

## **How to test**  
1. Go to the preview link and navigate to tegel lite -> breadcrumbs
2. Check focus state, it should now have the correct colors and width for both Scania and Traton
3. Check dark/light mode
4. Compare to [Figma](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=26408-59510&p=f&m=dev)
5. Look at the link components focus state in figma to see all correct colors

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
