### PR TITLE
fix(tl-header): update active background color for dropdown and item components

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-header/_dropdown.scss
+++ b/packages/core/src/tegel-lite/components/tl-header/_dropdown.scss
@@ -30,7 +30,7 @@
   }
 
   &:active {
-    background-color: var(--component-header-color-background-pressed);
+    background-color: var(--header-basic-element-background-selected);
     box-shadow: inset 0 0 0 2px var(--color-foreground-border-accent-focus);
   }
 
@@ -81,7 +81,7 @@
   }
 
   &:active {
-    background-color: var(--component-header-color-background-pressed);
+    background-color: var(--header-basic-element-background-selected);
     box-shadow: inset 0 0 0 2px var(--color-foreground-border-accent-focus);
   }
 

--- a/packages/core/src/tegel-lite/components/tl-header/_item.scss
+++ b/packages/core/src/tegel-lite/components/tl-header/_item.scss
@@ -34,7 +34,7 @@
   &:active {
     padding-top: 2px;
     padding-bottom: 2px;
-    background-color: var(--component-header-color-background-pressed);
+    background-color: var(--header-basic-element-background-selected);
     box-shadow: inset 0 0 0 2px var(--header-nav-item-border-pressed);
   }
 }


### PR DESCRIPTION
## **Describe pull-request**  
The pressed color for dropdown and items in header were wrong, they are now fixed with correct colors.

## **Issue Linking:**  
- **No issue:** Describe the problem being solved.  

## **How to test**  
1. Go to header component in tegel lite
2. Activate dropdown and item
3. Press them and make sure the pressed color is correct. Compare to [figma](https://www.figma.com/design/6osYTOfd4MgDq7LO6BCoUO/branch/O6kWF0NHTa64KfOWltlehj/TRATON-Component-Library?node-id=26566-59506&p=f&m=dev) 
4. Compare TRATON/Scania, and light/dark mode.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
