### PR TITLE
feat(tds-table-footer): open direction prop

### DIFF
--- a/packages/core/src/components/table/table-component-pagination.stories.tsx
+++ b/packages/core/src/components/table/table-component-pagination.stories.tsx
@@ -52,8 +52,8 @@ export default {
       description: 'List of rows per page values',
       control: {
         type: 'select',
-        options: ['[5,10,15]', '[20,30,40]', '[100, 220, 303]'],
       },
+      options: ['[5,10,15]', '[20,30,40]', '[100, 220, 303]'],
     },
     pages: {
       name: 'Pages',
@@ -73,6 +73,18 @@ export default {
       table: {
         defaultValue: { summary: true },
       },
+    },
+    rowsPerPageDropdownOpenDirection: {
+      name: 'Rows per page dropdown open direction',
+      description: 'Controls opening direction for rows per page dropdown',
+      control: {
+        type: 'select',
+      },
+      options: ['auto', 'up', 'down'],
+      table: {
+        defaultValue: { summary: 'auto' },
+      },
+      if: { arg: 'rowsPerPage', eq: true },
     },
     noMinWidth: {
       name: 'No minimum width',
@@ -126,6 +138,7 @@ export default {
     verticalDivider: false,
     rowsPerPage: true,
     rowsPerPageValues: '[10,25,50]',
+    rowsPerPageDropdownOpenDirection: 'auto',
     pages: 4,
     noMinWidth: false,
     column1Width: '',
@@ -142,6 +155,7 @@ const PaginationTemplate = ({
   verticalDivider,
   rowsPerPage,
   rowsPerPageValues,
+  rowsPerPageDropdownOpenDirection,
   pages,
   noMinWidth,
   column1Width,
@@ -210,7 +224,12 @@ const PaginationTemplate = ({
                 <tds-body-cell cell-value="Test value 8" cell-key="mileage"></tds-body-cell>
             </tds-table-body-row>
           </tds-table-body>
-          <tds-table-footer pages="${pages}" pagination rowsperpage="${rowsPerPage}"></tds-table-footer>
+          <tds-table-footer
+            pages="${pages}"
+            pagination
+            rowsperpage="${rowsPerPage}"
+            rows-per-page-dropdown-open-direction="${rowsPerPageDropdownOpenDirection}"
+          ></tds-table-footer>
   </tds-table>
   <!-- Note: Code below is just for demo purposes -->
   <div class="tds-u-mt1" style="width: 500px; background-color: lightblue; padding: 16px;">
@@ -226,7 +245,7 @@ const PaginationTemplate = ({
     <textarea id="event-value-textarea" rows="4" cols="50" readonly></textarea>
   </div>
 
-  
+
 
   <script>
     document.querySelector("tds-table-footer").rowsPerPageValues = ${rowsPerPageValues}
@@ -235,7 +254,7 @@ const PaginationTemplate = ({
       document.getElementById('event-value-textarea').value = JSON.stringify(e.detail, null, 2);
     });
   </script>
-  
+
   `);
 
 export const Default = PaginationTemplate.bind({});

--- a/packages/core/src/components/table/table-footer/readme.md
+++ b/packages/core/src/components/table/table-footer/readme.md
@@ -7,14 +7,15 @@
 
 ## Properties
 
-| Property            | Attribute          | Description                                                                                                                | Type             | Default        |
-| ------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------------- |
-| `cols`              | `cols`             | <b>Client override</b> Used to set the column span of the footer. Use as fallback if the automatic count of columns fails. | `null \| number` | `null`         |
-| `pages`             | `pages`            | Sets the number of pages.                                                                                                  | `number`         | `0`            |
-| `pagination`        | `pagination`       | Enable pagination and show pagination controls                                                                             | `boolean`        | `false`        |
-| `paginationValue`   | `pagination-value` | Sets the pagination number.                                                                                                | `number`         | `1`            |
-| `rowsPerPageValues` | --                 | Set available rows per page values                                                                                         | `number[]`       | `[10, 25, 50]` |
-| `rowsperpage`       | `rowsperpage`      | Enable rows per page dropdown                                                                                              | `boolean`        | `true`         |
+| Property                           | Attribute                               | Description                                                                                                                | Type                       | Default        |
+| ---------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------- |
+| `cols`                             | `cols`                                  | <b>Client override</b> Used to set the column span of the footer. Use as fallback if the automatic count of columns fails. | `null \| number`           | `null`         |
+| `pages`                            | `pages`                                 | Sets the number of pages.                                                                                                  | `number`                   | `0`            |
+| `pagination`                       | `pagination`                            | Enable pagination and show pagination controls                                                                             | `boolean`                  | `false`        |
+| `paginationValue`                  | `pagination-value`                      | Sets the pagination number.                                                                                                | `number`                   | `1`            |
+| `rowsPerPageDropdownOpenDirection` | `rows-per-page-dropdown-open-direction` | Set rows per page dropdown open direction                                                                                  | `"auto" \| "down" \| "up"` | `'auto'`       |
+| `rowsPerPageValues`                | --                                      | Set available rows per page values                                                                                         | `number[]`                 | `[10, 25, 50]` |
+| `rowsperpage`                      | `rowsperpage`                           | Enable rows per page dropdown                                                                                              | `boolean`                  | `true`         |
 
 
 ## Events

--- a/packages/core/src/components/table/table-footer/table-footer.tsx
+++ b/packages/core/src/components/table/table-footer/table-footer.tsx
@@ -41,6 +41,9 @@ export class TdsTableFooter {
   /** Set available rows per page values */
   @Prop() rowsPerPageValues: number[] = [10, 25, 50];
 
+  /** Set rows per page dropdown open direction */
+  @Prop() rowsPerPageDropdownOpenDirection: 'up' | 'down' | 'auto' = 'auto';
+
   /** Sets the number of pages. */
   @Prop({ reflect: true }) pages: number = 0;
 
@@ -280,6 +283,7 @@ export class TdsTableFooter {
                         size="xs"
                         defaultValue={`${this.rowsPerPageValues[0]}`}
                         onTdsChange={(event) => this.rowsPerPageChange(event)}
+                        openDirection={this.rowsPerPageDropdownOpenDirection}
                       >
                         {this.rowsPerPageValues.map((value) => (
                           <tds-dropdown-option value={`${value}`}>{value}</tds-dropdown-option>


### PR DESCRIPTION
… direction

## **Describe pull-request**  
This pull request adds new configurability to tds-table-footer rows-per-page behavior.
It introduces props to:

- control rows-per-page dropdown opening direction (rowsPerPageDropdownOpenDirection with auto | up | down)

It also updates the component documentation (readme.md) to include the new props and defaults.

## **Issue Linking:**  
- **No issue:** Improve flexibility of table footer pagination controls so consumers can define initial rows-per-page value and dropdown direction without custom workarounds.

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to the table footer usage (Storybook or local page using tds-table-footer).
2. Render footer with pagination + rows-per-page enabled.
3. Set rowsPerPageDropdownOpenDirection="up" and open the rows-per-page dropdown.
4. Verify dropdown opens upward.
5. Change to rowsPerPageDropdownOpenDirection="down" and verify it opens downward.
6. Change to rowsPerPageDropdownOpenDirection="auto" and verify behavior follows existing auto logic.
7. Run npm run build:all and confirm no build errors.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [x] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
New props are backward compatible with current behavior:

- rowsPerPageDropdownOpenDirection defaults to 'auto'

No API breaking changes introduced.
