### PR TITLE
fix(popover-canvas): add mapping for animation class

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-popover-canvas/tl-popover-canvas.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-popover-canvas/tl-popover-canvas.stories.tsx
@@ -40,7 +40,12 @@ export default {
 
 const Template = ({ modeVariant, showPopoverCanvas, animation }) => {
   const modeClass = `tl-popover-canvas--${modeVariant.toLowerCase()}`;
-  const animationClass = animation === 'fade' ? 'tl-popover-canvas--animation-fade' : '';
+  const animationMap = {
+    None: 'none',
+    Fade: 'fade',
+  };
+  const animationClass =
+    animationMap[animation] === 'fade' ? 'tl-popover-canvas--animation-fade' : '';
   const showPopoverClass = showPopoverCanvas ? 'tl-popover-canvas--visible' : '';
 
   return formatHtmlPreview(`


### PR DESCRIPTION
## **Describe pull-request**  
The mapping for animation classes in Tegel Lite Popover Canvas were removed. This PR reinstates this.

## **Issue Linking:**  
- **Jira:** Add ticket number after `CDEP-1988`: [CDEP-1988](https://jira.scania.com/browse/CDEP-1988)

## **How to test**  
1. Go to the preview link
2. Navigate to Tegel Lite -> Popover Canvas
3. Set the Animation control to "Fade"
4. Verify that the Popover Canvas element has an animation effect
5. Verify that the animation does not trigger if the Animation control is set to "None"

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors