### PR TITLE
fix: add missing tab components to imports

### DIFF
--- a/packages/core/src/tegel-lite/components.scss
+++ b/packages/core/src/tegel-lite/components.scss
@@ -41,8 +41,11 @@
 @use './components/tl-stepper/tl-stepper';
 @use './components/tl-table/tl-table';
 @use './components/tl-tabs/tl-folder-tabs/tl-folder-tabs';
+@use './components/tl-tabs/tl-folder-tabs/tl-folder-tab';
 @use './components/tl-tabs/tl-inline-tabs/tl-inline-tabs';
+@use './components/tl-tabs/tl-inline-tabs/tl-inline-tab';
 @use './components/tl-tabs/tl-navigation-tabs/tl-navigation-tabs';
+@use './components/tl-tabs/tl-navigation-tabs/tl-navigation-tab';
 @use './components/tl-text-field/tl-text-field';
 @use './components/tl-textarea/tl-textarea';
 @use './components/tl-toast/tl-toast';


### PR DESCRIPTION
## **Describe pull-request**  
adds the missing "tab" imports to components.scss

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://jira.scania.com/browse/CDEP-)
- **GitHub:** Include issue link  
- **No issue:** Describe the problem being solved.  

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to...
2. Check in...
3. Run ...

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
