### PR TITLE
fix(tabs): adjust left padding handling for inline tabs component

### DIFF
--- a/packages/core/src/components/tabs/inline-tabs/inline-tabs.scss
+++ b/packages/core/src/components/tabs/inline-tabs/inline-tabs.scss
@@ -4,6 +4,8 @@
 :host {
   @include tds-box-sizing;
 
+  --padding-left: 0; // Default value for left padding
+
   display: flex;
   background-color: var(--tds-inline-tabs-background);
   position: relative;
@@ -26,6 +28,7 @@
     overflow-x: scroll;
     scrollbar-width: none;
     gap: 16px; // Adds a consistent gap between the tab items
+    padding-left: var(--padding-left);
 
     &::-webkit-scrollbar {
       display: none;
@@ -38,7 +41,7 @@
   }
 
   .scroll-left-button {
-    left: 0;
+    left: calc(0px - var(--padding-left));
     z-index: 1;
   }
 

--- a/packages/core/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/packages/core/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -220,19 +220,12 @@ export class TdsInlineTabs {
     }
   }
 
-  private applyCustomLeftPadding(): void {
-    if (this.navWrapperElement) {
-      this.navWrapperElement.style.paddingLeft = `${this.leftPadding}px`;
-    }
-  }
-
   private handleSlotChange(): void {
     this.initializeTabs();
     this.addEventListenerToTabs();
     this.initializeSelectedTab();
     this.updateScrollButtons();
     this.addResizeObserver();
-    this.applyCustomLeftPadding(); // Apply custom left padding to the wrapper
   }
 
   connectedCallback(): void {
@@ -257,13 +250,13 @@ export class TdsInlineTabs {
       <Host
         role="tablist"
         class={`${this.modeVariant ? `tds-mode-variant-${this.modeVariant}` : ''}`}
+        style={{ '--padding-left': `${this.leftPadding}px` }}
       >
         <div
           class="wrapper"
           ref={(el) => {
             this.navWrapperElement = el as HTMLElement;
           }}
-          style={{ paddingLeft: `${this.leftPadding}px` }} // Set left padding directly here
         >
           <button
             aria-label={this.tdsScrollLeftAriaLabel}


### PR DESCRIPTION
## **Describe pull-request**
Fix navigation arrows on the inline tabs component. When adding a big left padding, the left arrow was shifting to the right because of the wrapper's padding. We simply subtract the left padding given by the wrapper to the left position of the left arrow.

Instead of setting the padding as a inline style to the wrapper/arrow, we added a new css variable (`--padding-left`) that we used for both styles.

## **Issue Linking**
- Jira: CDEP-826

## **How to test**
1. Go to the `Inline Tabs` story in Storybook.
2. In the controls panel, change the `leftPadding` prop to a value higher than `300`.
3. Verify the tab list shifts right by the specified amount (left padding is applied to the wrapper).
4. Click on the right arrow to scroll the tabs.
4. Verify the left scroll button position adjusts accordingly.
5. Set `leftPadding` back to `0` and confirm no padding is applied.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [x] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox)
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components
- [ ] Dark/light mode and variants
- [ ] Input fields – values should be displayed properly
- [ ] Events

## **Screenshots**
_Include before/after screenshots for UI changes._
