### PR TITLE
fix(tag): support both capitalized and lowercase variant prop values

### DIFF
--- a/packages/core/src/components/tag/readme.md
+++ b/packages/core/src/components/tag/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property            | Attribute | Description                          | Type                                                                       | Default     |
-| ------------------- | --------- | ------------------------------------ | -------------------------------------------------------------------------- | ----------- |
-| `size`              | `size`    | Sets the size of the tag             | `"lg" \| "sm"`                                                             | `'lg'`      |
-| `text` _(required)_ | `text`    | The title text to display in the tag | `string`                                                                   | `undefined` |
-| `variant`           | `variant` | Sets the variant mode of the tag     | `"Error" \| "Information" \| "Neutral" \| "New" \| "Success" \| "Warning"` | `'Neutral'` |
+| Property            | Attribute | Description                          | Type                                                                                                                                                   | Default     |
+| ------------------- | --------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| `size`              | `size`    | Sets the size of the tag             | `"lg" \| "sm"`                                                                                                                                         | `'lg'`      |
+| `text` _(required)_ | `text`    | The title text to display in the tag | `string`                                                                                                                                               | `undefined` |
+| `variant`           | `variant` | Sets the variant mode of the tag     | `"Error" \| "Information" \| "Neutral" \| "New" \| "Success" \| "Warning" \| "error" \| "information" \| "neutral" \| "new" \| "success" \| "warning"` | `'Neutral'` |
 
 
 ## Slots

