### PR TITLE
fix: use error icon for tl-text-field and tl-textarea help text

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.scss
+++ b/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.scss
@@ -312,7 +312,7 @@
       width: 16px;
       height: 16px;
       background-color: var(--text-field-error);
-      mask-image: var(--icon-info-svg);
+      mask-image: var(--icon-error-svg);
       mask-size: contain;
       mask-repeat: no-repeat;
       mask-position: center;

--- a/packages/core/src/tegel-lite/components/tl-textarea/tl-textarea.scss
+++ b/packages/core/src/tegel-lite/components/tl-textarea/tl-textarea.scss
@@ -236,7 +236,7 @@
       width: 16px;
       height: 16px;
       background-color: var(--textarea-error);
-      mask-image: var(--icon-info-svg);
+      mask-image: var(--icon-error-svg);
       mask-size: contain;
       mask-repeat: no-repeat;
       mask-position: center;


### PR DESCRIPTION
## **Describe pull-request**  
Fix incorrect icon in TextField and Textarea error help text. The components were displaying an info icon (`var(--icon-info-svg)`) instead of the error icon (`var(--icon-error-svg)`) when showing error state help text.

## **How to test**  
1. Go to preview link > Tegel Lite (CSS) > Text Field
2. Enable "Error" toggle to set error state
3. Verify that the help text icon shows an error icon (circle with exclamation mark) instead of an info icon (circle with "i")
4. Go to Textarea and repeat
