### PR TITLE
fix(modal): sync focus index on Tab when focus was moved by click

### DIFF
--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -278,6 +278,22 @@ export class TdsModal {
     if (focusableElements.length === 0) return;
 
     event.preventDefault();
+
+    // Sync activeElementIndex with the actual focused element.
+    // This handles cases where focus was moved by mouse click (or programmatically)
+    // without going through the Tab key handler.
+    let currentlyFocused: HTMLElement | null;
+    if (document.activeElement === this.host) {
+      // Focus is inside the shadow root (e.g. the close button)
+      currentlyFocused = this.host.shadowRoot?.activeElement as HTMLElement | null;
+    } else {
+      currentlyFocused = document.activeElement as HTMLElement | null;
+    }
+    const currentIndex = currentlyFocused ? focusableElements.indexOf(currentlyFocused) : -1;
+    if (currentIndex !== -1) {
+      this.activeElementIndex = currentIndex;
+    }
+
     // Going backwards (Shift + Tab) on the first element => move to last
     if (event.shiftKey) {
       this.activeElementIndex -= 1;
@@ -286,7 +302,7 @@ export class TdsModal {
       }
     }
 
-    // // Going forwards (Tab) on the last element => move to first
+    // Going forwards (Tab) on the last element => move to first
     if (!event.shiftKey) {
       this.activeElementIndex += 1;
       if (this.activeElementIndex === focusableElements.length) {


### PR DESCRIPTION
## **Describe pull-request**  
When a user clicked a focusable element inside the modal and then pressed Tab, the focus trap would jump to an unexpected element because activeElementIndex was out of sync with the actual DOM focus state.
Added a sync step at the start of the Tab key handler that reads document.activeElement (and shadowRoot.activeElement for shadow DOM elements like the close button) and updates activeElementIndex before calculating the next focus target.
Also removed a stray duplicate // from a comment.

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://jira.scania.com/browse/CDEP-)
- **GitHub:** Include issue link  
- **No issue:** Describe the problem being solved.  

## **How to test**  
 1. Open a modal with multiple focusable elements
 2. Click an element in the middle of the tab order, then press Tab — verify focus moves to the next element (not an unexpected one)
 3. Click the close button (shadow DOM), then press Tab — verify focus moves correctly
 4. Verify Shift+Tab wrapping still works as expected
 5. Verify Tab wrapping from last to first element still works

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
