### PR TITLE
style(tl-tooltip): added missing font for the component

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-tooltip/_tl-tooltip-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-tooltip/_tl-tooltip-vars.scss
@@ -2,3 +2,11 @@
   --tooltip-text: var(--color-foreground-text-inverse-strong);
   --tooltip-background: var(--color-background-inverse-layer-03);
 }
+
+.scania {
+  --tl-tooltip-line-height: 17px;
+}
+
+.traton {
+  --tl-tooltip-line-height: 16px;
+}

--- a/packages/core/src/tegel-lite/components/tl-tooltip/tl-tooltip.scss
+++ b/packages/core/src/tegel-lite/components/tl-tooltip/tl-tooltip.scss
@@ -6,6 +6,7 @@
 
   position: relative;
   display: inline-block;
+  line-height: var(--tl-tooltip-line-height);
 }
 
 .tl-tooltip__popup {


### PR DESCRIPTION
## **Describe pull-request**  
The tegel lite tooltip was missing font for TRATON. This PR adds it!

## **Issue Linking:**  
- **Jira:** [CDEP-1920](https://jira.scania.com/browse/CDEP-1920)

## **How to test**  
1. Go to preview link and open up tegel lite tooltip component
2. Switch to TRATON theme
3. Inspect element of tooltip and make sure that the font is "TRATON Type Text" and that the font size is 12 px with 17px as line height.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
