### PR TITLE
fix(tegel-lite): restore global source and use brand-agnostic semantic tokens

### DIFF
--- a/packages/core/scripts/compile-tegel-lite-components.js
+++ b/packages/core/scripts/compile-tegel-lite-components.js
@@ -11,7 +11,7 @@ const dirName = path.dirname(fileName);
 const componentsDir = path.resolve(dirName, '../src/tegel-lite/components'); // Source SCSS directory
 const outputCssDir = path.resolve(dirName, '../../tegel-lite/dist'); // Output compiled CSS directory
 // Define paths for global styles
-const globalScss = path.resolve(dirName, '../src/global/core.scss'); // Source global SCSS
+const globalScss = path.resolve(dirName, '../src/global/tegel-lite-global.scss'); // Source global SCSS
 const globalCss = path.resolve(dirName, '../../tegel-lite/dist/global.css'); // Output compiled global CSS
 
 // Define paths for Scania specific vars

--- a/packages/core/src/global/tegel-lite-global.scss
+++ b/packages/core/src/global/tegel-lite-global.scss
@@ -48,6 +48,8 @@ $local-assets: './assets' !default;
 // Beta components
 @use '../components/_beta/date-picker/date-picker-single/date-picker-vars' as *;
 
+@use 'shame' as *;
+
 body {
   font-family: 'Scania Sans Semi Condensed', 'Scania Sans Condensed', Arial, Helvetica, sans-serif;
   font-size: 14px;
@@ -89,5 +91,3 @@ body {
     background-color: var(--tds-grey-900);
   }
 }
-
-@use 'shame' as *;

--- a/packages/core/src/global/tegel-lite-global.scss
+++ b/packages/core/src/global/tegel-lite-global.scss
@@ -4,19 +4,9 @@
 * Once the Web Components imports are removed from the global.scss file, that file can be used for Tegel Lite as well.
 */
 
-$local-assets: './assets' !default;
-
-/* Multibrand tokens: Scania colors */
-@use '../../../../color/scania-color-primitives' as *;
-@use '../../../../color/scania-brand-usage' as *;
-
-/* Multibrand tokens: Scania typography */
-@use '../../../../typography/tokens/typography-scania' as *;
-
-/* Multibrand tokens: Scania spacing */
+// Spacing (brand-agnostic base units)
 @use '../../../../spacing/units' as *;
 @use '../../../../spacing/radius' as *;
-@use '../../../../spacing/scania-units' as *;
 
 // Motion
 @use '../../../../motion' as *;
@@ -29,14 +19,6 @@ $local-assets: './assets' !default;
 
 // Grid new
 @use '../../../../grid/grid' as *;
-
-// Typography
-@use '../../../../typography/scania-fonts' as *;
-@use '../../../../typography/scania-fonts-vars' as *;
-@use '../../../../typography/scania-fonts-selectors' as *;
-
-// Logos
-@use '../../../../logotype/logotype-scania' as *;
 
 // Vars
 @use '_variables' as *;
