### PR TITLE
refactor: remove wrapper requirement from tooltip component

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-tooltip/tl-tooltip.scss
+++ b/packages/core/src/tegel-lite/components/tl-tooltip/tl-tooltip.scss
@@ -4,13 +4,7 @@
 .tl-tooltip {
   @include detail-05;
 
-  position: relative;
-  display: inline-block;
-  line-height: var(--tl-tooltip-line-height);
-}
-
-.tl-tooltip__popup {
-  position: absolute;
+  position: fixed;
   z-index: var(--tds-z-index-tooltip, 1000);
   padding: 8px;
   max-width: 204px;
@@ -20,10 +14,12 @@
   background-color: var(--tooltip-background, #333);
   color: var(--tooltip-text, #fff);
   box-sizing: border-box;
+  line-height: var(--tl-tooltip-line-height);
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
   transition: opacity 0.2s ease, visibility 0.2s ease;
+  border-radius: 4px;
 
   &--visible {
     opacity: 1;
@@ -31,79 +27,36 @@
     pointer-events: auto;
   }
 
-  .tl-tooltip--bottom & {
-    top: calc(100% + var(--tl-tooltip-offset-distance, 8px));
-    left: 50%;
-    transform: translateX(-50%);
-    border-radius: 4px;
+  // Position modifiers - remove border-radius at corner pointing to trigger
+  &--top-start {
+    border-radius: 4px 4px 4px 0; // sharp corner at bottom-left
   }
 
-  .tl-tooltip--bottom-end & {
-    top: calc(100% + var(--tl-tooltip-offset-distance, 8px));
-    right: var(--tl-tooltip-offset-skidding, 0);
-    border-radius: 4px 0 4px 4px;
+  &--top-end {
+    border-radius: 4px 4px 0; // sharp corner at bottom-right
   }
 
-  .tl-tooltip--bottom-start & {
-    top: calc(100% + var(--tl-tooltip-offset-distance, 8px));
-    left: var(--tl-tooltip-offset-skidding, 0);
-    border-radius: 0 4px 4px;
+  &--bottom-start {
+    border-radius: 0 4px 4px; // sharp corner at top-left
   }
 
-  .tl-tooltip--left & {
-    right: calc(100% + var(--tl-tooltip-offset-distance, 8px));
-    top: 50%;
-    transform: translateY(-50%);
-    border-radius: 4px;
+  &--bottom-end {
+    border-radius: 4px 0 4px 4px; // sharp corner at top-right
   }
 
-  .tl-tooltip--left-end & {
-    right: calc(100% + var(--tl-tooltip-offset-distance, 8px));
-    bottom: 0;
-    border-radius: 4px 4px 0;
+  &--left-start {
+    border-radius: 4px 0 4px 4px; // sharp corner at top-right
   }
 
-  .tl-tooltip--left-start & {
-    right: calc(100% + var(--tl-tooltip-offset-distance, 8px));
-    top: 0;
-    border-radius: 4px 0 4px 4px;
+  &--left-end {
+    border-radius: 4px 4px 0; // sharp corner at bottom-right
   }
 
-  .tl-tooltip--right & {
-    left: calc(100% + var(--tl-tooltip-offset-distance, 8px));
-    top: 50%;
-    transform: translateY(-50%);
-    border-radius: 4px;
+  &--right-start {
+    border-radius: 0 4px 4px; // sharp corner at top-left
   }
 
-  .tl-tooltip--right-end & {
-    left: calc(100% + var(--tl-tooltip-offset-distance, 8px));
-    bottom: 0;
-    border-radius: 4px 4px 4px 0;
-  }
-
-  .tl-tooltip--right-start & {
-    left: calc(100% + var(--tl-tooltip-offset-distance, 8px));
-    top: 0;
-    border-radius: 0 4px 4px;
-  }
-
-  .tl-tooltip--top & {
-    bottom: calc(100% + var(--tl-tooltip-offset-distance, 8px));
-    left: 50%;
-    transform: translateX(-50%);
-    border-radius: 4px;
-  }
-
-  .tl-tooltip--top-end & {
-    bottom: calc(100% + var(--tl-tooltip-offset-distance, 8px));
-    right: var(--tl-tooltip-offset-skidding, 0);
-    border-radius: 4px 4px 0;
-  }
-
-  .tl-tooltip--top-start & {
-    bottom: calc(100% + var(--tl-tooltip-offset-distance, 8px));
-    left: var(--tl-tooltip-offset-skidding, 0);
-    border-radius: 4px 4px 4px 0;
+  &--right-end {
+    border-radius: 4px 4px 4px 0; // sharp corner at bottom-left
   }
 }


### PR DESCRIPTION
## **Describe pull-request**  
Refactors tooltip component to align with popup component pattern by removing the wrapper requirement.

## **How to test**  
1. Go to Preview Link → Tegel Lite (CSS) → Tooltip
2. Test all 12 position variants (top/bottom/left/right with center/start/end)
3. Verify positioning, border-radius corners, hover/click triggers, and scroll/resize behavior
4. Test with different trigger elements (button, link, icon)