### PR TITLE
refactor(tl-spinner): simplify structure from 3 to 2 elements

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-spinner/tl-spinner.scss
+++ b/packages/core/src/tegel-lite/components/tl-spinner/tl-spinner.scss
@@ -5,6 +5,9 @@
   @include tds-box-sizing;
 
   display: block;
+  width: calc(var(--tl-spinner-radius) * 2);
+  height: calc(var(--tl-spinner-radius) * 2);
+  transform: scale(-1, 1) rotate(-90deg);
 
   &--xs {
     --tl-spinner-radius: var(--tl-spinner-radius-xs);
@@ -37,13 +40,6 @@
   &--inverted {
     stroke: var(--tl-spinner-background-inverted);
   }
-}
-
-.tl-spinner__svg {
-  display: block;
-  width: calc(var(--tl-spinner-radius) * 2);
-  height: calc(var(--tl-spinner-radius) * 2);
-  transform: scale(-1, 1) rotate(-90deg);
 }
 
 .tl-spinner__circle {

--- a/packages/core/src/tegel-lite/components/tl-spinner/tl-spinner.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-spinner/tl-spinner.stories.tsx
@@ -59,11 +59,9 @@ const Template = ({ size, variant }) => {
       }
     </style>
     <div class="demo-wrapper">
-      <div class="tl-spinner ${sizeClass} ${variantClass}">
-        <svg class="tl-spinner__svg">
-          <circle class="tl-spinner__circle"/>
-        </svg>
-      </div>
+      <svg class="tl-spinner ${sizeClass} ${variantClass}">
+        <circle class="tl-spinner__circle"/>
+      </svg>
     </div>
   `);
 };

--- a/packages/tegel-lite/package.json
+++ b/packages/tegel-lite/package.json
@@ -58,7 +58,8 @@
     "./tl-popover-menu.css": "./dist/tl-popover-menu.css",
     "./tl-side-menu.css": "./dist/tl-side-menu.css",
     "./tl-footer.css": "./dist/tl-footer.css",
-    "./tl-slider.css": "./dist/tl-slider.css"
+    "./tl-slider.css": "./dist/tl-slider.css",
+    "./tl-radiobutton.css": "./dist/tl-radiobutton.css"
   },
   "files": [
     "dist/"


### PR DESCRIPTION
## **Describe pull-request**  
This PR simplifies the `tl-spinner` component structure by removing an unnecessary wrapper element. The spinner now uses the SVG element directly as the root component, reducing the markup from 3 elements to 2 elements while maintaining all functionality.

**Before:**
```html
<div class="tl-spinner tl-spinner--lg tl-spinner--default">
  <svg class="tl-spinner__svg">
    <circle class="tl-spinner__circle"></circle>
  </svg>
</div>

**After:**
```html
<svg class="tl-spinner tl-spinner--lg tl-spinner--default">
  <circle class="tl-spinner__circle"></circle>
</svg>

## **How to test**  
1. Go to preview link and navigate to Tegel Lite (CSS) → Spinner
2. Check that all size variants (xs, sm, md, lg) render correctly
3. Check that both color variants (default, inverted) display properly