### PR TITLE
chore: tegel lite release workflow

### DIFF
--- a/.github/workflows/tegel-lite-release.yml
+++ b/.github/workflows/tegel-lite-release.yml
@@ -1,0 +1,103 @@
+name: Tegel Lite Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to use'
+        required: true
+        default: 'develop'
+
+      nodeVersion:
+        description: 'Node version'
+        required: true
+        default: '22.12.0'
+        type: string
+
+      tag:
+        description: 'NPM tag'
+        required: true
+        default: 'latest'
+        type: choice
+        options:
+          - latest
+          - beta
+
+      betaVersionSuffix:
+        description: 'Beta version suffix (e.g., beta.0, beta.1) — only used when tag is beta'
+        required: false
+        default: 'beta.0'
+        type: string
+
+jobs:
+  release-tegel-lite:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.nodeVersion }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Configure Git user
+        run: |
+          git config --global user.name "Tegel - Scania"
+          git config --global user.email "tegel.design.system@gmail.com"
+
+      - name: Validate beta version suffix
+        if: ${{ inputs.tag == 'beta' }}
+        env:
+          INPUT_BETA_VERSION_SUFFIX: ${{ inputs.betaVersionSuffix }}
+        run: |
+          if ! printf '%s' "$INPUT_BETA_VERSION_SUFFIX" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9.\-]{0,20}$'; then
+            echo "Invalid betaVersionSuffix: $INPUT_BETA_VERSION_SUFFIX" >&2
+            exit 1
+          fi
+          echo "BETA_VERSION_SUFFIX=$INPUT_BETA_VERSION_SUFFIX" >> $GITHUB_ENV
+
+      - name: Install root dependencies
+        run: npm install
+
+      - name: Install Core dependencies
+        working-directory: packages/core
+        run: npm install
+
+      - name: Build Tegel Lite package
+        run: npm run build:tegel-lite
+
+      - name: Update package version for beta
+        if: ${{ inputs.tag == 'beta' }}
+        working-directory: packages/tegel-lite
+        run: |
+          current_version=$(jq -r '.version' package.json | sed 's/-[a-zA-Z0-9.\-]*$//')
+          new_version="${current_version}-${BETA_VERSION_SUFFIX}"
+          echo "Updating package.json version to $new_version"
+          jq ".version = \"$new_version\"" package.json > package.tmp.json
+          mv package.tmp.json package.json
+
+      - name: Check if Tegel Lite version already exists
+        id: check-version
+        working-directory: packages/tegel-lite
+        run: |
+          PACKAGE_NAME=$(jq -r '.name' package.json)
+          PACKAGE_VERSION=$(jq -r '.version' package.json)
+          if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version > /dev/null 2>&1; then
+            echo "Version $PACKAGE_VERSION already exists. Skipping publish."
+            echo "VERSION_EXISTS=true" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION_EXISTS=false" >> $GITHUB_OUTPUT
+          fi
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Publish Tegel Lite package to NPM
+        if: steps.check-version.outputs.VERSION_EXISTS != 'true'
+        working-directory: packages/tegel-lite
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --tag ${{ inputs.tag }}

--- a/.github/workflows/tegel-lite-release.yml
+++ b/.github/workflows/tegel-lite-release.yml
@@ -14,23 +14,14 @@ on:
         default: '22.12.0'
         type: string
 
-      tag:
-        description: 'NPM tag'
-        required: true
-        default: 'latest'
-        type: choice
-        options:
-          - latest
-          - beta
-
       betaVersionSuffix:
-        description: 'Beta version suffix (e.g., beta.0, beta.1) — only used when tag is beta'
-        required: false
+        description: 'Beta version suffix (e.g., beta.0, beta.1)'
+        required: true
         default: 'beta.0'
         type: string
 
 jobs:
-  release-tegel-lite:
+  beta-release-tegel-lite:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -51,7 +42,6 @@ jobs:
           git config --global user.email "tegel.design.system@gmail.com"
 
       - name: Validate beta version suffix
-        if: ${{ inputs.tag == 'beta' }}
         env:
           INPUT_BETA_VERSION_SUFFIX: ${{ inputs.betaVersionSuffix }}
         run: |
@@ -68,36 +58,36 @@ jobs:
         working-directory: packages/core
         run: npm install
 
-      - name: Build Tegel Lite package
-        run: npm run build:tegel-lite
-
-      - name: Update package version for beta
-        if: ${{ inputs.tag == 'beta' }}
+      - name: Update Tegel Lite package version
+        id: set-version
         working-directory: packages/tegel-lite
         run: |
           current_version=$(jq -r '.version' package.json | sed 's/-[a-zA-Z0-9.\-]*$//')
           new_version="${current_version}-${BETA_VERSION_SUFFIX}"
-          echo "Updating package.json version to $new_version"
+          echo "Setting new version: $new_version"
           jq ".version = \"$new_version\"" package.json > package.tmp.json
           mv package.tmp.json package.json
+          echo "PACKAGE_VERSION=$new_version" >> $GITHUB_OUTPUT
+
+      - name: Build Tegel Lite package
+        run: npm run build:tegel-lite
 
       - name: Check if Tegel Lite version already exists
         id: check-version
         working-directory: packages/tegel-lite
         run: |
           PACKAGE_NAME=$(jq -r '.name' package.json)
-          PACKAGE_VERSION=$(jq -r '.version' package.json)
+          PACKAGE_VERSION=${{ steps.set-version.outputs.PACKAGE_VERSION }}
           if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version > /dev/null 2>&1; then
             echo "Version $PACKAGE_VERSION already exists. Skipping publish."
             echo "VERSION_EXISTS=true" >> $GITHUB_OUTPUT
           else
             echo "VERSION_EXISTS=false" >> $GITHUB_OUTPUT
           fi
-          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
 
       - name: Publish Tegel Lite package to NPM
         if: steps.check-version.outputs.VERSION_EXISTS != 'true'
         working-directory: packages/tegel-lite
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --tag ${{ inputs.tag }}
+        run: npm publish --access public --tag beta


### PR DESCRIPTION
## **Describe pull-request**
Adds a new standalone GitHub Actions workflow for publishing `@scania/tegel-lite` as a beta release independently of the core package. Previously, tegel-lite could only be published as part of the full beta release workflow alongside core — this workflow allows publishing tegel-lite on its own with a custom beta version suffix.

## **Issue Linking:**
- **No issue:** No existing workflow for standalone tegel-lite beta releases.

## **How to test**
1. Merge this PR into `develop`
2. Go to Actions → "Tegel Lite Release" in GitHub
3. Trigger the workflow manually with a branch, node version, and beta version suffix (e.g. `beta.0`)
4. Verify the versioned package is published to NPM under the `beta` tag

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox)
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components
- [ ] Dark/light mode and variants
- [ ] Input fields – values should be displayed properly
- [ ] Events

## **Screenshots**
N/A — CI/workflow change only.

## **Additional context**
To promote a published beta version to `latest` on NPM, run manually:
`npm dist-tag add @scania/tegel-lite@<version> latest`
