### PR TITLE
fix(variables): only include icon css vars in tegel lite

### DIFF
--- a/packages/core/scripts/compile-tegel-lite-components.js
+++ b/packages/core/scripts/compile-tegel-lite-components.js
@@ -15,11 +15,11 @@ const globalScss = path.resolve(dirName, '../src/global/tegel-lite-global.scss')
 const globalCss = path.resolve(dirName, '../../tegel-lite/dist/global.css'); // Output compiled global CSS
 
 // Define paths for Scania specific vars
-const scaniaVarsScss = path.resolve(dirName, '../src/global/scania-variables.scss'); // Source Scania vars SCSS
+const scaniaVarsScss = path.resolve(dirName, '../src/global/tegel-lite-scania-variables.scss'); // Source Scania vars SCSS
 const scaniaVarsCss = path.resolve(dirName, '../../tegel-lite/dist/scania-variables.css'); // Output compiled Scania vars CSS
 
 // Define paths for Traton specific vars
-const tratonVarsScss = path.resolve(dirName, '../src/global/traton-variables.scss'); // Source Traton vars SCSS
+const tratonVarsScss = path.resolve(dirName, '../src/global/tegel-lite-traton-variables.scss'); // Source Traton vars SCSS
 const tratonVarsCss = path.resolve(dirName, '../../tegel-lite/dist/traton-variables.css'); // Output compiled Traton vars CSS
 
 // Define paths for all components bundle

--- a/packages/core/src/global/scania-variables.scss
+++ b/packages/core/src/global/scania-variables.scss
@@ -25,11 +25,3 @@
 @use '../../../../typography/scania-fonts' as *;
 @use '../../../../typography/scania-fonts-vars' as *;
 @use '../../../../typography/scania-fonts-selectors' as *;
-
-/* Scania primitive icon tokens */
-@use '../../../../tokens/scss/scania/scania-icons-primitive' with (
-  $local-assets: './assets'
-);
-
-/* Scania icon tokens */
-@use '../../../../tokens/scss/scania/scania-icons' as *;

--- a/packages/core/src/global/tegel-lite-components.scss
+++ b/packages/core/src/global/tegel-lite-components.scss
@@ -1,5 +1,15 @@
 @use 'tl-scrollbar-vars' as *;
 
+/* Icon tokens for Storybook (in production Tegel Lite these come from the brand variable CSS files) */
+@use '../../../../tokens/scss/scania/scania-icons-primitive' with (
+  $local-assets: '../dist/tegel/assets'
+);
+@use '../../../../tokens/scss/scania/scania-icons' as *;
+@use '../../../../tokens/scss/traton/traton-icons-primitive' with (
+  $local-assets: '../dist/tegel/assets'
+);
+@use '../../../../tokens/scss/traton/traton-icons' as *;
+
 @use '../tegel-lite/components/tl-button/tl-button' as *;
 @use '../tegel-lite/components/tl-header/tl-header' as *;
 @use '../tegel-lite/components/tl-message/tl-message' as *;

--- a/packages/core/src/global/tegel-lite-scania-variables.scss
+++ b/packages/core/src/global/tegel-lite-scania-variables.scss
@@ -1,0 +1,12 @@
+// Tegel Lite Scania variables
+// Includes base Scania variables + icon tokens
+
+@use 'scania-variables' as *;
+
+/* Scania primitive icon tokens */
+@use '../../../../tokens/scss/scania/scania-icons-primitive' with (
+  $local-assets: './assets'
+);
+
+/* Scania icon tokens */
+@use '../../../../tokens/scss/scania/scania-icons' as *;

--- a/packages/core/src/global/tegel-lite-traton-variables.scss
+++ b/packages/core/src/global/tegel-lite-traton-variables.scss
@@ -1,0 +1,12 @@
+// Tegel Lite Traton variables
+// Includes base Traton variables + icon tokens
+
+@use 'traton-variables' as *;
+
+/* Traton primitive icon tokens */
+@use '../../../../tokens/scss/traton/traton-icons-primitive' with (
+  $local-assets: './assets'
+);
+
+/* Traton icon tokens */
+@use '../../../../tokens/scss/traton/traton-icons' as *;

--- a/packages/core/src/global/traton-variables.scss
+++ b/packages/core/src/global/traton-variables.scss
@@ -25,11 +25,3 @@
 @use '../../../../typography/tokens/typography-traton' as *;
 @use '../../../../spacing/traton-units' as *;
 @use '../../../../typography/traton-fonts' as *;
-
-/* Traton primitive icon tokens */
-@use '../../../../tokens/scss/traton/traton-icons-primitive' with (
-  $local-assets: './assets'
-);
-
-/* Traton icon tokens */
-@use '../../../../tokens/scss/traton/traton-icons' as *;


### PR DESCRIPTION
## **Describe pull-request**  
Removes ~285 unused icon CSS custom properties (with `url()` asset paths) from the core web component bundle. These icon token variables are only consumed by Tegel Lite components via `mask-image` — no web component reference them. Their presence in the core CSS caused unnecessary asset resolution warnings in the Angular wrapper dev server.

Icon tokens are now imported via dedicated Tegel Lite wrapper files (`tegel-lite-scania-variables.scss` / `tegel-lite-traton-variables.scss`) and the build script has been updated accordingly. A separate import was added to `tegel-lite-components.scss` to keep Storybook working.

## **Issue Linking:**  
- **No issue:** Icon CSS variables with `url()` paths in the core bundle were unused by web components and caused asset resolution warnings in the Angular dev server.

## **How to test**  
1. Run `npm run build` — core builds without errors
2. Run `npm run build:tegel-lite` — Tegel Lite builds without errors
3. Verify `dist/tegel/tegel.css` no longer contains `--scania-icon-` or `--traton-icon-` variables
4. Verify `packages/tegel-lite/dist/scania-variables.css` still contains the icon variables

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Storybook controls
- [ ] Dark/light mode and variants 

## **Screenshots**  
N/A — no visual changes expected.

## **Additional context**  
The Tegel Lite production build is unaffected since it already compiled `scania-variables.scss` / `traton-variables.scss` as separate CSS files. The new wrapper files simply add the icon imports on top of the base brand variables for Tegel Lite only.
