### PR TITLE
fix(style-dictionary): add tl mode variants

### DIFF
--- a/style-dictionary.config.mjs
+++ b/style-dictionary.config.mjs
@@ -469,13 +469,13 @@ const themeConfigs = Array.from(brands.values()).reduce((configs, brand) => {
     if (brand.name === 'scania') {
       colorTokensSelector =
         themeType === 'light'
-          ? `:root,\n.tds-mode-light,\n.scania .tds-mode-light`
-          : `.tds-mode-dark,\n.scania .tds-mode-dark`;
+          ? `:root,\n.tds-mode-light,\n.tl-mode-light,\n.scania .tds-mode-light,\n.scania .tl-mode-light`
+          : `.tds-mode-dark,\n.tl-mode-dark,\n.scania .tds-mode-dark,\n.scania .tl-mode-dark`;
     } else {
       colorTokensSelector =
         themeType === 'light'
-          ? `.traton,\n.traton .tds-mode-light`
-          : `.traton .tds-mode-dark`;
+          ? `.traton,\n.traton .tds-mode-light,\n.traton .tl-mode-light`
+          : `.traton .tds-mode-dark,\n.traton .tl-mode-dark`;
     }
 
     configs[themeName] = {

--- a/tokens/scss/scania/color-dark.scss
+++ b/tokens/scss/scania/color-dark.scss
@@ -3,7 +3,9 @@
  */
 
 .tds-mode-dark,
-.scania .tds-mode-dark {
+.tl-mode-dark,
+.scania .tds-mode-dark,
+.scania .tl-mode-dark {
   --color-background-base: var(--scania-color-grey-950);
   --color-background-layer-01: var(--scania-color-grey-900);
   --color-background-layer-02: var(--scania-color-grey-850);

--- a/tokens/scss/scania/color-light.scss
+++ b/tokens/scss/scania/color-light.scss
@@ -4,7 +4,9 @@
 
 :root,
 .tds-mode-light,
-.scania .tds-mode-light {
+.tl-mode-light,
+.scania .tds-mode-light,
+.scania .tl-mode-light {
   --color-background-base: var(--scania-color-grey-00);
   --color-background-layer-01: var(--scania-color-grey-50);
   --color-background-layer-02: var(--scania-color-grey-00);

--- a/tokens/scss/traton/color-dark.scss
+++ b/tokens/scss/traton/color-dark.scss
@@ -2,7 +2,8 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.traton .tds-mode-dark {
+.traton .tds-mode-dark,
+.traton .tl-mode-dark {
   --color-background-base: var(--traton-color-blue-1000);
   --color-background-layer-01: var(--traton-color-blue-950);
   --color-background-layer-02: var(--traton-color-blue-900);

--- a/tokens/scss/traton/color-light.scss
+++ b/tokens/scss/traton/color-light.scss
@@ -3,7 +3,8 @@
  */
 
 .traton,
-.traton .tds-mode-light {
+.traton .tds-mode-light,
+.traton .tl-mode-light {
   --color-background-base: var(--traton-color-grey-50);
   --color-background-layer-01: var(--traton-color-grey-100);
   --color-background-layer-02: var(--traton-color-grey-50);


### PR DESCRIPTION
## **Describe pull-request**  
This PR updates the style dictionary config to add tl-mode-variant classes to tokens light/dark color css files. 

## **Issue Linking:**  
- **No issue:** Describe the problem being solved.  

## **How to test**  
1. Check that tokens -> scss -> scania files:
color-dark.scss & color-light.scss
contains tl-mode-light and tl-mode-dark classes

2.Check that tokens -> scss -> traton files:
color-dark.scss & color-light.scss
contains tl-mode-light and tl-mode-dark classes

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
