### PR TITLE
fix: exclude stories from the tegel-lite folder in story loading

### DIFF
--- a/packages/core/.storybook/main.ts
+++ b/packages/core/.storybook/main.ts
@@ -13,7 +13,9 @@ function loadStories() {
   // Otherwise, exclude stories from the _beta folder
   return process.env.VITE_STORYBOOK_ENV === 'dev'
     ? storyFiles
-    : storyFiles.filter((file: string | string[]) => !file.includes('/_beta/'));
+    : storyFiles.filter(
+        (file: string | string[]) => !file.includes('/_beta/') && !file.includes('/tegel-lite/'),
+      );
 }
 
 let addons = ['@vueless/storybook-dark-mode', '@storybook/addon-docs'];


### PR DESCRIPTION
## **Describe pull-request**  
exclude stories from the tegel-lite folder in story loading

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://jira.scania.com/browse/CDEP-)
- **GitHub:** Include issue link  
- **No issue:** Describe the problem being solved.  

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to...
2. Check in...
3. Run ...

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
