### PR TITLE
fix(tl-text-field, tl-textarea): reordered disabled & read-only controls in storybook

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.stories.tsx
@@ -76,10 +76,6 @@ export default {
       name: 'No minimum width',
       control: { type: 'boolean' },
     },
-    disabled: {
-      name: 'Disabled',
-      control: { type: 'boolean' },
-    },
     readonly: {
       name: 'Read only',
       control: { type: 'boolean' },
@@ -88,6 +84,10 @@ export default {
       name: 'Hide read only icon',
       control: { type: 'boolean' },
       if: { arg: 'readonly', eq: true },
+    },
+    disabled: {
+      name: 'Disabled',
+      control: { type: 'boolean' },
     },
   },
   args: {
@@ -106,9 +106,9 @@ export default {
     charCounter: false,
     maxLength: 12,
     noMinWidth: false,
-    disabled: false,
     readonly: false,
     hideReadonlyIcon: false,
+    disabled: false,
   },
 };
 
@@ -128,9 +128,9 @@ const Template = ({
   charCounter,
   maxLength,
   noMinWidth,
-  disabled,
   readonly,
   hideReadonlyIcon,
+  disabled,
 }) => {
   const componentClasses = [
     'tl-text-field',

--- a/packages/core/src/tegel-lite/components/tl-textarea/tl-textarea.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-textarea/tl-textarea.stories.tsx
@@ -62,12 +62,6 @@ export default {
       control: { type: 'boolean' },
       description: 'Remove minimum width constraint',
     },
-
-    disabled: {
-      name: 'Disabled',
-      control: { type: 'boolean' },
-      description: 'Disable the textarea',
-    },
     readonly: {
       name: 'Read Only',
       control: { type: 'boolean' },
@@ -80,24 +74,26 @@ export default {
       if: { arg: 'readonly', eq: true },
       description: 'Hide the read-only indicator icon',
     },
+    disabled: {
+      name: 'Disabled',
+      control: { type: 'boolean' },
+      description: 'Disable the textarea',
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
     state: 'Default',
-
     label: 'Label',
     labelPosition: 'Outside',
     placeholder: 'Placeholder',
     helper: '',
-
     rows: 5,
     charCounter: false,
     maxLength: 12,
     noMinWidth: false,
-
-    disabled: false,
     readonly: false,
     hideReadonlyIcon: false,
+    disabled: false,
   },
 };
 


### PR DESCRIPTION
## **Describe pull-request**  
This PR reorders the read-only and disabled controls in storybook to be consistent with the web components.

## **Issue Linking:**  
- **Jira:** [CDEP-1915](https://jira.scania.com/browse/CDEP-1915)

## **How to test**  
1. Go to [preview link](https://pr-1661.d3fazya28914g3.amplifyapp.com/)
2. Open up textfield
3. Make sure that read-only control is shown before disabled. (disabled control should be last in order)
4. Check the same for textarea

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
