### PR TITLE
fix(tds-chip): change box-sizing to content-box and remove unnecessar…

### DIFF
--- a/packages/core/src/components/chip/chip.scss
+++ b/packages/core/src/components/chip/chip.scss
@@ -16,116 +16,114 @@
 }
 
 /* Component styling */
+.tds-chip-component {
+  display: inline-flex;
 
-.component {
-  .tds-chip-component {
+  label {
+    box-sizing: content-box;
+    background-color: var(--tds-chips-background);
+    color: var(--tds-chips-color);
+    font: var(--tds-detail-02);
+    letter-spacing: var(--tds-detail-02-ls);
     display: inline-flex;
+    align-items: center;
+    border-radius: 32px;
+    border: 1px solid var(--tds-chips-border);
+    cursor: pointer;
+    white-space: nowrap;
 
+    &:hover {
+      background-color: var(--tds-chips-background-hover);
+      border-color: var(--tds-chips-border-hover);
+    }
+  }
+
+  &.disabled {
     label {
-      background-color: var(--tds-chips-background);
-      color: var(--tds-chips-color);
-      font: var(--tds-detail-02);
-      letter-spacing: var(--tds-detail-02-ls);
-      display: inline-flex;
-      align-items: center;
-      border-radius: 32px;
-      border: 1px solid var(--tds-chips-border);
-      cursor: pointer;
-      white-space: nowrap;
-
-      &:hover {
-        background-color: var(--tds-chips-background-hover);
-        border-color: var(--tds-chips-border-hover);
-      }
-    }
-
-    &.disabled {
-      label {
-        background-color: var(--tds-chips-background-disabled);
-        color: var(--tds-chips-text-disabled);
-        border-color: transparent;
-        cursor: default;
-        pointer-events: none;
-      }
-
-      input {
-        pointer-events: none; // Ensure input does not respond to interactions
-      }
-
-      input[type='radio']:checked:disabled + label {
-        background-color: var(--tds-chips-background-active-disabled);
-        color: var(--tds-chips-text-checked-disabled);
-        border-color: transparent;
-      }
-
-      input[type='checkbox']:checked:disabled + label {
-        background-color: var(--tds-chips-background-active-disabled);
-        color: var(--tds-chips-text-checked-disabled);
-        border-color: transparent;
-      }
-    }
-
-    // Base size styles
-    &.lg label {
-      height: 16px;
-      padding: 8px 16px;
-      gap: 6px;
-    }
-
-    &.sm label {
-      height: 16px;
-      padding: 4px 12px;
-      gap: 4px;
-    }
-
-    // Prefix/suffix overrides
-    &.sm.prefix label {
-      padding: 4px 12px 4px 8px;
-    }
-
-    &.sm.suffix label {
-      padding: 4px 8px 4px 12px;
-    }
-
-    &.lg.prefix label {
-      padding: 8px 16px 8px 10px;
-    }
-
-    &.lg.suffix label {
-      padding: 8px 10px 8px 16px;
-    }
-
-    // Combined prefix + suffix
-    &.sm.prefix.suffix label {
-      padding: 4px 8px;
-    }
-
-    &.lg.prefix.suffix label {
-      padding: 8px 10px;
+      background-color: var(--tds-chips-background-disabled);
+      color: var(--tds-chips-text-disabled);
+      border-color: transparent;
+      cursor: default;
+      pointer-events: none;
     }
 
     input {
-      opacity: 0;
-      position: absolute;
-      z-index: -1;
+      pointer-events: none; // Ensure input does not respond to interactions
     }
 
-    input:focus-visible + label {
-      @include tds-focus-state;
-
-      background-color: var(--tds-chips-background-focus);
+    input[type='radio']:checked:disabled + label {
+      background-color: var(--tds-chips-background-active-disabled);
+      color: var(--tds-chips-text-checked-disabled);
       border-color: transparent;
     }
 
-    input:checked + label {
-      background-color: var(--tds-chips-background-active);
-      color: var(--tds-chips-color-active);
-      border-color: var(--tds-chips-background-active);
+    input[type='checkbox']:checked:disabled + label {
+      background-color: var(--tds-chips-background-active-disabled);
+      color: var(--tds-chips-text-checked-disabled);
+      border-color: transparent;
+    }
+  }
 
-      &:hover {
-        background-color: var(--tds-chips-background-active-hover);
-        border-color: var(--tds-chips-border-selected-hover);
-      }
+  // Base size styles
+  &.lg label {
+    height: 16px;
+    padding: 8px 16px;
+    gap: 6px;
+  }
+
+  &.sm label {
+    height: 16px;
+    padding: 4px 12px;
+    gap: 4px;
+  }
+
+  // Prefix/suffix overrides
+  &.sm.prefix label {
+    padding: 4px 12px 4px 8px;
+  }
+
+  &.sm.suffix label {
+    padding: 4px 8px 4px 12px;
+  }
+
+  &.lg.prefix label {
+    padding: 8px 16px 8px 10px;
+  }
+
+  &.lg.suffix label {
+    padding: 8px 10px 8px 16px;
+  }
+
+  // Combined prefix + suffix
+  &.sm.prefix.suffix label {
+    padding: 4px 8px;
+  }
+
+  &.lg.prefix.suffix label {
+    padding: 8px 10px;
+  }
+
+  input {
+    opacity: 0;
+    position: absolute;
+    z-index: -1;
+  }
+
+  input:focus-visible + label {
+    @include tds-focus-state;
+
+    background-color: var(--tds-chips-background-focus);
+    border-color: transparent;
+  }
+
+  input:checked + label {
+    background-color: var(--tds-chips-background-active);
+    color: var(--tds-chips-color-active);
+    border-color: var(--tds-chips-background-active);
+
+    &:hover {
+      background-color: var(--tds-chips-background-active-hover);
+      border-color: var(--tds-chips-border-selected-hover);
     }
   }
 }

--- a/packages/core/src/components/chip/chip.tsx
+++ b/packages/core/src/components/chip/chip.tsx
@@ -172,22 +172,20 @@ export class TdsChip {
 
     return (
       <Host>
-        <div class="component">
-          <div class={chipClasses}>
-            <input
-              type={this.type}
-              id={this.chipId}
-              aria-checked={this.type === 'button' ? undefined : String(this.checked)}
-              role={this.type}
-              aria-label={this.tdsAriaLabel}
-              {...inputAttributes}
-            ></input>
-            <label onClick={(event) => event.stopPropagation()} htmlFor={this.chipId}>
-              {hasPrefixSlot && <slot name="prefix" />}
-              {hasLabelSlot && <slot name="label" />}
-              {hasSuffixSlot && <slot name="suffix" />}
-            </label>
-          </div>
+        <div class={chipClasses}>
+          <input
+            type={this.type}
+            id={this.chipId}
+            aria-checked={this.type === 'button' ? undefined : String(this.checked)}
+            role={this.type}
+            aria-label={this.tdsAriaLabel}
+            {...inputAttributes}
+          ></input>
+          <label onClick={(event) => event.stopPropagation()} htmlFor={this.chipId}>
+            {hasPrefixSlot && <slot name="prefix" />}
+            {hasLabelSlot && <slot name="label" />}
+            {hasSuffixSlot && <slot name="suffix" />}
+          </label>
         </div>
       </Host>
     );


### PR DESCRIPTION
## **Describe pull-request**  
This PR fixes how chips are rendered within a table.
It was an issue reported by one of our users via GitHub and also in the support channels.


## **Issue Linking:**  
- **Jira:** [CDEP-1956](https://jira.scania.com/browse/CDEP-1956)
- **GitHub:** [Issue #1644](https://github.com/scania-digital-design-system/tegel/issues/1644)

## **How to test**  
1. Checkout the [branch fix/tds-chip-box-sizing](https://github.com/scania-digital-design-system/tegel/tree/fix/tds-chip-box-sizing) in tegel 
2. Edit the `table-component-basic.stories.tsx` and add a `<tds-chip>` in one of the `<table-body-cell>`
3. Run `npm run start`
4. Open [basic table component](http://localhost:6006/?path=/story/components-table-basic--default)
5. Compare with the [standalone chip](http://localhost:6006/?path=/story/components-chip--default&args=icon:!true)


## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  

The reported screenshot from the GitHub issue 👇 

<img width="951" height="274" alt="536750223-209608ad-88da-44f8-b9bf-4d6ebe8b35ac" src="https://github.com/user-attachments/assets/1d81d881-a406-4a99-801d-80e9948d046f" />


With the proposed fix 👇  (also with a button ... because why not? for realz, to check that only the chip was affected!) 

<img width="1250" height="762" alt="image" src="https://github.com/user-attachments/assets/7acec5a3-11dd-4402-a560-2bf3fa95d7e0" />



## **Additional context**  
The table styling adds the `box-sizing: border-box` to all its children. This means that the heights for the elements rendered there will be computed as `height = content + padding + border` as opposed to `box-sizing: content-box` (the default CSS) that computes the height as the content only. 

What we were observing was that the label, which defined the height as 16px with a padding top and bottom of 8 pixels each (ie 16px) meaning that the padding was "disappearing" or at least that was what the eye was observing. 

<img width="1241" height="617" alt="image" src="https://github.com/user-attachments/assets/9643b191-575c-457a-a0d4-428f1cfcafe0" />



<img width="1254" height="722" alt="image" src="https://github.com/user-attachments/assets/728c1e60-f758-4f12-a4e2-c0da834b203e" />