### PR TITLE
fix(tegel-lite): tl-slider disabled styles bleed to all sliders on page

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-slider/tl-slider.scss
+++ b/packages/core/src/tegel-lite/components/tl-slider/tl-slider.scss
@@ -47,7 +47,7 @@
     margin-left: 0;
   }
 
-  :has(input[type='range']:disabled) & {
+  .tl-slider:has(input[type='range']:disabled) & {
     color: var(--slider-disabled-text);
   }
 }
@@ -133,7 +133,7 @@
   flex-shrink: 0;
   align-self: center;
 
-  :has(input[type='range']:disabled) & {
+  .tl-slider:has(input[type='range']:disabled) & {
     color: var(--slider-disabled-text);
   }
 }
@@ -216,7 +216,7 @@
     display: block;
   }
 
-  :has(input[type='range']:disabled) & {
+  .tl-slider:has(input[type='range']:disabled) & {
     display: none;
   }
 }
@@ -281,7 +281,7 @@
     }
   }
 
-  :has(input[type='range']:disabled) & {
+  .tl-slider:has(input[type='range']:disabled) & {
     background-color: var(--slider-disabled);
     cursor: not-allowed;
 
@@ -318,7 +318,7 @@
   left: 50%;
   transform: translate(-50%, -50%);
 
-  :has(input[type='range']:disabled) & {
+  .tl-slider:has(input[type='range']:disabled) & {
     background-color: var(--slider-disabled);
   }
 }
@@ -337,7 +337,7 @@
   user-select: none;
   color: var(--slider-divider-values);
 
-  :has(input[type='range']:disabled) & {
+  .tl-slider:has(input[type='range']:disabled) & {
     color: var(--slider-disabled-text);
   }
 }
@@ -351,7 +351,7 @@
   top: -1px;
   z-index: 1;
 
-  :has(input[type='range']:disabled) & {
+  .tl-slider:has(input[type='range']:disabled) & {
     background-color: var(--slider-disabled);
   }
 }


### PR DESCRIPTION
## **Describe pull-request**
Fixes an issue in `tl-slider.scss` where `:has(input[type='range']:disabled)` 
selectors were unscoped, causing all sliders on a page to appear visually 
disabled whenever any single disabled slider existed in the DOM.

## **Issue Linking:**
[CDEP-2014](https://jira.scania.com/browse/CDEP-2014)

## **How to test**
1. Clone and start the [tegel-lite-react-demo](https://github.com/scania-digital-design-system/tegel-lite-react-demo) app locally
2. Install the version **without** the fix:
   `npm i @scania/tegel-lite@0.1.0-beta.updated-globals`
   _(Note: this version does not include the fix)_
3. Open the **Slider** component in the side menu
4. Note that all sliders appear disabled (muted colors, `cursor: not-allowed`), even though only one example is actually disabled
5. Now install the version with the fix:
   `npm i @scania/tegel-lite@0.1.0-beta.tl-slider-update`
6. Restart the dev server and open the Slider page again
7. Confirm that only the disabled slider example appears disabled — all others are fully interactive

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox)
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Dark/light mode and variants

## **Additional context**
Does not reproduce in Storybook since stories render in isolation — each story 
renders a single slider with no others on the page. Only manifests when multiple 
sliders coexist on the same page, which is the common real-world usage pattern.
