### PR TITLE
fix(tds-side-menu): trap focus only when open on mobile

### DIFF
--- a/packages/core/src/components/side-menu/side-menu.tsx
+++ b/packages/core/src/components/side-menu/side-menu.tsx
@@ -51,6 +51,8 @@ export class TdsSideMenu {
    * NOTE: Only use this if you have prevented the automatic collapsing with preventDefault on the tdsCollapse event. */
   @Prop({ mutable: true }) collapsed: boolean = false;
 
+  @State() isMobile: boolean = false;
+
   @State() isUpperSlotEmpty: boolean = false;
 
   @State() isCollapsed: boolean = false;
@@ -64,18 +66,19 @@ export class TdsSideMenu {
   private matchesLgBreakpointMq!: MediaQueryList;
 
   handleMatchesLgBreakpointChange: (e: MediaQueryListEvent) => void = (e) => {
-    const isBelowLg = !e.matches;
-    if (isBelowLg) {
+    const isMobile = !e.matches;
+    this.isMobile = isMobile;
+    if (isMobile) {
       this.collapsed = false;
     } else {
-      this.collapsed = this.initialCollapsedState;
       this.open = false;
+      this.collapsed = this.initialCollapsedState;
     }
   };
 
   @Listen('keydown', { target: 'window' })
   handleKeyDown(event: KeyboardEvent) {
-    if (event.key === 'Escape' && this.open) {
+    if (event.key === 'Escape' && this.isMobile && this.open) {
       this.open = false;
     }
   }
@@ -83,6 +86,7 @@ export class TdsSideMenu {
   connectedCallback() {
     this.matchesLgBreakpointMq = window.matchMedia(`(min-width: ${GRID_LG_BREAKPOINT}px)`);
     this.matchesLgBreakpointMq.addEventListener('change', this.handleMatchesLgBreakpointChange);
+    this.isMobile = !this.matchesLgBreakpointMq.matches;
     this.isCollapsed = this.collapsed;
     this.initialCollapsedState = this.collapsed;
   }
@@ -95,13 +99,18 @@ export class TdsSideMenu {
     if (!hasUpperSlotElements) {
       this.isUpperSlotEmpty = true;
     }
-    if (window.innerWidth < GRID_LG_BREAKPOINT) {
+    if (this.isMobile) {
       this.collapsed = false;
     }
   }
 
   disconnectedCallback() {
-    this.matchesLgBreakpointMq.removeEventListener('change', this.handleMatchesLgBreakpointChange);
+    if (this.matchesLgBreakpointMq) {
+      this.matchesLgBreakpointMq.removeEventListener(
+        'change',
+        this.handleMatchesLgBreakpointChange,
+      );
+    }
   }
 
   @Watch('collapsed')
@@ -117,6 +126,10 @@ export class TdsSideMenu {
 
   @Watch('open')
   onOpenChange(newVal: boolean) {
+    if (!this.isMobile) {
+      if (newVal) this.open = false;
+      return;
+    }
     if (newVal) {
       // When menu opens, focus the first interactive element
       setTimeout(() => {
@@ -170,7 +183,7 @@ export class TdsSideMenu {
   @Listen('keydown', { target: 'window', capture: true })
   handleFocusTrap(event: KeyboardEvent) {
     // Only trap focus if the menu is open
-    if (!this.open) return;
+    if (!this.open || !this.isMobile) return;
 
     // We care only about the Tab key
     if (event.key !== 'Tab') return;
@@ -243,7 +256,7 @@ export class TdsSideMenu {
           'menu-persistent': this.persistent,
           'menu-collapsed': this.collapsed,
         }}
-        aria-expanded={!this.collapsed ? 'true' : 'false'}
+        aria-expanded={(this.isMobile ? this.open : !this.collapsed) ? 'true' : 'false'}
       >
         <div
           class={{


### PR DESCRIPTION
## **Describe pull-request**  
This PR fixes flaky keyboard tabbing where focus sometimes jumped from main content to the left side menu on desktop.
Root cause was `tds-side-menu` trapped focus whenever open === true, even on desktop persistent sidebar. This caused tab navigation in the page body to be redirected to the side menu.

* Added an isMobile state to separate mobile drawer behavior from desktop sidebar.
* Focus trap + open/close focus handling now run only on mobile.
* On desktop, open is ignored/set to false to prevent accidental focus trapping.

## **Issue Linking:**  
- **Jira:** [CDEP-1977](https://jira.scania.com/browse/CDEP-1977)

## **How to test**  
1. Open React demo preview: https://pr-282.d2vh2lmnzgzrkl.amplifyapp.com/
2. Go to Stepper in the side menu.
3. Click the first input in the main content, type, press Tab repeatedly.
4. Verify that focus continues through the form fields in the main content and does not jump to side menu.
5. Go to Form and repeat steps 3 and 4.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [x] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events