### PR TITLE
fix(storybook): use CSS vars for background colors instead of hardcoded values

### DIFF
--- a/packages/core/.storybook/preview.css
+++ b/packages/core/.storybook/preview.css
@@ -44,13 +44,21 @@ a:not(tds-link *, tds-breadcrumb *) {
 
 :root,
 .tds-mode-light .docs-story {
-  color: var(--tds-grey-950);
-  background-color: var(--tds-white);
+  color: var(--color-foreground-text-strong, var(--tds-grey-950));
+  background-color: var(--color-background-base, var(--tds-white));
+}
+
+.tds-mode-light.tds-mode-variant-secondary .docs-story {
+  background-color: var(--color-background-layer-01, var(--tds-grey-50));
 }
 
 .tds-mode-dark .docs-story {
-  color: var(--tds-grey-100);
-  background-color: var(--tds-grey-950);
+  color: var(--color-foreground-text-strong, var(--tds-grey-100));
+  background-color: var(--color-background-base, var(--tds-grey-950));
+}
+
+.tds-mode-dark.tds-mode-variant-secondary .docs-story {
+  background-color: var(--color-background-layer-01, var(--tds-grey-900));
 }
 
 /* Force code examples in markdown (readme/notes) to use white background with dark text */

--- a/packages/core/.storybook/preview.ts
+++ b/packages/core/.storybook/preview.ts
@@ -7,49 +7,15 @@ import '../dist/tegel/tegel.css';
 import './preview.css';
 import { ScaniaDark, ScaniaLight } from './ScaniaLogotype';
 
-const applyBackgroundColor = (brand: string, modeVariant: string, isDarkMode: boolean) => {
-  const body = document.body;
-
-  const backgrounds = {
-    scania: {
-      light: {
-        primary: '#FFFFFF', // grey-00
-        secondary: '#F6F7F9', // grey-50
-      },
-      dark: {
-        primary: '#0B0C0F', // grey-950
-        secondary: '#15181D', // grey-900
-      },
-    },
-    traton: {
-      light: {
-        primary: '#FCFBF7',
-        secondary: '#F6F3E9',
-      },
-      dark: {
-        primary: '#001214',
-        secondary: '#001D21',
-      },
-    },
-  };
-
-  const brandColors = backgrounds[brand]?.[isDarkMode ? 'dark' : 'light'];
-  body.style.backgroundColor = brandColors?.[modeVariant] || '';
-};
-
 // Initialize dark mode listener after Storybook is ready
 try {
   const channel = addons.getChannel();
 
   channel.on('DARK_MODE', (isDarkMode) => {
     const body = document.body;
-    const brand = document.documentElement.classList.contains('traton') ? 'traton' : 'scania';
-    const modeVariant = body.classList.contains('tds-mode-secondary') ? 'secondary' : 'primary';
 
     body.classList.remove('tds-mode-light', 'tds-mode-dark');
     body.classList.add(`tds-mode-${isDarkMode ? 'dark' : 'light'}`);
-
-    applyBackgroundColor(brand, modeVariant, isDarkMode);
   });
 } catch (error) {
   // Channel might not be available during initial load
@@ -104,11 +70,8 @@ const toggleBrandDecorator: Decorator = (StoryFn, context) => {
   html.classList.remove('scania', 'traton');
   html.classList.add(brand);
 
-  document.body.classList.remove('tds-mode-primary', 'tds-mode-secondary');
-  document.body.classList.add(`tds-mode-${modeVariant}`);
-
-  const isDarkMode = document.body.classList.contains('tds-mode-dark');
-  applyBackgroundColor(brand, modeVariant, isDarkMode);
+  document.body.classList.remove('tds-mode-variant-primary', 'tds-mode-variant-secondary');
+  document.body.classList.add(`tds-mode-variant-${modeVariant}`);
 
   return StoryFn();
 };

--- a/packages/core/src/global/core.scss
+++ b/packages/core/src/global/core.scss
@@ -83,19 +83,19 @@ body {
 
 :root,
 .tds-mode-light {
-  color: var(--tds-grey-958);
-  background-color: var(--tds-white);
+  color: var(--color-foreground-text-strong);
+  background-color: var(--color-background-base);
 
   &.tds-mode-variant-primary,
   & .tds-mode-variant-primary {
-    color: var(--tds-grey-958);
-    background-color: var(--tds-white);
+    color: var(--color-foreground-text-strong);
+    background-color: var(--color-background-base);
   }
 
   &.tds-mode-variant-secondary,
   & .tds-mode-variant-secondary {
-    color: var(--tds-grey-958);
-    background-color: var(--tds-grey-50);
+    color: var(--color-foreground-text-strong);
+    background-color: var(--color-background-layer-01);
   }
 
   & tds-button.tds-mode-variant-primary,
@@ -105,19 +105,19 @@ body {
 }
 
 .tds-mode-dark {
-  color: var(--tds-grey-100);
-  background-color: var(--tds-grey-958);
+  color: var(--color-foreground-text-strong);
+  background-color: var(--color-background-base);
 
   &.tds-mode-variant-primary,
   & .tds-mode-variant-primary {
-    color: var(--tds-grey-100);
-    background-color: var(--tds-grey-958);
+    color: var(--color-foreground-text-strong);
+    background-color: var(--color-background-base);
   }
 
   &.tds-mode-variant-secondary,
   & .tds-mode-variant-secondary {
-    color: var(--tds-grey-100);
-    background-color: var(--tds-grey-900);
+    color: var(--color-foreground-text-strong);
+    background-color: var(--color-background-layer-01);
   }
 
   & tds-button.tds-mode-variant-primary,


### PR DESCRIPTION
## **Describe pull-request**
Storybook was using hardcoded hex values in `preview.ts` to set background colors for Scania and Traton brands. 
Also incorrect CSS class names was used for mode variants - (`tds-mode-primary`/`tds-mode-secondary` instead of `tds-mode-variant-primary`/`tds-mode-variant-secondary`), which prevented the SCSS-based backgrounds from applying. When correcting the class names the hard coded values is no longer needed.

This PR:
- Removes the `applyBackgroundColor` function with hardcoded hex values from `preview.ts`
- Fixes incorrect mode variant class names
- Adds variant-aware background rules for the docs tab in `preview.css` using brand-agnostic tokens with Scania fallbacks
- Switches `core.scss` to brand-agnostic tokens (`--color-background-base`, `--color-background-layer-01`) so backgrounds work correctly for both brands in dev mode (`VITE_STORYBOOK_ENV=dev`)
- Production build using `global.scss` are unchanged

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-2002](https://jira.scania.com/browse/CDEP-2002)

## **How to test**
1. Run `npm run build:all` and start Storybook without dev flag — verify Scania backgrounds work in both Default and Docs tabs (light/dark + primary/secondary)
2. Run with `VITE_STORYBOOK_ENV=dev` — verify both Scania and Traton backgrounds work correctly in Default and Docs tabs
3. Toggle between light/dark mode, primary/secondary variant, and Scania/Traton brand in all combinations

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [x] Behavior available in Storybook with documented descriptions (if applicable)
- [x] `npm run build:all` without errors

## **Suggested test steps**
- [x] Dark/light mode and variants

## **Screenshots**
_Include before/after screenshots for UI changes._

## **Additional context**
The `core.scss` changes only affect dev builds (via `multibrand-development.scss`). The `preview.css` changes use CSS variable fallbacks (`var(--color-background-base, var(--tds-white))`) so they work in both dev and non-dev Storybook builds.
