### PR TITLE
fix(tl-text-field): fixed icon position missaligning when no label

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.scss
+++ b/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.scss
@@ -45,8 +45,10 @@
     z-index: 1;
   }
 
-  // Default behavior (label outside) - readonly icon position adjustment
-  &:not(&--label-inside)#{&}--readonly:not(&--disabled):not(&--hide-readonly-icon)::before {
+  // Default behavior (label outside) - readonly icon position adjustment (only when a label element exists)
+  &:has(.tl-text-field__label):not(&--label-inside)#{&}--readonly:not(&--disabled):not(
+  &--hide-readonly-icon
+)::before {
     top: calc(50% + 24px);
   }
 
@@ -371,9 +373,9 @@
     z-index: 1;
   }
 
-  // Default behavior (label outside) - prefix position adjustment
-  .tl-text-field:not(.tl-text-field--label-inside) &--text,
-  .tl-text-field:not(.tl-text-field--label-inside) &--icon {
+  // Default behavior (label outside) - prefix position adjustment (only when a label element exists)
+  .tl-text-field:has(.tl-text-field__label):not(.tl-text-field--label-inside) &--text,
+  .tl-text-field:has(.tl-text-field__label):not(.tl-text-field--label-inside) &--icon {
     transform: translateY(calc(-50% + 24px));
   }
 
@@ -407,9 +409,9 @@
     z-index: 1;
   }
 
-  // Default behavior (label outside) - suffix position adjustment
-  .tl-text-field:not(.tl-text-field--label-inside) &--text,
-  .tl-text-field:not(.tl-text-field--label-inside) &--icon {
+  // Default behavior (label outside) - suffix position adjustment (only when a label element exists)
+  .tl-text-field:has(.tl-text-field__label):not(.tl-text-field--label-inside) &--text,
+  .tl-text-field:has(.tl-text-field__label):not(.tl-text-field--label-inside) &--icon {
     transform: translateY(calc(-50% + 24px));
   }
 
@@ -435,9 +437,9 @@
   padding-right: 0;
   z-index: 1;
 
-  // Default behavior (label outside) - suffix position adjustment
-  .tl-text-field:not(.tl-text-field--label-inside) &--text,
-  .tl-text-field:not(.tl-text-field--label-inside) &--icon {
+  // Default behavior (label outside) - suffix position adjustment (only when a label element exists)
+  .tl-text-field:has(.tl-text-field__label):not(.tl-text-field--label-inside) &--text,
+  .tl-text-field:has(.tl-text-field__label):not(.tl-text-field--label-inside) &--icon {
     transform: translateY(calc(-50% + 24px));
   }
 


### PR DESCRIPTION
## **Describe pull-request**  
The issue in the tegel lite text field is that the icons(suffix, prefix, readonly) are not centered when there is no label. This PR fixes that issue.

## **Issue Linking:**  
- **Jira:** [CDEP-1930](https://jira.scania.com/browse/CDEP-1930)

## **How to test**  
1. Go to preview link
2. Open up the tegel lite text field component
3. Set label position --> "No label"
4. Now test and see if icons are centered in the middle of the component(they should not be outside the box). Test these options one at a time: Suffix, Prefix, Readonly.
5. And for each of the options above, try changing the size of the component between small, medium and large to see if there is any difference

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