--- a/packages/core/src/components/tag/tag.stories.tsx
+++ b/packages/core/src/components/tag/tag.stories.tsx
@@ -45,9 +45,9 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Neutral', 'Success', 'Warning', 'New', 'Information', 'Error'],
+      options: ['neutral', 'success', 'warning', 'new', 'information', 'error'],
       table: {
-        defaultValue: { summary: 'Neutral' },
+        defaultValue: { summary: 'neutral' },
       },
     },
     prefix: {
@@ -63,7 +63,7 @@ export default {
   args: {
     text: 'Tag Label',
     size: 'lg',
-    variant: 'Neutral',
+    variant: 'neutral',
   },
 };
 

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -22,18 +22,18 @@ export class TdsTag {
 
   /** Sets the variant mode of the tag */
   @Prop() variant:
-    | 'Success'
-    | 'Warning'
-    | 'New'
-    | 'Neutral'
-    | 'Information'
-    | 'Error'
     | 'success'
     | 'warning'
     | 'new'
     | 'neutral'
     | 'information'
-    | 'error' = 'Neutral';
+    | 'error'
+    | 'Success'
+    | 'Warning'
+    | 'New'
+    | 'Neutral'
+    | 'Information'
+    | 'Error' = 'Neutral';
 
   render() {
     const hasPrefixSlot = hasSlot('prefix', this.host);

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -21,14 +21,26 @@ export class TdsTag {
   @Prop() size: 'lg' | 'sm' = 'lg';
 
   /** Sets the variant mode of the tag */
-  @Prop() variant: 'Success' | 'Warning' | 'New' | 'Neutral' | 'Information' | 'Error' = 'Neutral';
+  @Prop() variant:
+    | 'Success'
+    | 'Warning'
+    | 'New'
+    | 'Neutral'
+    | 'Information'
+    | 'Error'
+    | 'success'
+    | 'warning'
+    | 'new'
+    | 'neutral'
+    | 'information'
+    | 'error' = 'Neutral';
 
   render() {
     const hasPrefixSlot = hasSlot('prefix', this.host);
 
     const getTagClasses = () => ({
       [`${this.size.toLowerCase()}`]: true,
-      [`${this.variant.toLowerCase()}`]: true,
+      [this.variant.toLowerCase()]: true,
     });
 
     return (

--- a/packages/core/src/components/tag/test/default/index.html
+++ b/packages/core/src/components/tag/test/default/index.html
@@ -24,5 +24,11 @@
     </tds-tag>
     <tds-tag variant="Error" prefix="placeholder" text="Error" data-testid="tds-tag-testid-error">
     </tds-tag>
+    <tds-tag variant="neutral" text="lowercase neutral" data-testid="tds-tag-testid-lowercase-neutral"></tds-tag>
+    <tds-tag variant="success" text="lowercase success" data-testid="tds-tag-testid-lowercase-success"></tds-tag>
+    <tds-tag variant="warning" text="lowercase warning" data-testid="tds-tag-testid-lowercase-warning"></tds-tag>
+    <tds-tag variant="new" text="lowercase new" data-testid="tds-tag-testid-lowercase-new"></tds-tag>
+    <tds-tag variant="information" text="lowercase information" data-testid="tds-tag-testid-lowercase-information"></tds-tag>
+    <tds-tag variant="error" text="lowercase error" data-testid="tds-tag-testid-lowercase-error"></tds-tag>
   </body>
 </html>

--- a/packages/core/src/components/tag/test/default/index.html
+++ b/packages/core/src/components/tag/test/default/index.html
@@ -24,11 +24,5 @@
     </tds-tag>
     <tds-tag variant="Error" prefix="placeholder" text="Error" data-testid="tds-tag-testid-error">
     </tds-tag>
-    <tds-tag variant="neutral" text="lowercase neutral" data-testid="tds-tag-testid-lowercase-neutral"></tds-tag>
-    <tds-tag variant="success" text="lowercase success" data-testid="tds-tag-testid-lowercase-success"></tds-tag>
-    <tds-tag variant="warning" text="lowercase warning" data-testid="tds-tag-testid-lowercase-warning"></tds-tag>
-    <tds-tag variant="new" text="lowercase new" data-testid="tds-tag-testid-lowercase-new"></tds-tag>
-    <tds-tag variant="information" text="lowercase information" data-testid="tds-tag-testid-lowercase-information"></tds-tag>
-    <tds-tag variant="error" text="lowercase error" data-testid="tds-tag-testid-lowercase-error"></tds-tag>
   </body>
 </html>

--- a/packages/core/src/components/tag/test/default/tag.e2e.ts
+++ b/packages/core/src/components/tag/test/default/tag.e2e.ts
@@ -47,6 +47,24 @@ test.describe.parallel(componentName, () => {
     await expect(tag).toHaveClass(/neutral/);
   });
 
+  test('Check that lowercase variant input produces correct lowercase CSS classes', async ({
+    page,
+  }) => {
+    // Given - tags with lowercase variant values in the fixture
+
+    // When (rendering happens on page load)
+
+    // Then - each lowercase variant should produce its corresponding lowercase CSS class
+    await expect(page.getByTestId('tds-tag-testid-lowercase-neutral')).toHaveClass(/neutral/);
+    await expect(page.getByTestId('tds-tag-testid-lowercase-success')).toHaveClass(/success/);
+    await expect(page.getByTestId('tds-tag-testid-lowercase-warning')).toHaveClass(/warning/);
+    await expect(page.getByTestId('tds-tag-testid-lowercase-new')).toHaveClass(/new/);
+    await expect(page.getByTestId('tds-tag-testid-lowercase-information')).toHaveClass(
+      /information/,
+    );
+    await expect(page.getByTestId('tds-tag-testid-lowercase-error')).toHaveClass(/error/);
+  });
+
   test('Check that tag content structure is correct', async ({ page }) => {
     const tag = page.getByTestId('tds-tag-testid-default');
     const tagContent = tag.locator('.tds-tag__content');

--- a/packages/core/src/components/tag/test/default/tag.e2e.ts
+++ b/packages/core/src/components/tag/test/default/tag.e2e.ts
@@ -50,7 +50,8 @@ test.describe.parallel(componentName, () => {
   test('Check that lowercase variant input produces correct lowercase CSS classes', async ({
     page,
   }) => {
-    // Given - tags with lowercase variant values in the fixture
+    // Given - tags with lowercase variant values in a dedicated fixture
+    await page.goto('src/components/tag/test/lowercase/index.html');
 
     // When (rendering happens on page load)
 

--- a/packages/core/src/components/tag/test/lowercase/index.html
+++ b/packages/core/src/components/tag/test/lowercase/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Tag - Lowercase variants</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
+    <link rel="stylesheet" href="../../../../../dist/tegel/tegel.css" />
+    <script type="module">
+      import { defineCustomElements } from '../../../../../loader/index.es2017.js';
+      defineCustomElements();
+    </script>
+  </head>
+
+  <body>
+    <tds-tag variant="neutral" text="lowercase neutral" data-testid="tds-tag-testid-lowercase-neutral"></tds-tag>
+    <tds-tag variant="success" text="lowercase success" data-testid="tds-tag-testid-lowercase-success"></tds-tag>
+    <tds-tag variant="warning" text="lowercase warning" data-testid="tds-tag-testid-lowercase-warning"></tds-tag>
+    <tds-tag variant="new" text="lowercase new" data-testid="tds-tag-testid-lowercase-new"></tds-tag>
+    <tds-tag variant="information" text="lowercase information" data-testid="tds-tag-testid-lowercase-information"></tds-tag>
+    <tds-tag variant="error" text="lowercase error" data-testid="tds-tag-testid-lowercase-error"></tds-tag>
+  </body>
+</html>


### PR DESCRIPTION
## **Describe pull-request**
The variant prop on tds-tag previously only accepted capitalized values (e.g. Success) but applied CSS classes that are lowercase (e.g. success), causing styling to break. The prop type is now expanded to accept both casings and the class is always applied in lowercase.

## **Issue Linking**
Jira: [CDEP-1993](https://jira.scania.com/browse/CDEP-1993)
Github: [Issue-1718](https://github.com/scania-digital-design-system/tegel/issues/1718)

## **How to test**
Go to the tds-tag component in Storybook
Set variant to a capitalized value (e.g. Success) and verify correct styling applies
Set variant to a lowercase value (e.g. success) and verify the same styling applies