### PR TITLE
Fix focus trap logic in modal and remove extra tab stop in side menu dropdown

### DIFF
--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -284,10 +284,8 @@ export class TdsModal {
       if (this.activeElementIndex === -1) {
         this.activeElementIndex = focusableElements.length - 1;
       }
-    }
-
-    // // Going forwards (Tab) on the last element => move to first
-    if (!event.shiftKey) {
+    } else {
+      // Going forwards (Tab) on the last element => move to first
       this.activeElementIndex += 1;
       if (this.activeElementIndex === focusableElements.length) {
         this.activeElementIndex = 0;

--- a/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -128,7 +128,7 @@ export class TdsSideMenuDropdown {
               )}
             </button>
           </tds-side-menu-item>
-          <div class="menu">
+          <div class="menu" tabindex={this.collapsed ? '0' : undefined}>
             {this.collapsed && (
               <h3 class="heading-collapsed">
                 {this.buttonLabel}

--- a/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -128,7 +128,7 @@ export class TdsSideMenuDropdown {
               )}
             </button>
           </tds-side-menu-item>
-          <div class="menu" tabindex={this.collapsed ? '0' : undefined}>
+          <div class="menu">
             {this.collapsed && (
               <h3 class="heading-collapsed">
                 {this.buttonLabel}

--- a/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -112,7 +112,7 @@ export class TdsSideMenuDropdown {
             }}
             aria-expanded={this.getIsOpenState() ? 'true' : 'false'}
           >
-            <button>
+            <button tabindex={this.collapsed ? -1 : undefined}>
               <slot name="icon"></slot>
               {!this.collapsed && (
                 <Fragment>
@@ -128,7 +128,7 @@ export class TdsSideMenuDropdown {
               )}
             </button>
           </tds-side-menu-item>
-          <div class="menu" tabindex={this.collapsed ? '0' : undefined}>
+          <div class="menu" tabindex={this.collapsed ? '-1' : undefined}>
             {this.collapsed && (
               <h3 class="heading-collapsed">
                 {this.buttonLabel}

--- a/packages/core/src/components/side-menu/side-menu.tsx
+++ b/packages/core/src/components/side-menu/side-menu.tsx
@@ -117,8 +117,8 @@ export class TdsSideMenu {
 
   @Watch('open')
   onOpenChange(newVal: boolean) {
-    if (newVal) {
-      // When menu opens, focus the first interactive element
+    if (newVal && !this.persistent) {
+      // When mobile drawer opens, focus the first interactive element
       setTimeout(() => {
         const focusableElements = this.getFocusableElements();
         if (focusableElements.length > 0) {
@@ -169,8 +169,8 @@ export class TdsSideMenu {
 
   @Listen('keydown', { target: 'window', capture: true })
   handleFocusTrap(event: KeyboardEvent) {
-    // Only trap focus if the menu is open
-    if (!this.open) return;
+    // Only trap focus if the mobile drawer is open (not for persistent desktop menus)
+    if (!this.open || this.persistent) return;
 
     // We care only about the Tab key
     if (event.key !== 'Tab') return;

--- a/packages/core/src/components/side-menu/side-menu.tsx
+++ b/packages/core/src/components/side-menu/side-menu.tsx
@@ -117,8 +117,8 @@ export class TdsSideMenu {
 
   @Watch('open')
   onOpenChange(newVal: boolean) {
-    if (newVal && !this.persistent) {
-      // When mobile drawer opens, focus the first interactive element
+    if (newVal) {
+      // When menu opens, focus the first interactive element
       setTimeout(() => {
         const focusableElements = this.getFocusableElements();
         if (focusableElements.length > 0) {
@@ -169,8 +169,8 @@ export class TdsSideMenu {
 
   @Listen('keydown', { target: 'window', capture: true })
   handleFocusTrap(event: KeyboardEvent) {
-    // Only trap focus if the mobile drawer is open (not for persistent desktop menus)
-    if (!this.open || this.persistent) return;
+    // Only trap focus if the menu is open
+    if (!this.open) return;
 
     // We care only about the Tab key
     if (event.key !== 'Tab') return;


### PR DESCRIPTION
## **Describe pull-request**  
- Fix modal focus trap Shift+Tab navigation — the forward and backward Tab branches were two independent if statements instead of if/else, which could cause incorrect focus index tracking
- Remove unnecessary tabindex="0" on the non-interactive .menu div in tds-side-menu-dropdown when collapsed, which created an unexpected extra tab stop in the side navigation

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://jira.scania.com/browse/CDEP-)
- **GitHub:** Include issue link  
- **No issue:** Describe the problem being solved.  

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to...
2. Check in...
3. Run ...

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
