### PR TITLE
fix(tabs): fix folder tab re-selection when navigating back to first tab

### DIFF
--- a/packages/core/src/components/tabs/folder-tabs/folder-tabs.tsx
+++ b/packages/core/src/components/tabs/folder-tabs/folder-tabs.tsx
@@ -102,7 +102,7 @@ export class TdsFolderTabs {
       return tabElement;
     });
 
-    if (this.selectedIndex) {
+    if (this.selectedIndex !== undefined) {
       this.tabElements[this.selectedIndex].setSelected(true);
     }
   }

--- a/packages/core/src/components/tabs/test/folder-tabs/folder-tabs.e2e.ts
+++ b/packages/core/src/components/tabs/test/folder-tabs/folder-tabs.e2e.ts
@@ -43,6 +43,7 @@ testConfigurations.withModeVariants.forEach((config) => {
 test.describe.parallel(componentName, () => {
   let folderTabs;
   let firstTab;
+  let firstTabDiv;
   let secondTab;
   let secondTabDiv;
   let thirdTab;
@@ -59,6 +60,7 @@ test.describe.parallel(componentName, () => {
     thirdTab = page.locator('button', { hasText: 'Third Tab' });
     fourthTab = page.locator('button', { hasText: 'Fourth Tab' });
     // Divs inside tabs specifically for click interactions
+    firstTabDiv = page.locator('tds-folder-tab:has-text("First tab") >> div');
     secondTabDiv = page.locator('tds-folder-tab:has-text("Second tab is much longer") >> div');
     thirdTabDiv = page.locator('tds-folder-tab:has-text("Third Tab") >> div');
   });
@@ -99,5 +101,19 @@ test.describe.parallel(componentName, () => {
     await expect(folderTabs).toHaveAttribute('selected-index', '2', { timeout: 5000 });
     await expect(secondTabDiv).not.toHaveClass(/selected/);
     await expect(thirdTabDiv).toHaveClass(/selected/);
+  });
+
+  test('Switching from second tab back to first tab shows first tab as selected', async () => {
+    // Given
+    await secondTabDiv.click({ force: true });
+    await expect(folderTabs).toHaveAttribute('selected-index', '1', { timeout: 5000 });
+
+    // When
+    await firstTabDiv.click({ force: true });
+
+    // Then
+    await expect(folderTabs).toHaveAttribute('selected-index', '0', { timeout: 5000 });
+    await expect(firstTabDiv).toHaveClass(/selected/);
+    await expect(secondTabDiv).not.toHaveClass(/selected/);
   });
 });


### PR DESCRIPTION
## **Describe pull-request**  
The active tab underline disappeared when navigating back to the first folder tab because `handleSelectedIndexUpdate` used a truthy check (`if (this.selectedIndex)`) that evaluates to false when `selectedIndex` is 0. The condition is now `if (this.selectedIndex !== undefined)` so tab[0] is correctly re-selected. A regression test covering the Tab1 → Tab2 → Tab1 sequence is included.


## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://jira.scania.com/browse/CDEP-)
- **GitHub:** Include issue link  
- **No issue:** Describe the problem being solved.  

## **How to test**  
1. Go to the Folder Tabs component in Storybook
2. Click the second tab — verify it becomes selected
3. Click the first tab — verify it becomes selected and the underline appears correctly
4. Confirm the second tab is no longer marked as selected

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
