### PR TITLE
fix(tl-message): add vars file and correct color variables

### DIFF
--- a/packages/core/src/components/message/message-vars.scss
+++ b/packages/core/src/components/message/message-vars.scss
@@ -1,5 +1,4 @@
 /* Component variables */
-.tl-message,
 tds-message {
   --message-main-background: var(--color-background-layer-03);
   --message-mode-primary-background: var(--color-background-layer-03);

--- a/packages/core/src/tegel-lite/components/tl-message/_tl-message-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-message/_tl-message-vars.scss
@@ -1,0 +1,24 @@
+.tl-message {
+  --message-main-background: var(--color-background-layer-01);
+  --message-mode-primary-background: var(--color-background-layer-01);
+  --message-mode-secondary-background: var(--color-background-layer-02);
+  --message-main-text-color: var(--color-foreground-text-strong);
+
+  /* Info */
+  --message-info-border-color: var(--color-system-info-subtle);
+  --message-info-icon-color: var(--color-system-info-default);
+
+  /* Success */
+  --message-success-border-color: var(--color-system-success-subtle);
+  --message-success-icon-color: var(--color-system-success-default);
+
+  /* Error */
+  --message-error-background: var(--color-system-danger-discrete);
+  --message-error-border-color: var(--color-system-danger-subtle);
+  --message-error-icon-color: var(--color-system-danger-default);
+  --message-error-header-text-color: var(--color-system-danger-default);
+
+  /* Warning */
+  --message-warning-border-color: var(--color-system-warning-subtle);
+  --message-warning-icon-color: var(--color-system-warning-default);
+}

--- a/packages/core/src/tegel-lite/components/tl-message/tl-message.scss
+++ b/packages/core/src/tegel-lite/components/tl-message/tl-message.scss
@@ -1,4 +1,5 @@
 @use '../../../../../../typography/mixins/type-styles' as *;
+@use './tl-message-vars' as *;
 
 .tl-message {
   &--primary {


### PR DESCRIPTION
## **Describe pull-request**  
This PR adds the correct color variable for the icons and background of the Tegel Lite message component. The component was also missing its own vars file, that is now also added in this PR.

## **Issue Linking:**  
[CDEP-1879](https://jira.scania.com/browse/CDEP-1879)
[CDEP-1880](https://jira.scania.com/browse/CDEP-1880)

## **How to test**  
1. Go to the preview link and navigate to Tegel Lite -> Message component
2. Inspect the color of the icon and the background color of the component and confirm that it matches [figma](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=13906-11814&m=dev)
3. Check specifically that the background color in primary mode (both dark/light, traton/scania) now matches figma.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