@@ -59,35 +41,35 @@ body {
 
 :root,
 .tds-mode-light {
-  color: var(--tds-grey-958);
-  background-color: var(--tds-white);
+  color: var(--color-foreground-text-strong);
+  background-color: var(--color-background-base);
 
   &.tds-mode-variant-primary,
   & .tds-mode-variant-primary {
-    color: var(--tds-grey-958);
-    background-color: var(--tds-white);
+    color: var(--color-foreground-text-strong);
+    background-color: var(--color-background-base);
   }
 
   &.tds-mode-variant-secondary,
   & .tds-mode-variant-secondary {
-    color: var(--tds-grey-958);
-    background-color: var(--tds-grey-50);
+    color: var(--color-foreground-text-strong);
+    background-color: var(--color-background-layer-01);
   }
 }
 
 .tds-mode-dark {
-  color: var(--tds-grey-100);
-  background-color: var(--tds-grey-958);
+  color: var(--color-foreground-text-strong);
+  background-color: var(--color-background-base);
 
   &.tds-mode-variant-primary,
   & .tds-mode-variant-primary {
-    color: var(--tds-grey-100);
-    background-color: var(--tds-grey-958);
+    color: var(--color-foreground-text-strong);
+    background-color: var(--color-background-base);
   }
 
   &.tds-mode-variant-secondary,
   & .tds-mode-variant-secondary {
-    color: var(--tds-grey-100);
-    background-color: var(--tds-grey-900);
+    color: var(--color-foreground-text-strong);
+    background-color: var(--color-background-layer-01);
   }
 }

--- a/packages/core/src/global/tegel-lite-global.scss
+++ b/packages/core/src/global/tegel-lite-global.scss
@@ -39,6 +39,26 @@ body {
   flex: 1;
 }
 
+// Override hardcoded Scania font values from scania-variables (_scania-fonts-selectors.scss) with brand-agnostic tokens
+h1 {
+  font-family: var(--headline-01-font-family);
+}
+h2 {
+  font-family: var(--headline-02-font-family);
+}
+h3 {
+  font-family: var(--headline-03-font-family);
+}
+h4 {
+  font-family: var(--headline-04-font-family);
+}
+h5 {
+  font-family: var(--headline-05-font-family);
+}
+h6 {
+  font-family: var(--headline-06-font-family);
+}
+
 :root,
 .tds-mode-light {
   color: var(--color-foreground-text-strong);

--- a/packages/core/src/global/tegel-lite-global.scss
+++ b/packages/core/src/global/tegel-lite-global.scss
@@ -33,7 +33,7 @@
 @use 'shame' as *;
 
 body {
-  font-family: 'Scania Sans Semi Condensed', 'Scania Sans Condensed', Arial, Helvetica, sans-serif;
+  font-family: var(--body-01-font-family);
   font-size: 14px;
   margin: 0;
   flex: 1;

--- a/packages/core/src/tegel-lite/components/tl-badge/_tl-badge-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-badge/_tl-badge-vars.scss
@@ -1,3 +1,5 @@
+@use '../../../../../../tokens/scss/component/badge';
+
 .tl-badge {
   --badge-background-color: var(--component-badge-background);
   --badge-color-text: var(--component-badge-text);

--- a/packages/core/src/tegel-lite/components/tl-card/_tl-card-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-card/_tl-card-vars.scss
@@ -1,3 +1,5 @@
+@use '../../../../../../tokens/scss/component/card';
+
 .tl-card {
   --card-background: var(--tds-white);
   --card-background-primary: var(--component-card-primary);

--- a/packages/core/src/tegel-lite/components/tl-dropdown/_tl-dropdown-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-dropdown/_tl-dropdown-vars.scss
@@ -1,4 +1,5 @@
 // Tegel Lite Dropdown Variables
+@use '../../../../../../tokens/scss/component/dropdown';
 
 .tl-dropdown-option {
   --dropdown-option-background: var(--color-background-layer-01);

--- a/packages/core/src/tegel-lite/components/tl-dropdown/_tl-dropdown-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-dropdown/_tl-dropdown-vars.scss
@@ -10,6 +10,9 @@
 }
 
 .tl-dropdown {
+  // Colors - Base
+  --dropdown-background: var(--color-background-layer-01);
+
   &--primary {
     --dropdown-background: var(--color-background-layer-01);
   }
@@ -17,9 +20,6 @@
   &--secondary {
     --dropdown-background: var(--color-background-layer-02);
   }
-
-  // Colors - Base
-  --dropdown-background: var(--color-background-layer-01);
 
   // Colors - Label/Placeholder/Helper
   --dropdown-text: var(--color-foreground-text-strong);

--- a/packages/core/src/tegel-lite/components/tl-footer/_tl-footer-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-footer/_tl-footer-vars.scss
@@ -1,3 +1,5 @@
+@use '../../../../../../tokens/scss/component/footer';
+
 .tl-footer {
   --footer-top-background-primary: var(--color-background-layer-01);
   --footer-top-background-secondary: var(--color-background-base);

--- a/packages/core/src/tegel-lite/components/tl-header/_dropdown.scss
+++ b/packages/core/src/tegel-lite/components/tl-header/_dropdown.scss
@@ -1,5 +1,4 @@
 @use '../../../mixins/tl-scrollbar' as *;
-@use '../../../mixins/z-index' as *;
 @use '../../../mixins/box-sizing' as *;
 @use './tl-header-vars' as *;
 @use '../../../../../../typography/mixins/type-styles' as *;
@@ -38,7 +37,6 @@
     background-color: var(--component-header-color-background-pressed);
     color: var(--header-nav-item-dropdown-opened);
     position: relative;
-    z-index: calc(var(--tds-z-index-header) + 1);
 
     &:hover {
       background-color: var(--component-header-color-background-pressed);
@@ -89,7 +87,6 @@
     background-color: var(--component-header-color-background-pressed);
     color: var(--header-nav-item-dropdown-opened);
     position: relative;
-    z-index: calc(var(--tds-z-index-header) + 1);
 
     &:hover {
       background-color: var(--component-header-color-background-pressed);
@@ -129,7 +126,7 @@
   min-width: 190px;
   max-height: calc(100vh - var(--tds-header-height));
   overflow-y: auto;
-  z-index: var(--tds-z-index-header);
+
   @include tl-scrollbar;
 
   @media all and (max-width: $media-fullwidth) {
@@ -154,7 +151,6 @@
   min-width: 290px;
   max-height: calc(100vh - var(--tds-header-height));
   overflow-y: auto;
-  z-index: var(--tds-z-index-header);
   border-radius: 4px;
   @include tl-scrollbar;
 
@@ -176,7 +172,7 @@
   min-width: 320px;
   max-height: calc(100vh - var(--tds-header-height));
   overflow-y: auto;
-  z-index: var(--tds-z-index-header);
+
   @include tl-scrollbar;
 
   &--open {
@@ -197,7 +193,6 @@
   min-width: 320px;
   max-height: calc(100vh - var(--tds-header-height));
   overflow-y: auto;
-  z-index: var(--tds-z-index-header);
   border-radius: 4px;
   @include tl-scrollbar;
 

--- a/packages/core/src/tegel-lite/components/tl-header/_tl-header-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-header/_tl-header-vars.scss
@@ -2,6 +2,13 @@
 
 //Needs updating with variables. Didn't work with original in test project
 .tl-header {
+  /* Layout */
+  --tds-header-height: 64px;
+  --tds-header-list-item-md-height: 48px;
+
+  /* App launcher dropdown background */
+  --tds-header-app-launcher-menu-background: var(--header-app-launcher-menu-background);
+
   /* Base text */
   --header-nav-item: var(--component-header-color-foreground-strong);
 

--- a/packages/core/src/tegel-lite/components/tl-header/tl-header.scss
+++ b/packages/core/src/tegel-lite/components/tl-header/tl-header.scss
@@ -1,6 +1,5 @@
 @use '../../../mixins/box-sizing' as *;
 @use '../../../mixins/flex-center' as *;
-@use '../../../mixins/z-index' as *;
 @use './tl-header-vars' as *;
 @use '../../../../../../typography/mixins/type-styles' as *;
 
@@ -15,7 +14,6 @@
   height: var(--tds-header-height);
   background-color: var(--header-background);
   width: 100%;
-  z-index: var(--tds-z-index-header);
 }
 
 .tl-header__nav {

--- a/packages/core/src/tegel-lite/components/tl-modal/_tl-modal-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-modal/_tl-modal-vars.scss
@@ -1,3 +1,5 @@
+@use '../../../../../../tokens/scss/component/shadow';
+
 /* Component variables */
 
 .tl-modal,

--- a/packages/core/src/tegel-lite/components/tl-side-menu/_tl-side-menu-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-side-menu/_tl-side-menu-vars.scss
@@ -1,3 +1,5 @@
+@use '../../../../../../tokens/scss/component/side-menu';
+
 .tl-side-menu {
   --side-menu-background-cover: var(--color-background-base);
   --side-menu-item-state-hover: var(--color-background-layer-01);

--- a/packages/core/src/tegel-lite/components/tl-side-menu/_tl-side-menu-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-side-menu/_tl-side-menu-vars.scss
@@ -11,6 +11,11 @@
   --side-menu-single-item-color: var(--color-foreground-text-strong);
   --side-menu-bottom-menu-border-top: var(--component-side-menu-color-divider);
 
+  // Legacy --tds-* vars referenced in tl-side-menu dropdown SCSS
+  --tds-header-app-launcher-menu-bg: var(--color-background-base);
+  --tds-nav-item-border-color: var(--color-foreground-border-accent-focus);
+  --tds-nav-dropdown-menu-box: 0 3px 3px rgb(0 0 0 / 15%), 0 -1px 1px rgb(0 0 0 / 1%);
+
   // Custom variables for dropdown colors when not collapsed:
   --side-menu-dropdown-list-item-custom-background: var(--side-menu-background-cover);
   --side-menu-dropdown-list-item-custom-background-hover: var(--side-menu-item-state-hover);

--- a/packages/core/src/tegel-lite/components/tl-spinner/_tl-spinner-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-spinner/_tl-spinner-vars.scss
@@ -1,3 +1,5 @@
+@use '../../../../../../tokens/scss/component/spinner';
+
 /* Component variables  */
 .tl-spinner {
   --tl-spinner-background: var(--component-spinner-color);

--- a/packages/core/src/tegel-lite/components/tl-stepper/_tl-stepper-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-stepper/_tl-stepper-vars.scss
@@ -1,3 +1,5 @@
+@use '../../../../../../tokens/scss/component/stepper';
+
 .tl-stepper {
   // Current
   --stepper-current-number-with-border: var(--color-foreground-border-strong);

--- a/packages/core/src/tegel-lite/components/tl-table/_tl-table-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-table/_tl-table-vars.scss
@@ -1,3 +1,5 @@
+@use '../../../../../../tokens/scss/component/table';
+
 .tl-table {
   /* Table-text */
   --table-text: var(--color-foreground-text-strong);


### PR DESCRIPTION
## **Describe pull-request**  
The Tegel Lite build was compiling `core.scss` instead of `tegel-lite-global.scss` for its global styles. This caused missing CSS custom properties (`--tds-*` colors, spacing tokens) while including unnecessary web component variables. 
This broke features like dark/light mode background colors when consuming the `@scania/tegel-lite` package.

Published beta: `@scania/tegel-lite@0.1.0-beta.globals-test-4`

Changes:
- Switch build script to compile `tegel-lite-global.scss` instead of `core.scss`
- Add component token `@use` imports to tl component vars files so each component is self-contained
- Move `@use 'shame'` before CSS rules to fix Sass compilation order
- Fix dropdown `--primary`/`--secondary` mode variant not working due to CSS cascade ordering bug: the base `--dropdown-background` was declared after the `&--primary`/`&--secondary` modifiers, causing the base to always override them in compiled CSS
- Replace hardcoded `--tds-*` color tokens in mode variant blocks with brand-agnostic semantic tokens (`--color-background-base`, `--color-background-layer-01`, `--color-foreground-text-strong`) so mode variants resolve correctly for both Scania and Traton brands
- Remove redundant Scania-specific imports (color primitives, brand usage, typography, fonts, logotype) from `tegel-lite-global.scss` — these are already provided by the separately compiled `scania-variables.css`/`traton-variables.css` that consumers are required to load
- Define missing `--tds-*` vars in header and side-menu component vars files (`--tds-header-height`, `--tds-header-list-item-md-height`, `--tds-header-app-launcher-menu-background`, `--tds-nav-item-border-color`, `--tds-nav-dropdown-menu-box`) — these were previously provided accidentally by `core.scss`
- Remove `z-index` from header and dropdown components — z-index is not part of Tegel Lite and `--tds-z-index-header` was never defined
- Replace hardcoded Scania font stack in `body` with `var(--body-01-font-family)` so the correct brand font is applied for both Scania and Traton


## **Issue Linking:**  
- **No issue:** The Tegel Lite build script was pointing to the wrong SCSS source file (`core.scss` instead of `tegel-lite-global.scss`), resulting in missing foundational CSS custom properties and bloated output with web component variables.

## **How to test**  
1. Run `npm run build:tegel-lite`
2. Verify `packages/tegel-lite/dist/global.css` contains `--tds-grey-958` (was missing before)
3. Verify `packages/tegel-lite/dist/global.css` does NOT contain `--tds-accordion-*` web component vars (was bloating before)
4. Verify `packages/tegel-lite/dist/global.css` does NOT contain `--scania-neutral-solid-*` or `@font-face` declarations (now provided by brand variables files)
5. Use the built package in a consuming app (React/Angular) and verify dark/light mode background works
6. Test with both `.scania` and `.traton` brand classes — mode variant backgrounds should use the correct brand colors
7. Test `tl-dropdown` with `--primary` on a `tds-mode-variant-primary` surface and `--secondary` on a `tds-mode-variant-secondary` surface — secondary dropdown should have a white background contrasting with the grey surface

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [x] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Additional context**  
Previously `core.scss` was used as the Tegel Lite global source, which included web component variables not needed by Tegel Lite. This PR restores `tegel-lite-global.scss` and moves component token imports into each component's own vars file.

The mode variant blocks used hardcoded Scania `--tds-*` tokens for background and text colors, so Traton always showed Scania colors. These are replaced with brand-agnostic semantic tokens that resolve per brand via the variables files. Scania-specific imports that duplicated what `scania-variables.css` already provides were also removed.

A pre-existing dropdown cascade bug was also fixed: the base `--dropdown-background` was declared after the modifiers in SCSS, causing the base to always win in compiled CSS. This only affected the dist output — Storybook compiles SCSS differently, masking the issue.

