### PR TITLE
chore(tegel-lite): remove tegel lite beta release steps from holy grail workflow

### DIFF
--- a/.github/workflows/holy-grail.yml
+++ b/.github/workflows/holy-grail.yml
@@ -35,16 +35,6 @@ on:
           - beta
           - dev
 
-      tegelLiteTag:
-        description: 'Tegel Lite NPM tag (independent of main tag)'
-        required: true
-        default: 'beta'
-        type: choice
-        options:
-          - latest
-          - beta
-          - dev
-
       dryVersion:
         description: 'Dry version'
         required: false
@@ -85,11 +75,6 @@ jobs:
       - name: React - Bump version
         id: react-version
         working-directory: packages/react
-        run: npm version ${{ github.event.inputs.version || env.VERSION }} --no-git-tag-version
-
-      - name: Tegel Lite - Bump version
-        id: tegel-lite-version
-        working-directory: packages/tegel-lite
         run: npm version ${{ github.event.inputs.version || env.VERSION }} --no-git-tag-version
 
       - name: Core - Read package.json Version
@@ -381,53 +366,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  #RELEASE TEGEL LITE
-  release-tegel-lite:
-    needs: [create-release-branch, release-core]
-    runs-on: ubuntu-latest
-    env:
-      WORKING_DIRECTORY: packages/tegel-lite
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.create-release-branch.outputs.branch }}
-          fetch-depth: 1 # Fetch just the release branch
-
-      - name: Set up node
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ github.event.inputs.nodeVersion || env.NODE_VERSION }}
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Tegel Lite - Read package.json Version
-        id: version
-        working-directory: packages/tegel-lite
-        run: echo "PACKAGE_VERSION=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
-
-      - name: Install dependencies in root
-        run: npm ci
-
-      - name: Core - Install
-        working-directory: packages/core
-        run: npm ci
-
-      - name: Tegel Lite - Build
-        run: npm run build:tegel-lite
-
-      - name: Tegel Lite - Publish
-        if: github.event.inputs.dryVersion != 'true' && github.event_name != 'schedule'
-        working-directory: packages/tegel-lite
-        run: npm publish --tag ${{ github.event.inputs.tegelLiteTag || 'beta' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   #ON FAILURE
   on-failure:
-    needs:
-      [create-release-branch, release-core, release-angular-17, release-react, release-tegel-lite]
+    needs: [create-release-branch, release-core, release-angular-17, release-react]
     runs-on: ubuntu-latest
-    if: github.event.inputs.dryVersion != 'true' && github.event_name != 'schedule' && (needs.create-release-branch.result == 'failure' || needs.release-core.result == 'failure' || needs.release-angular-17.result == 'failure' || needs.release-react.result == 'failure' || needs.release-tegel-lite.result == 'failure')
+    if: github.event.inputs.dryVersion != 'true' && github.event_name != 'schedule' && (needs.create-release-branch.result == 'failure' || needs.release-core.result == 'failure' || needs.release-angular-17.result == 'failure' || needs.release-react.result == 'failure')
     steps:
       - name: Download version
         uses: actions/download-artifact@v4
@@ -440,10 +383,9 @@ jobs:
 
   #MERGE RELEASE BRANCH TO DEVELOP
   merge-release-branch-into-develop:
-    needs:
-      [create-release-branch, release-core, release-angular-17, release-react, release-tegel-lite]
+    needs: [create-release-branch, release-core, release-angular-17, release-react]
     runs-on: ubuntu-latest
-    if: github.event.inputs.dryVersion != 'true' && github.event_name != 'schedule' && (needs.create-release-branch.result == 'success' && needs.release-core.result == 'success' && needs.release-angular-17.result == 'success' && needs.release-react.result == 'success' && needs.release-tegel-lite.result == 'success')
+    if: github.event.inputs.dryVersion != 'true' && github.event_name != 'schedule' && (needs.create-release-branch.result == 'success' && needs.release-core.result == 'success' && needs.release-angular-17.result == 'success' && needs.release-react.result == 'success')
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -543,7 +485,6 @@ jobs:
         bump-wrappers-to-new-version,
         release-angular-17,
         release-react,
-        release-tegel-lite,
       ]
     runs-on: ubuntu-latest
     if: always()
@@ -558,8 +499,7 @@ jobs:
              [ "${{ needs.release-core.result }}" == "failure" ] || \
              [ "${{ needs.bump-wrappers-to-new-version.result }}" == "failure" ] || \
              [ "${{ needs.release-angular-17.result }}" == "failure" ] || \
-             [ "${{ needs.release-react.result }}" == "failure" ] || \
-             [ "${{ needs.release-tegel-lite.result }}" == "failure" ]; then
+             [ "${{ needs.release-react.result }}" == "failure" ]; then
             status="🔴 *Tegel Release ${version}* failed"
           else
             status="🟢 *Tegel Release ${version}* succeeded"


### PR DESCRIPTION
## **Describe pull-request**  
Tegel Lite is part of the holy grail script for continuous release. Since Tegel Lite is still in beta it should not be part of continuous releases, but rather release as needed. It should only be part of the holy grail script once it's in a stable version. This PR removes the beta release of tegel lite for now.

We should use the beta release workflow instead.

## **Issue Linking:**  
- **Jira:** [CDEP-1978](https://jira.scania.com/browse/CDEP-1978)

## **How to test**  
Test that holy grail doesnt fail. (DRY RUN OF HOLY GRAIL)

I did a test also and it succeeded: https://github.com/scania-digital-design-system/tegel/actions/runs/22344316499

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
