### PR TITLE
fix(inline-tabs): restore active indicator when switching back to first tab

### DIFF
--- a/packages/core/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/packages/core/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -103,7 +103,7 @@ export class TdsInlineTabs {
       return tabElement;
     });
 
-    if (this.selectedIndex) {
+    if (this.selectedIndex !== undefined) {
       this.tabElements[this.selectedIndex].setSelected(true);
     }
   }

--- a/packages/core/src/components/tabs/test/inline-tabs/inline-tabs.e2e.ts
+++ b/packages/core/src/components/tabs/test/inline-tabs/inline-tabs.e2e.ts
@@ -42,6 +42,7 @@ testConfigurations.withModeVariants.forEach((config) => {
 test.describe.parallel(componentName, () => {
   let inlineTabs;
   let firstTab;
+  let firstTabDiv;
   let secondTab;
   let secondTabDiv;
   let thirdTab;
@@ -57,6 +58,7 @@ test.describe.parallel(componentName, () => {
     thirdTab = page.locator('button', { hasText: 'Third Tab' });
     fourthTab = page.locator('button', { hasText: 'Fourth Tab' });
     // Divs inside tabs specifically for click interactions
+    firstTabDiv = page.locator('tds-inline-tab:has-text("First tab") >> div');
     secondTabDiv = page.locator('tds-inline-tab:has-text("Second tab is much longer") >> div');
     thirdTabDiv = page.locator('tds-inline-tab:has-text("Third Tab") >> div');
   });
@@ -97,5 +99,19 @@ test.describe.parallel(componentName, () => {
     await expect(inlineTabs).toHaveAttribute('selected-index', '2', { timeout: 5000 });
     await expect(secondTabDiv).not.toHaveClass(/selected/);
     await expect(thirdTabDiv).toHaveClass(/selected/);
+  });
+
+  test('Switching from second tab back to first tab shows first tab as selected', async () => {
+    // Given
+    await secondTabDiv.click({ force: true });
+    await expect(inlineTabs).toHaveAttribute('selected-index', '1', { timeout: 5000 });
+
+    // When
+    await firstTabDiv.click({ force: true });
+
+    // Then
+    await expect(inlineTabs).toHaveAttribute('selected-index', '0', { timeout: 5000 });
+    await expect(firstTabDiv).toHaveClass(/selected/);
+    await expect(secondTabDiv).not.toHaveClass(/selected/);
   });
 });


### PR DESCRIPTION
## **Describe pull-request**
The active tab underline disappeared when navigating back to the first tab because handleSelectedIndexUpdate used a truthy check (if (this.selectedIndex)) that evaluates to false when selectedIndex is 0. The condition is now if (this.selectedIndex !== undefined) so tab[0] is correctly re-selected. A regression test covering the Tab1 → Tab2 → Tab1 sequence is included.

## **Issue Linking**
Jira: [CDEP-1994](https://jira.scania.com/browse/CDEP-1994)
Github: [Issue-1720](https://github.com/scania-digital-design-system/tegel/issues/1720)

## **How to test**
Created a betarelease with my fix which can be tested in this code sandbox
https://stackblitz.com/edit/vitejs-vite-nrmnprhw?file=package.json