### PR TITLE
fix(tegel-lite): remove unused global imports

### DIFF
--- a/packages/core/src/global/tegel-lite-global.scss
+++ b/packages/core/src/global/tegel-lite-global.scss
@@ -8,29 +8,18 @@
 @use '../../../../spacing/units' as *;
 @use '../../../../spacing/radius' as *;
 
+// Spacing vars
+@use '../../../../spacing/spacing-vars' as *;
+
 // Motion
 @use '../../../../motion' as *;
 
 // Colors
 @use '../../../../color/color' as *;
 
-// Grid (Deprecated - will be removed in version 2.0)
-@use '../../../../grid-deprecated/grid-deprecated' as *;
-
-// Grid new
-@use '../../../../grid/grid' as *;
-
 // Vars
 @use '_variables' as *;
 @use 'tl-scrollbar-vars' as *;
-
-// Utility classes
-@use '_utility-classes' as *;
-
-// Beta components
-@use '../components/_beta/date-picker/date-picker-single/date-picker-vars' as *;
-
-@use 'shame' as *;
 
 body {
   font-family: var(--body-01-font-family);


### PR DESCRIPTION
## **Describe pull-request**

Remove unused global SCSS imports from `tegel-lite-global.scss` to reduce the tegel-lite bundle size and remove unnecessary dependencies.

**Removed imports:**
- `grid-deprecated` (deprecated, not used by tegel-lite components)
- `grid` (not used by tegel-lite components)
- `_utility-classes` (not used by tegel-lite components)
- `beta date-picker` (not used by tegel-lite)
- `shame` (not needed)

**Added:**
- `spacing-vars` as a direct import — it was previously included via the deprecated grid import and is needed by tegel-lite components.

## **Issue Linking:**
- **Jira:** [CDEP-2031](https://jira.scania.com/browse/CDEP-2031)

## **How to test**
A beta version `@scania/tegel-lite@0.1.0-beta.trim-globals.0` has been published and installed in both demo apps on these preview links:
- **React:** https://pr-48.dxqjewiof3vdp.amplifyapp.com
- **Angular:** https://pr-33.d1gpvxaycl8qno.amplifyapp.com

1. Open the preview links above
2. Navigate through the components and verify they render correctly

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [x] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Screenshots**
N/A — no visual changes expected.
