### PR TITLE
fix(tl-table): fix font rules in pagination

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-table/_footer.scss
+++ b/packages/core/src/tegel-lite/components/tl-table/_footer.scss
@@ -60,6 +60,7 @@
 
 .tl-table__rows-per-page-label {
   margin-right: var(--tds-spacing-element-8);
+  font-family: var(--detail-02-font-family);
 }
 
 .tl-table__rows-per-page-select {
@@ -70,6 +71,7 @@
   border-radius: var(--tds-spacing-element-4);
   padding: 0 var(--tds-spacing-element-8);
   transition: background-color 250ms ease;
+  font-family: var(--detail-02-font-family);
 
   &:hover {
     background-color: var(--table-footer-page-selector-input-hover);
@@ -94,6 +96,7 @@
   height: 30px;
   border: none;
   transition: background-color 250ms ease;
+  font-family: var(--detail-02-font-family);
 
   &:hover {
     background-color: var(--table-footer-page-selector-input-hover);
@@ -110,6 +113,11 @@
 
 .tl-table__footer-text {
   padding: 1px 22px 0 0;
+  font-family: var(--detail-02-font-family);
+
+  span {
+    font-family: var(--detail-02-font-family);
+  }
 }
 
 .tl-table__footer-button {


### PR DESCRIPTION
## **Describe pull-request**  
This PR Implements the correct typography variables to enable the font to switch between the brands in the Tegel Lite Table Pagination.

## **Issue Linking:**  
[CDEP-1933](https://jira.scania.com/browse/CDEP-1933)

## **How to test**  
1. Go to the preview link and navigate to Tegel Lite -> Table -> Pagination
2. Check that the font-family switches to Scania/Traton fonts correctly for all texts and inputs in the pagination row.
3. Check dark/light mode

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
