### PR TITLE
refactor: split divider discrete variant into light and dark

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-divider/_tl-divider-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-divider/_tl-divider-vars.scss
@@ -1,5 +1,6 @@
 .tl-divider {
   --divider-background: var(--color-foreground-border-discrete);
   --divider-background-strong: var(--color-foreground-border-strong);
-  --divider-background-discrete: var(--color-foreground-border-discrete);
+  --divider-background-discrete-light: var(--color-foreground-border-discrete);
+  --divider-background-discrete-dark: var(--color-foreground-border-disabled);
 }

--- a/packages/core/src/tegel-lite/components/tl-divider/tl-divider.scss
+++ b/packages/core/src/tegel-lite/components/tl-divider/tl-divider.scss
@@ -10,8 +10,12 @@
     background-color: var(--divider-background-strong);
   }
 
-  &--discrete {
-    background-color: var(--divider-background-discrete);
+  &--discrete-light {
+    background-color: var(--divider-background-discrete-light);
+  }
+
+  &--discrete-dark {
+    background-color: var(--divider-background-discrete-dark);
   }
 
   &--horizontal {

--- a/packages/core/src/tegel-lite/components/tl-divider/tl-divider.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-divider/tl-divider.stories.tsx
@@ -12,9 +12,9 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Discrete', 'Expressive'],
+      options: ['Discrete Light', 'Discrete Dark', 'Expressive'],
       table: {
-        defaultValue: { summary: 'Discrete' },
+        defaultValue: { summary: 'Discrete Light' },
       },
     },
     orientation: {
@@ -46,7 +46,7 @@ export default {
     },
   },
   args: {
-    variant: 'Discrete',
+    variant: 'Discrete Light',
     orientation: 'Horizontal',
     width: 150,
     height: 150,
@@ -55,7 +55,12 @@ export default {
 
 const Template = ({ orientation, variant, width, height }) => {
   const orientationClass = orientation === 'Horizontal' ? 'horizontal' : 'vertical';
-  const variantClass = variant === 'Expressive' ? 'expressive' : 'discrete';
+  let variantClass = 'discrete-light';
+  if (variant === 'Expressive') {
+    variantClass = 'expressive';
+  } else if (variant === 'Discrete Dark') {
+    variantClass = 'discrete-dark';
+  }
   const style = orientation === 'Horizontal' ? `width: ${width}px;` : `height: ${height}px;`;
 
   return formatHtmlPreview(`


### PR DESCRIPTION
## **Describe pull-request**  
Split `divider--discrete` into `discrete-light` and `discrete-dark` to match Figma. The `discrete-light` variant maintains the same appearance as before, while `discrete-dark` uses the `border-disabled.

## **How to test**  
1. Go to Preview Link and navigate to the `tl-divider` component
2. Check the variant control - verify three options are available: "Discrete Light", "Discrete Dark", and "Expressive"
3. Compare with Figma in all themes and modes