### PR TITLE
fix(tabs): fix folder tab selection when navigating back to first tab

### DIFF
--- a/packages/core/src/components/tabs/folder-tabs/folder-tabs.tsx
+++ b/packages/core/src/components/tabs/folder-tabs/folder-tabs.tsx
@@ -102,7 +102,7 @@ export class TdsFolderTabs {
       return tabElement;
     });
 
-    if (this.selectedIndex) {
+    if (this.selectedIndex !== undefined) {
       this.tabElements[this.selectedIndex].setSelected(true);
     }
   }

--- a/packages/core/src/components/tabs/test/folder-tabs/folder-tabs.e2e.ts
+++ b/packages/core/src/components/tabs/test/folder-tabs/folder-tabs.e2e.ts
@@ -43,6 +43,7 @@ testConfigurations.withModeVariants.forEach((config) => {
 test.describe.parallel(componentName, () => {
   let folderTabs;
   let firstTab;
+  let firstTabDiv;
   let secondTab;
   let secondTabDiv;
   let thirdTab;
@@ -59,6 +60,7 @@ test.describe.parallel(componentName, () => {
     thirdTab = page.locator('button', { hasText: 'Third Tab' });
     fourthTab = page.locator('button', { hasText: 'Fourth Tab' });
     // Divs inside tabs specifically for click interactions
+    firstTabDiv = page.locator('tds-folder-tab:has-text("First tab") >> div');
     secondTabDiv = page.locator('tds-folder-tab:has-text("Second tab is much longer") >> div');
     thirdTabDiv = page.locator('tds-folder-tab:has-text("Third Tab") >> div');
   });
@@ -99,5 +101,19 @@ test.describe.parallel(componentName, () => {
     await expect(folderTabs).toHaveAttribute('selected-index', '2', { timeout: 5000 });
     await expect(secondTabDiv).not.toHaveClass(/selected/);
     await expect(thirdTabDiv).toHaveClass(/selected/);
+  });
+
+  test('Switching from second tab back to first tab shows first tab as selected', async () => {
+    // Given
+    await secondTabDiv.click({ force: true });
+    await expect(folderTabs).toHaveAttribute('selected-index', '1', { timeout: 5000 });
+
+    // When
+    await firstTabDiv.click({ force: true });
+
+    // Then
+    await expect(folderTabs).toHaveAttribute('selected-index', '0', { timeout: 5000 });
+    await expect(firstTabDiv).toHaveClass(/selected/);
+    await expect(secondTabDiv).not.toHaveClass(/selected/);
   });
 });


### PR DESCRIPTION
## Summary
- Fixed a bug where navigating back to the first folder tab (index 0) did not select it, because `if (this.selectedIndex)` evaluated `0` as falsy
- Changed the condition to `if (this.selectedIndex !== undefined)` to correctly handle index 0
- Added a Playwright e2e test covering the Tab1 → Tab2 → Tab1 regression scenario

## Test plan
- [ ] Run `npm test` in `packages/core` and verify the new test passes
- [ ] Manually verify that clicking the first folder tab selects it when navigating back from another tab