### PR TITLE
fix: tl-datetime color issues across browsers 

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-datetime/_tl-datetime-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-datetime/_tl-datetime-vars.scss
@@ -11,10 +11,10 @@
   --datetime-background-disabled-primary: var(--color-background-layer-01);
   --datetime-background-disabled-secondary: var(--color-background-layer-02);
   --datetime-background-disabled: var(--datetime-background-disabled-primary);
-  --datetime-text-disabled: var(--color-foreground-text-subtle);
-  --datetime-placeholder-disabled: var(--color-foreground-text-subtle);
-  --datetime-label-disabled: var(--color-foreground-text-subtle);
-  --datetime-icon-disabled: var(--color-foreground-text-subtle);
+  --datetime-text-disabled: var(--color-foreground-text-disabled);
+  --datetime-placeholder-disabled: var(--color-foreground-text-disabled);
+  --datetime-label-disabled: var(--color-foreground-text-disabled);
+  --datetime-icon-disabled: var(--color-foreground-text-disabled);
 
   // Label
   --datetime-label: var(--color-foreground-text-strong);
@@ -51,6 +51,7 @@
   --datetime-box-shadow: 0 -1px 0 0 var(--color-foreground-border-soft);
   --datetime-box-shadow-hover: 0 -1px 0 0 var(--color-foreground-border-strong);
   --datetime-box-shadow-focus: 0 -2px 0 0 var(--color-foreground-border-accent-focus);
+  --datetime-box-shadow-disabled: none;
   --datetime-box-shadow-error: 0 -1px 0 0 var(--color-system-danger-default);
   --datetime-box-shadow-error-hover: 0 -1px 0 0 var(--color-system-danger-default);
   --datetime-box-shadow-error-focus: 0 -2px 0 0 var(--color-system-danger-default);
@@ -104,6 +105,7 @@
   --datetime-box-shadow: 0 0 0 1px var(--color-foreground-border-soft);
   --datetime-box-shadow-hover: 0 0 0 1px var(--color-foreground-border-strong);
   --datetime-box-shadow-focus: 0 0 0 2px var(--color-foreground-border-accent-focus);
+  --datetime-box-shadow-disabled: none;
   --datetime-box-shadow-error: 0 0 0 1px var(--color-system-danger-default);
   --datetime-box-shadow-error-hover: 0 0 0 1px var(--color-system-danger-default);
   --datetime-box-shadow-error-focus: 0 0 0 2px var(--color-system-danger-default);

--- a/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.scss
+++ b/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.scss
@@ -67,12 +67,17 @@
     height: 20px;
     mask-repeat: no-repeat;
     mask-position: center;
-    mask-size: contain;
+    mask-size: 20px 20px;
     background-color: var(--datetime-icon);
     pointer-events: none;
 
     /* Default: calendar icon for date/datetime inputs */
     mask-image: var(--icon-calendar-svg);
+
+    /* Firefox - hide our custom icon since Firefox shows its own */
+    @supports (-moz-appearance: none) {
+      display: none;
+    }
   }
 
   /* Change to clock icon for time input */
@@ -136,9 +141,47 @@
     color: var(--datetime-placeholder-focus);
   }
 
+  /* WebKit datetime fields */
+  &::-webkit-datetime-edit-text {
+    -webkit-text-fill-color: var(--datetime-text);
+  }
+
+  &::-webkit-datetime-edit-month-field {
+    -webkit-text-fill-color: var(--datetime-text);
+  }
+
+  &::-webkit-datetime-edit-day-field {
+    -webkit-text-fill-color: var(--datetime-text);
+  }
+
+  &::-webkit-datetime-edit-year-field {
+    -webkit-text-fill-color: var(--datetime-text);
+  }
+
+  &::-webkit-datetime-edit-hour-field {
+    -webkit-text-fill-color: var(--datetime-text);
+  }
+
+  &::-webkit-datetime-edit-minute-field {
+    -webkit-text-fill-color: var(--datetime-text);
+  }
+
+  &::-webkit-datetime-edit-second-field {
+    -webkit-text-fill-color: var(--datetime-text);
+  }
+
+  &::-webkit-datetime-edit-millisecond-field {
+    -webkit-text-fill-color: var(--datetime-text);
+  }
+
+  &::-webkit-datetime-edit-meridiem-field {
+    -webkit-text-fill-color: var(--datetime-text);
+  }
+
   &:disabled {
     background-color: var(--datetime-background-disabled);
     color: var(--datetime-text-disabled);
+    box-shadow: inset var(--datetime-box-shadow-disabled);
     cursor: not-allowed;
 
     &::placeholder {
@@ -147,6 +190,43 @@
 
     ~ .tl-datetime__label-inside {
       color: var(--datetime-label-disabled);
+    }
+
+    /* WebKit datetime fields - disabled state */
+    &::-webkit-datetime-edit-text {
+      -webkit-text-fill-color: var(--datetime-text-disabled);
+    }
+
+    &::-webkit-datetime-edit-month-field {
+      -webkit-text-fill-color: var(--datetime-text-disabled);
+    }
+
+    &::-webkit-datetime-edit-day-field {
+      -webkit-text-fill-color: var(--datetime-text-disabled);
+    }
+
+    &::-webkit-datetime-edit-year-field {
+      -webkit-text-fill-color: var(--datetime-text-disabled);
+    }
+
+    &::-webkit-datetime-edit-hour-field {
+      -webkit-text-fill-color: var(--datetime-text-disabled);
+    }
+
+    &::-webkit-datetime-edit-minute-field {
+      -webkit-text-fill-color: var(--datetime-text-disabled);
+    }
+
+    &::-webkit-datetime-edit-second-field {
+      -webkit-text-fill-color: var(--datetime-text-disabled);
+    }
+
+    &::-webkit-datetime-edit-millisecond-field {
+      -webkit-text-fill-color: var(--datetime-text-disabled);
+    }
+
+    &::-webkit-datetime-edit-meridiem-field {
+      -webkit-text-fill-color: var(--datetime-text-disabled);
     }
   }
 


### PR DESCRIPTION
## **Describe pull-request**

Fixes color inconsistencies in the `tl-datetime` component across browsers:
- Disabled state colors now use `--color-foreground-text-disabled` instead of `--color-foreground-text-subtle`
- WebKit datetime field text colors properly styled in Chrome/Safari/Edge
- Custom calendar/clock icons hidden in Firefox (uses native icons like web components)
- Removed border in disabled state

## **Issue Linking:**

- **Jira:** [CDEP-1935](https://jira.scania.com/browse/CDEP-1935)

## **How to test**

1. Go to preview link > Tegel Lite > tl-datetime
2. Test different input types: `date`, `datetime-local`, `time` (note: `month` and `week` only work in Chrome)
3. Verify disabled state colors are correct across all elements (text, label, icon, placeholder)
4. Test in Chrome/Safari/Edge: check that datetime field values display with correct colors
5. Test in Firefox: verify only native calendar/clock icons appear (no duplicates)