### PR TITLE
fix(tl-message): change element name to align with other components

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-message/tl-message.scss
+++ b/packages/core/src/tegel-lite/components/tl-message/tl-message.scss
@@ -83,7 +83,7 @@
   }
 }
 
-.tl-message__content {
+.tl-message__text {
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -103,7 +103,7 @@
   }
 }
 
-.tl-message__extended-message {
+.tl-message__subheader {
   @include detail-02;
 
   color: var(--message-main-text-color);

--- a/packages/core/src/tegel-lite/components/tl-message/tl-message.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-message/tl-message.stories.tsx
@@ -71,11 +71,11 @@ const Template = ({ modeVariant, messageVariant, minimal, noIcon }) => {
     <div class="demo-wrapper">
       <div class="tl-message ${modeClass} ${variantClass} ${minimalClass} ${noIconClass}">
         <div class="tl-message__wrapper">
-          <div class="tl-message__content">
+          <div class="tl-message__text">
             <div class="tl-message__header">Message header</div>
             ${
               !minimal
-                ? `<div class="tl-message__extended-message">Longer Message text can be placed here. Longer Message text can be placed here.</div>`
+                ? `<div class="tl-message__subheader">Longer Message text can be placed here. Longer Message text can be placed here.</div>`
                 : ''
             }
           </div>

--- a/packages/tegel-lite/tests/tl-message/index.html
+++ b/packages/tegel-lite/tests/tl-message/index.html
@@ -23,7 +23,7 @@
           <div class="tl-message__wrapper tl-message__wrapper--information">
             <div class="tl-message__content">
               <div class="tl-message__header">Message header</div>
-              <div class="tl-message__extended-message">
+              <div class="tl-message__subheader">
                 Longer Message text can be placed here. Longer Message text can be placed here.
               </div>
             </div>
@@ -34,7 +34,7 @@
           <div class="tl-message__wrapper tl-message__wrapper--error">
             <div class="tl-message__content">
               <div class="tl-message__header">Message header</div>
-              <div class="tl-message__extended-message">
+              <div class="tl-message__subheader">
                 Longer Message text can be placed here. Longer Message text can be placed here.
               </div>
             </div>
@@ -45,7 +45,7 @@
           <div class="tl-message__wrapper tl-message__wrapper--warning">
             <div class="tl-message__content">
               <div class="tl-message__header">Message header</div>
-              <div class="tl-message__extended-message">
+              <div class="tl-message__subheader">
                 Longer Message text can be placed here. Longer Message text can be placed here.
               </div>
             </div>
@@ -56,7 +56,7 @@
           <div class="tl-message__wrapper tl-message__wrapper--success">
             <div class="tl-message__content">
               <div class="tl-message__header">Message header</div>
-              <div class="tl-message__extended-message">
+              <div class="tl-message__subheader">
                 Longer Message text can be placed here. Longer Message text can be placed here.
               </div>
             </div>
@@ -72,7 +72,7 @@
           <div class="tl-message__wrapper tl-message__wrapper--information">
             <div class="tl-message__content">
               <div class="tl-message__header">Message header</div>
-              <div class="tl-message__extended-message">
+              <div class="tl-message__subheader">
                 Longer Message text can be placed here. Longer Message text can be placed here.
               </div>
             </div>
@@ -83,7 +83,7 @@
           <div class="tl-message__wrapper tl-message__wrapper--error">
             <div class="tl-message__content">
               <div class="tl-message__header">Message header</div>
-              <div class="tl-message__extended-message">
+              <div class="tl-message__subheader">
                 Longer Message text can be placed here. Longer Message text can be placed here.
               </div>
             </div>
@@ -94,7 +94,7 @@
           <div class="tl-message__wrapper tl-message__wrapper--warning">
             <div class="tl-message__content">
               <div class="tl-message__header">Message header</div>
-              <div class="tl-message__extended-message">
+              <div class="tl-message__subheader">
                 Longer Message text can be placed here. Longer Message text can be placed here.
               </div>
             </div>
@@ -105,7 +105,7 @@
           <div class="tl-message__wrapper tl-message__wrapper--success">
             <div class="tl-message__content">
               <div class="tl-message__header">Message header</div>
-              <div class="tl-message__extended-message">
+              <div class="tl-message__subheader">
                 Longer Message text can be placed here. Longer Message text can be placed here.
               </div>
             </div>


### PR DESCRIPTION
## **Describe pull-request**  
This PR changes the element naming to align with other similar components like toast and banner.

## **Issue Linking:**  
[CDEP-1842](https://jira.scania.com/browse/CDEP-1842)

## **How to test**  
1. Go to the preview link and navigate to Tegel Lite -> Message
2. Confirm that the element classname wrapping the texts is now "tl-message__text"
3. Confirm that the text under header now has the element class "tl-message__subheader"

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events