### PR TITLE
fix(tl-dropdown): remove box-shadow in dark mode

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-dropdown/tl-dropdown.scss
+++ b/packages/core/src/tegel-lite/components/tl-dropdown/tl-dropdown.scss
@@ -432,6 +432,10 @@
   transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s 0.2s;
   @include tl-scrollbar;
 
+  .tds-mode-dark & {
+    box-shadow: none;
+  }
+
   .tl-dropdown--dropup & {
     top: auto;
     bottom: 100%;


### PR DESCRIPTION
## **Describe pull-request**  
The Tegel Lite Dropdown component displays a box-shadow in dark mode. The box-shadow should be there in light mode, but not in dark mode.

## **Issue Linking:**  
[CDEP-1934](https://jira.scania.com/browse/CDEP-1934)

## **How to test**  
1. Go to preview link -> Tegel Lite Dropdown component
2. Verify that the box shadow exists in light mode but not in dark mode for both Scania and Traton. 

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
