### PR TITLE
fix(tl-chip): fix background disabled

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-chip/_tl-chip-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-chip/_tl-chip-vars.scss
@@ -1,4 +1,5 @@
 .tl-chip {
+  // Chip-specific variables (used directly in component)
   --chip-text: var(--color-foreground-text-strong);
   --chip-text-active: var(--component-chip-foreground-inverse);
   --chip-background: var(--component-chip-color-default);
@@ -11,4 +12,64 @@
   --chip-background-focus: var(--component-chip-color-focused);
   --chip-border-radius: var(--component-chip-border-radius);
   --chip-focused-on-selected: var(--component-chip-color-focused-on-selected);
+
+  // Base component-chip variables (from tokens)
+  --component-chip-color-focused-on-selected: var(--color-system-info-subtle);
+  --component-chip-color-disabled: var(--color-background-surface-100);
+  --component-chip-color-focused: var(--color-background-layer-02);
+  --component-chip-color-hover: var(--color-background-surface-600);
+  --component-chip-color-selected: var(--color-brand-primary-400);
+  --component-chip-color-disabled-selected: var(--color-brand-primary-400);
+  --component-chip-color-hover-on-selected: var(--color-system-info-default);
+  --component-chip-color-default: var(--color-background-surface-200);
+  --component-chip-foreground-inverse: var(--color-foreground-text-inverse-strong);
+  --component-chip-foreground-foreground-disabled-selected: var(
+    --color-foreground-text-inverse-subtle
+  );
+  --component-chip-border-selected-focus-border: var(--color-system-info-default);
+}
+
+:root,
+.scania {
+  .tl-chip {
+    --component-chip-border-radius: 16px;
+  }
+
+  .tds-mode-light .tl-chip {
+    --component-chip-color-hover: var(--color-background-surface-300);
+    --component-chip-foreground-foreground-disabled-selected: var(
+      --color-foreground-text-inverse-subtle
+    );
+  }
+
+  .tds-mode-dark .tl-chip {
+    --component-chip-color-default: var(--color-background-surface-400);
+    --component-chip-color-focused-on-selected: var(--color-system-info-discrete);
+    --component-chip-color-hover-on-selected: var(--color-system-info-default);
+    --component-chip-foreground-foreground-disabled-selected: var(--color-foreground-text-subtle);
+    --component-chip-foreground-inverse: var(--color-foreground-text-strong);
+  }
+}
+
+.traton {
+  .tl-chip {
+    --component-chip-border-radius: 2px;
+  }
+
+  .tds-mode-light .tl-chip {
+    --component-chip-color-default: var(--color-background-surface-200);
+    --component-chip-color-selected: var(--color-background-surface-300);
+    --component-chip-color-hover-on-selected: var(--color-background-surface-400);
+    --component-chip-foreground-inverse: var(--color-foreground-text-strong);
+    --component-chip-color-focused-on-selected: var(--component-chip-color-focused);
+    --component-chip-foreground-foreground-disabled-selected: var(--color-background-surface-200);
+  }
+
+  .tds-mode-dark .tl-chip {
+    --component-chip-color-default: var(--color-background-surface-300);
+    --component-chip-color-disabled: var(--color-background-surface-200);
+    --component-chip-foreground-inverse: var(--color-foreground-text-inverse-strong);
+    --component-chip-color-focused-on-selected: var(--color-background-surface-700);
+    --component-chip-color-hover-on-selected: var(--color-background-surface-800);
+  }
 }

--- a/tokens/scss/component/chip.scss
+++ b/tokens/scss/component/chip.scss
@@ -2,7 +2,6 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.tl-chip,
 tds-chip {
   --component-chip-color-focused-on-selected: var(--color-system-info-discrete);
   --component-chip-color-disabled: var(--color-background-surface-400);
@@ -17,7 +16,6 @@ tds-chip {
   --component-chip-border-selected-focus-border: var(--color-system-info-default);
 }
 
-.tl-chip,
 tds-chip {
   --component-chip-color-focused-on-selected: var(--color-system-info-subtle);
   --component-chip-color-disabled: var(--color-background-surface-400);
@@ -37,12 +35,10 @@ tds-chip {
 
 :root,
 .scania {
-  .tl-chip,
   tds-chip {
     --component-chip-border-radius: 16px;
   }
 
-  .tds-mode-light .tl-chip,
   .tds-mode-light tds-chip {
     --component-chip-color-hover: var(--color-background-surface-300);
     --component-chip-foreground-foreground-disabled-selected: var(
@@ -50,7 +46,6 @@ tds-chip {
     );
   }
 
-  .tds-mode-dark .tl-chip,
   .tds-mode-dark tds-chip {
     --component-chip-color-default: var(--color-background-surface-400);
     --component-chip-color-focused-on-selected: var(--color-system-info-discrete);
@@ -61,12 +56,10 @@ tds-chip {
 }
 
 .traton {
-  .tl-chip,
   tds-chip {
     --component-chip-border-radius: 2px;
   }
 
-  .tds-mode-light .tl-chip,
   .tds-mode-light tds-chip {
     --component-chip-color-default: var(--color-background-surface-200);
     --component-chip-color-selected: var(--color-background-surface-300);
@@ -76,7 +69,6 @@ tds-chip {
     --component-chip-foreground-foreground-disabled-selected: var(--color-background-surface-200);
   }
 
-  .tds-mode-dark .tl-chip,
   .tds-mode-dark tds-chip {
     --component-chip-color-default: var(--color-background-surface-300);
     --component-chip-color-disabled: var(--color-background-surface-200);


### PR DESCRIPTION
## **Describe pull-request**  
The background of the Tegel Lite Chip in disbaled state for Traton was incorrect. This PR fixes that issue and also moves the variables needed from the web components vars file to the Tegel Lite Chip vars file (like other TL components).

## **Issue Linking:**  
 [CDEP-1878](https://jira.scania.com/browse/CDEP-1878)

## **How to test**  
1. Go to the preview link and navigate to Tegel Lite and the Chip component
2. Check the disabled state, specifically for Traton and compare it to [figma](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/TRATON-Component-Library?node-id=26478-63955&p=f&m=dev)

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events