### PR TITLE
fix(breadcrumbs): update color for separators

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-breadcrumbs/_tl-breadcrumbs-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-breadcrumbs/_tl-breadcrumbs-vars.scss
@@ -3,7 +3,7 @@
   --breadcrumb-label: var(--color-foreground-text-strong);
   --breadcrumb-hover: var(--color-foreground-text-strong);
   --breadcrumb-current: var(--color-foreground-text-subtle);
-  --breadcrumb-separator-color: var(--color-foreground-text-subtle);
+  --breadcrumb-separator-color: var(--color-foreground-text-strong);
 
   // Spacing
   --breadcrumb-separator-margin: 4px;


### PR DESCRIPTION
## **Describe pull-request**  
The Tegel Lite breadcrumbs component had the wrong color for the separator lines. 

## **Issue Linking:**  
 [CDEP-1877](https://jira.scania.com/browse/CDEP-1877)

## **How to test**  
1. Go to preview link and navigate to Tegel Lite -> Breadcrumbs
2. Check that the color of the separators align with [figma](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=26408-59510&p=f&m=dev)
3. Check dark/light mode and Scania/Traton theme

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
