### PR TITLE
fix(tl-text-field): fix vertical alignment of prefix and suffix icons

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-text-field/readme.md
+++ b/packages/core/src/tegel-lite/components/tl-text-field/readme.md
@@ -7,12 +7,14 @@ The Text Field component provides a single-line input field with labels, helper 
 ```html
 <div class="tl-text-field">
   <label class="tl-text-field__label" for="input1">Label</label>
-  <input 
-    type="text" 
-    id="input1"
-    class="tl-text-field__input"
-    placeholder="Enter text"
-  />
+  <div class="tl-text-field__input-wrapper">
+    <input
+      type="text"
+      id="input1"
+      class="tl-text-field__input"
+      placeholder="Enter text"
+    />
+  </div>
   <div class="tl-text-field__bottom">
     <div class="tl-text-field__helper">Helper text</div>
   </div>
@@ -34,6 +36,7 @@ The Text Field component provides a single-line input field with labels, helper 
 | ------------------------------------ | ------------ | ------------------------------- |
 | `.tl-text-field`                     | `<div>`      | Main container                  |
 | `.tl-text-field__label`              | `<label>`    | Label for the input             |
+| `.tl-text-field__input-wrapper`      | `<div>`      | Wrapper around input, prefix/suffix, and inside-label |
 | `.tl-text-field__input`              | `<input>`    | Input element                   |
 | `.tl-text-field__prefix--text`       | `<span>`     | Prefix text content             |
 | `.tl-text-field__prefix--icon`       | `<span>`     | Prefix icon content             |

--- a/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.scss
+++ b/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.scss
@@ -15,7 +15,26 @@
     min-width: auto;
   }
 
-  &--readonly:not(&--disabled):not(&--hide-readonly-icon)::before {
+  &:has(.tl-text-field__input:disabled) {
+    cursor: not-allowed;
+  }
+
+  .tl-icon {
+    background-color: var(--text-field-affix);
+
+    :has(.tl-text-field__input:disabled) & {
+      background-color: var(--text-field-affix-disabled);
+    }
+  }
+}
+
+.tl-text-field__input-wrapper {
+  position: relative;
+
+  .tl-text-field:has(.tl-text-field__input[readonly]):not(:has(.tl-text-field__input:disabled)):not(
+  .tl-text-field--hide-readonly-icon
+)
+  &::before {
     content: '';
     position: absolute;
     top: 50%;
@@ -29,25 +48,6 @@
     mask-position: center;
     transform: translateY(-50%);
     z-index: 1;
-  }
-
-  // Outside label - readonly icon position adjustment (only when label exists)
-  &:not(&--label-inside):has(.tl-text-field__label):has(.tl-text-field__input[readonly]):not(
-      :has(.tl-text-field__input:disabled)
-    ):not(&--hide-readonly-icon)::before {
-    top: calc(50% + 24px);
-  }
-
-  &:has(.tl-text-field__input:disabled) {
-    cursor: not-allowed;
-  }
-
-  .tl-icon {
-    background-color: var(--text-field-affix);
-
-    :has(.tl-text-field__input:disabled) & {
-      background-color: var(--text-field-affix-disabled);
-    }
   }
 }
 
@@ -83,9 +83,9 @@
   }
 
   .tl-text-field--success:not(:has(.tl-text-field__input[readonly])):not(
-      :has(.tl-text-field__input:disabled)
-    )
-    &:not(:focus) {
+  :has(.tl-text-field__input:disabled)
+)
+  &:not(:focus) {
     box-shadow: inset var(--text-field-box-shadow-success);
   }
 
@@ -106,7 +106,7 @@
   }
 
   :has(.tl-text-field__input[readonly]):not(:has(.tl-text-field__input:disabled)):hover
-    &:not(:focus) {
+  &:not(:focus) {
     box-shadow: inset var(--text-field-box-shadow-hover);
   }
 
@@ -118,9 +118,9 @@
   }
 
   .tl-text-field:has(.tl-text-field__input[readonly]):not(:has(.tl-text-field__input:disabled)):not(
-      .tl-text-field--hide-readonly-icon
-    )
-    & {
+  .tl-text-field--hide-readonly-icon
+)
+  & {
     padding-right: 54px;
   }
 
@@ -194,6 +194,7 @@
     @include detail-02;
 
     position: absolute;
+    top: 50%;
     left: var(--text-field-label-inside-left, 16px);
     color: var(--text-field-label-inside);
     pointer-events: none;
@@ -201,19 +202,6 @@
     transform-origin: top left;
     transition: transform 0.15s, font-size 0.15s, color 0.15s, top 0.15s;
     z-index: 1;
-  }
-
-  /* Center label in input row before focus/fill */
-  .tl-text-field--label-inside.tl-text-field--lg & {
-    top: 28px; /* half of 56px input height */
-  }
-
-  .tl-text-field--label-inside.tl-text-field--md & {
-    top: 24px; /* half of 48px input height */
-  }
-
-  .tl-text-field--label-inside.tl-text-field--sm & {
-    top: 20px; /* half of 40px input height */
   }
 
   .tl-text-field--label-inside:has(.tl-text-field__prefix--icon) & {
@@ -227,10 +215,10 @@
   // Focus and filled state for lg and md
   .tl-text-field--label-inside.tl-text-field--lg:has(.tl-text-field__input:focus) &,
   .tl-text-field--label-inside.tl-text-field--lg:has(.tl-text-field__input:not(:placeholder-shown))
-    &,
+  &,
   .tl-text-field--label-inside.tl-text-field--md:has(.tl-text-field__input:focus) &,
   .tl-text-field--label-inside.tl-text-field--md:has(.tl-text-field__input:not(:placeholder-shown))
-    & {
+  & {
     @include detail-07;
 
     top: 8px;
@@ -240,47 +228,47 @@
 
   // Keep prefix offset when focused for lg and md
   .tl-text-field--label-inside.tl-text-field--lg:has(.tl-text-field__prefix--icon):has(
-      .tl-text-field__input:focus
-    )
-    &,
+  .tl-text-field__input:focus
+)
+  &,
   .tl-text-field--label-inside.tl-text-field--lg:has(.tl-text-field__prefix--icon):has(
-      .tl-text-field__input:not(:placeholder-shown)
-    )
-    &,
+  .tl-text-field__input:not(:placeholder-shown)
+)
+  &,
   .tl-text-field--label-inside.tl-text-field--md:has(.tl-text-field__prefix--icon):has(
-      .tl-text-field__input:focus
-    )
-    &,
+  .tl-text-field__input:focus
+)
+  &,
   .tl-text-field--label-inside.tl-text-field--md:has(.tl-text-field__prefix--icon):has(
-      .tl-text-field__input:not(:placeholder-shown)
-    )
-    & {
+  .tl-text-field__input:not(:placeholder-shown)
+)
+  & {
     left: calc(16px + 20px + 8px);
   }
 
   .tl-text-field--label-inside.tl-text-field--lg:has(.tl-text-field__prefix--text):has(
-      .tl-text-field__input:focus
-    )
-    &,
+  .tl-text-field__input:focus
+)
+  &,
   .tl-text-field--label-inside.tl-text-field--lg:has(.tl-text-field__prefix--text):has(
-      .tl-text-field__input:not(:placeholder-shown)
-    )
-    &,
+  .tl-text-field__input:not(:placeholder-shown)
+)
+  &,
   .tl-text-field--label-inside.tl-text-field--md:has(.tl-text-field__prefix--text):has(
-      .tl-text-field__input:focus
-    )
-    &,
+  .tl-text-field__input:focus
+)
+  &,
   .tl-text-field--label-inside.tl-text-field--md:has(.tl-text-field__prefix--text):has(
-      .tl-text-field__input:not(:placeholder-shown)
-    )
-    & {
+  .tl-text-field__input:not(:placeholder-shown)
+)
+  & {
     left: calc(16px + var(--text-field-affix-width-text) + 8px);
   }
 
   // Focus and filled state for sm - label disappears
   .tl-text-field--label-inside.tl-text-field--sm:has(.tl-text-field__input:focus) &,
   .tl-text-field--label-inside.tl-text-field--sm:has(.tl-text-field__input:not(:placeholder-shown))
-    & {
+  & {
     opacity: 0;
     visibility: hidden;
   }
@@ -339,9 +327,9 @@
   }
 
   .tl-text-field--error:not(:has(.tl-text-field__input[readonly])):not(
-      :has(.tl-text-field__input:disabled)
-    )
-    & {
+  :has(.tl-text-field__input:disabled)
+)
+  & {
     color: var(--text-field-error);
   }
 
@@ -361,9 +349,9 @@
   }
 
   .tl-text-field--error:not(:has(.tl-text-field__input[readonly])):not(
-      :has(.tl-text-field__input:disabled)
-    )
-    & {
+  :has(.tl-text-field__input:disabled)
+)
+  & {
     color: var(--text-field-error);
 
     .tl-text-field__charcounter-divider {
@@ -384,14 +372,8 @@
     position: absolute;
     left: 16px;
     top: 50%;
-    transform: translateY(calc(-50% - 1px));
+    transform: translateY(-50%);
     z-index: 1;
-  }
-
-  // Default behavior (label outside) - prefix position adjustment (only when a label element exists)
-  .tl-text-field:has(.tl-text-field__label):not(.tl-text-field--label-inside) &--text,
-  .tl-text-field:has(.tl-text-field__label):not(.tl-text-field--label-inside) &--icon {
-    transform: translateY(calc(-50% + 24px));
   }
 
   :has(.tl-text-field__input:disabled) &--text,
@@ -420,14 +402,8 @@
     position: absolute;
     right: 16px;
     top: 50%;
-    transform: translateY(calc(-50% - 1px));
+    transform: translateY(-50%);
     z-index: 1;
-  }
-
-  // Default behavior (label outside) - suffix position adjustment (only when a label element exists)
-  .tl-text-field:has(.tl-text-field__label):not(.tl-text-field--label-inside) &--text,
-  .tl-text-field:has(.tl-text-field__label):not(.tl-text-field--label-inside) &--icon {
-    transform: translateY(calc(-50% + 24px));
   }
 
   :has(.tl-text-field__input:disabled) &--text,
@@ -441,34 +417,6 @@
     .tl-icon,
     > .tl-icon {
       background-color: var(--text-field-affix-disabled) !important;
-    }
-  }
-}
-
-.tl-text-field__suffix {
-  @include affix-base;
-
-  right: 16px;
-  padding-right: 0;
-  z-index: 1;
-
-  // Default behavior (label outside) - suffix position adjustment (only when a label element exists)
-  .tl-text-field:has(.tl-text-field__label):not(.tl-text-field--label-inside) &--text,
-  .tl-text-field:has(.tl-text-field__label):not(.tl-text-field--label-inside) &--icon {
-    transform: translateY(calc(-50% + 24px));
-  }
-
-  :has(.tl-text-field__input:disabled) &--text,
-  :has(.tl-text-field__input:disabled) &--icon {
-    color: var(--text-field-affix-disabled);
-
-    > * {
-      color: var(--text-field-affix-disabled);
-    }
-
-    .tl-icon,
-    > .tl-icon {
-      background-color: var(--text-field-affix-disabled);
     }
   }
 

--- a/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-text-field/tl-text-field.stories.tsx
@@ -158,7 +158,7 @@ const Template = ({
       prefixContent = '<span class="tl-text-field__prefix--text">$</span>';
     } else {
       prefixContent =
-        '<span class="tl-icon tl-icon--info tl-icon--20 tl-text-field__prefix--icon"></span>';
+        '<span class="tl-icon tl-icon--placeholder tl-icon--20 tl-text-field__prefix--icon"></span>';
     }
   }
 
@@ -168,7 +168,7 @@ const Template = ({
       suffixContent = '<span class="tl-text-field__suffix--text">$</span>';
     } else {
       suffixContent =
-        '<span class="tl-icon tl-icon--info tl-icon--20 tl-text-field__suffix--icon"></span>';
+        '<span class="tl-icon tl-icon--placeholder tl-icon--20 tl-text-field__suffix--icon"></span>';
     }
   }
 
@@ -199,10 +199,13 @@ const Template = ({
       "@scania/tegel-lite/tl-icon.css"
     -->
     <div class="${componentClasses}"${styleAttr}>
-      ${labelContent}
-      <input class="tl-text-field__input" ${inputAttrs} />
-      ${prefixContent}
-      ${suffixContent}
+      ${labelPosition === 'Outside' ? labelContent : ''}
+      <div class="tl-text-field__input-wrapper">
+        ${labelPosition === 'Inside' ? labelContent : ''}
+        <input class="tl-text-field__input" ${inputAttrs} />
+        ${prefixContent}
+        ${suffixContent}
+      </div>
       ${helperWrapperContent}
     </div>
 


### PR DESCRIPTION
## **Describe pull-request**  
Fixes vertical alignment of prefix/suffix icons and text in the `tl-text-field` component, 
and fixes the readonly icon which was taking up space but not rendering visibly.

The root cause was that prefix, suffix, and readonly icons were absolutely positioned 
relative to the entire `.tl-text-field` container — which includes the label (when outside) 
and the helper text below. The original code tried to compensate with hardcoded transform 
offsets (e.g. `translateY(calc(-50% + 24px))` for label-outside, `translateY(calc(-50% - 1px))` 
as a base), but these were fragile and didn't reliably center the icons across all 
combinations of sizes and label positions.

The fix introduces a `.tl-text-field__input-wrapper` element that wraps the input, prefix, 
suffix, and inside-label. This gives the absolutely positioned elements a correct positioning 
context scoped to the input area, so `top: 50%` naturally centers them on the input.

This also removes:
- Hardcoded transform offsets (`translateY(calc(-50% + 24px))`) that compensated for the label height
- A `-1px` adjustment in the prefix/suffix transforms
- A duplicate `.tl-text-field__suffix` block
- Fixed `top` values per size for the inside-label (replaced with `top: 50%; transform: translateY(-50%)`)
- The separate readonly icon position adjustment rule for label-outside

## **Issue Linking:**  
- **Jira:** [CDEP-2016](https://jira.scania.com/browse/CDEP-2016)

## **How to test**  
1. Go to Storybook → Tegel Lite (Beta) → Text Field: [https://pr-1794.d3fazya28914g3.amplifyapp.com/?path=/story/tegel-lite-beta-text-field--default](https://pr-1794.d3fazya28914g3.amplifyapp.com/?path=/story/tegel-lite-beta-text-field--default)
2. Enable Prefix (Icon and Text types) — verify icon/text is vertically centered in the input
3. Enable Suffix (Icon and Text types) — verify icon/text is vertically centered in the input
4. Test with all label positions (Outside, Inside, No label) and all sizes (Large, Medium, Small)
5. Enable Read only — verify the readonly icon is vertically centered
6. Toggle "Hide read only icon" — verify it disappears

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [x] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [x] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [x] Dark/light mode and variants 
- [x] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
This is a structural change to the HTML and SCSS. Consumers using Tegel Lite's `tl-text-field` will need to add the `.tl-text-field__input-wrapper` div around their input, prefix, suffix, and inside-label elements. The outside label and helper/counter content stay outside the wrapper.
