### PR TITLE
fix(tl-text-field, tl-textarea): display error color for char counter

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.scss
+++ b/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.scss
@@ -347,7 +347,11 @@
   }
 
   .tl-text-field--error:not(.tl-text-field--readonly):not(.tl-text-field--disabled) & {
-    display: none;
+    color: var(--text-field-error);
+
+    .tl-text-field__charcounter-divider {
+      color: var(--text-field-error);
+    }
   }
 }
 

--- a/packages/core/src/tegel-lite/components/tl-textarea/tl-textarea.scss
+++ b/packages/core/src/tegel-lite/components/tl-textarea/tl-textarea.scss
@@ -271,7 +271,11 @@
   }
 
   .tl-textarea--error:not(.tl-textarea--readonly):not(.tl-textarea--disabled) & {
-    display: none;
+    color: var(--textarea-error);
+
+    .tl-textarea__charcounter-divider {
+      color: var(--textarea-error);
+    }
   }
 }
 


### PR DESCRIPTION
## **Describe pull-request**  
This PR introduces a fix that showcases the char counter in error color(red) when the textfield/textarea is in error state.

## **Issue Linking:**  
- **Jira:** [CDEP-1916](https://jira.scania.com/browse/CDEP-1916)

## **How to test**  
1. Go to [preview link](https://pr-1663.d3fazya28914g3.amplifyapp.com/)
2. Open up textfield
3. Set state to error via storybook control
4. Set char counter to true. It should display the char counter in red color
5. Repeat the test for textarea

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
