### PR TITLE
fix(tl-radiobutton): add border in disabled state

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-radio-button/_tl-radio-button-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-radio-button/_tl-radio-button-vars.scss
@@ -6,6 +6,7 @@
   --radio-button-border: var(--color-foreground-border-strong);
   --radio-button-label: var(--color-foreground-text-strong);
   --radio-button-label-disabled: var(--color-foreground-text-disabled);
+  --radio-button-border-disabled: var(--color-foreground-border-discrete);
 
   // Active (checked)
   --radio-button-focus: var(--color-foreground-border-accent-focus);

--- a/packages/core/src/tegel-lite/components/tl-radio-button/tl-radio-button.scss
+++ b/packages/core/src/tegel-lite/components/tl-radio-button/tl-radio-button.scss
@@ -100,7 +100,7 @@
 
     &::after {
       background-color: var(--radio-button-background-disabled);
-      border-color: var(--radio-button-background-disabled);
+      border: 1px solid var(--radio-button-border-disabled);
       outline: none;
     }
 


### PR DESCRIPTION
## **Describe pull-request**  
The Tegel Lite Radiobutton was missing a border in disabled state.

## **Issue Linking:**  
 [CDEP-1907](https://jira.scania.com/browse/CDEP-1907)

## **How to test**  
1. Go to preview link and navigate to Tegel Lite -> Radiobutton
2. Check that the input has a border in disabled state
3. Check both Scania/Traton in dark/light mode and compare to [figma](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/branch/O6kWF0NHTa64KfOWltlehj/TRATON-Component-Library?node-id=3799-61364&m=dev)

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
Before:
<img width="168" height="82" alt="Screenshot 2026-01-21 at 15 06 47" src="https://github.com/user-attachments/assets/58490c9c-e67a-4d8c-82aa-8300bbfcfbc4" />

After:
<img width="185" height="98" alt="Screenshot 2026-01-21 at 15 06 21" src="https://github.com/user-attachments/assets/ac17be84-2a4d-45c3-bd17-ac5a212906a8" />


