### PR TITLE
fix(sass): resolve Dart Sass deprecation

### DIFF
--- a/packages/core/src/mixins/_z-index.scss
+++ b/packages/core/src/mixins/_z-index.scss
@@ -1,7 +1,9 @@
 // source: https://www.smashingmagazine.com/2014/06/sassy-z-index-management-for-complex-layouts/
+@use 'sass:list';
+
 @function tds-z-index($element) {
   $z-index: default, dropdown, tab, header, banner, side-menu, overlay, modal, toast, tooltip;
-  $value: index($z-index, $element);
+  $value: list.index($z-index, $element);
 
   @if $value {
     @return ($value - 1) * 100;


### PR DESCRIPTION

- Add @use 'sass:list' import to use namespaced list module
- Replace index() with list.index() in tds-z-index() function
- Resolves deprecation warning for Dart Sass 3.0.0 compatibility

## **Describe pull-request**  
We are getting deprecation warnings when running `npm run build`. This PR fixes that. 

## **Issue Linking:**  
- **No issue:** 
<img width="932" height="185" alt="Screenshot 2026-02-09 at 08 38 51" src="https://github.com/user-attachments/assets/696cb7e6-dd45-4a0f-80f3-ce61d4611f79" />


## **How to test**  
Verify against develop with this branch and run `npm run build` or `npm run build:all`, there should be no warnings in command line