### PR TITLE
fix(tl-button): remove mode variant

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-button/tl-button.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-button/tl-button.stories.tsx
@@ -5,18 +5,6 @@ import { iconsNames } from '../../../components/icon/iconsArray';
 export default {
   title: 'Tegel Lite (Beta)/Button',
   argTypes: {
-    modeVariant: {
-      name: 'Mode variant',
-      description:
-        'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
-      control: {
-        type: 'radio',
-      },
-      options: ['Inherit from parent', 'Primary', 'Secondary'],
-      table: {
-        defaultValue: { summary: 'Inherit from parent' },
-      },
-    },
     variant: {
       name: 'Variant',
       description:


### PR DESCRIPTION
## **Describe pull-request**  
This PR removes the mode variant selectors from the Tegel Lite button since they don't apply any changes. 

## **Issue Linking:**  
[CDEP-1989](https://jira.scania.com/browse/CDEP-1989)

## **How to test**  
1. Go to the preview link and navigate to Tegel Lite -> Button
2. Check in the storybook settings and confirm there is no longer a Mode Variant option in settings (not the same as variant option that should still be in place)

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
