### PR TITLE
fix(datetime): update error and disabled state

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.scss
+++ b/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.scss
@@ -89,8 +89,8 @@
     background-color: var(--datetime-icon-error);
   }
 
-  /* Disabled state (should not override error state) */
-  .tl-datetime:has(input:disabled):not(.tl-datetime--error) &::after {
+  /* Disabled state */
+  .tl-datetime:has(input:disabled) &::after {
     background-color: var(--datetime-icon-disabled);
   }
 }
@@ -116,7 +116,7 @@
     box-shadow: inset var(--datetime-box-shadow-focus);
   }
 
-  .tl-datetime:hover &:not(:focus) {
+  .tl-datetime:hover &:not(:focus):not(:disabled) {
     box-shadow: inset var(--datetime-box-shadow-hover);
   }
 
@@ -128,8 +128,12 @@
     }
   }
 
-  .tl-datetime--error:hover &:not(:focus) {
+  .tl-datetime--error:hover &:not(:focus):not(:disabled) {
     box-shadow: inset var(--datetime-box-shadow-error-hover);
+  }
+
+  .tl-datetime--error &:disabled {
+    box-shadow: inset var(--datetime-box-shadow-error);
   }
 
   &::placeholder {


### PR DESCRIPTION
## **Describe pull-request**  
In Tegel Lite Datetime component when error is enabled together with disabled state, the icon should be disabled and there should be no hover effect. 

## **Issue Linking:**  
[CDEP-2013](https://jira.scania.com/browse/CDEP-2013)

## **How to test**  
1. Go to preview link and navigate to Tegel Lite -> Datetime component
2. Enable error state together with disabled
3. Verify that there's no hover effect and that the icon in the text field is also disabled

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
