### PR TITLE
fix(tl-radiobutton): fix focus outline width

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-radio-button/_tl-radio-button-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-radio-button/_tl-radio-button-vars.scss
@@ -15,4 +15,20 @@
   // Units
   --radio-button-spacing-4: var(--tds-spacing-element-4) 0 var(--tds-spacing-element-4)
     var(--tds-spacing-element-4);
+
+  // Focus outline
+  --radio-button-focus-outline-color: var(--color-foreground-border-accent-focus);
+  --radio-button-focus-outline-width: 2px;
+}
+
+.scania {
+  .tl-radio-button {
+    --radio-button-focus-outline-width: 2px;
+  }
+}
+
+.traton {
+  .tl-radio-button {
+    --radio-button-focus-outline-width: 4px;
+  }
 }

--- a/packages/core/src/tegel-lite/components/tl-radio-button/tl-radio-button.scss
+++ b/packages/core/src/tegel-lite/components/tl-radio-button/tl-radio-button.scss
@@ -66,7 +66,7 @@
     }
 
     &::after {
-      outline: 1px solid var(--tds-radio-button-interaction-outline);
+      outline: var(--radio-button-focus-outline-width) solid var(--radio-button-focus-outline-color);
     }
   }
 
@@ -80,13 +80,13 @@
   /* Checked + focus */
   &:checked:focus {
     &::after {
-      outline: 4px solid var(--radio-button-focus);
+      outline: var(--radio-button-focus-outline-width) solid var(--radio-button-focus-outline-color);
     }
   }
 
   /* Hover */
   .tl-radio-button:not(:has(:disabled)):hover &::after {
-    outline: 2px solid var(--radio-button-background-hover);
+    outline: var(--radio-button-focus-outline-width) solid var(--radio-button-background-hover);
   }
 
   /* Disabled */


### PR DESCRIPTION
## **Describe pull-request**  
The Tegel Lite Radio Button component implements the incorrect stroke width in focus state for the Scania version. The stroke width should be 2px for Scania and 4px (currently implemented) for TRATON. This PR fixes that.

## **Issue Linking:**  
[CDEP-1909](https://jira.scania.com/browse/CDEP-1909)

## **How to test**  
1. Go to preview link and navigate to Tegel Lite -> Radio button
2. Check focus state, inspect and confirm that it is 2px for Scania and 4px for Traton

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
