### PR TITLE
Fix opacity variable format for disabled chip states

### DIFF
--- a/tokens/scss/component/chip.scss
+++ b/tokens/scss/component/chip.scss
@@ -16,7 +16,7 @@
   --component-chip-border-radius-none: var(--scania-unit-0);
   --component-chip-border-radius-default: var(--scania-unit-24);
   --component-chip-border-radius-full: var(--scania-unit-9999);
-  --component-chip-opacity-disabled: var(--scania-opacity-25%);
+  --component-chip-opacity-disabled: var(--scania-opacity-25);
   --component-chip-text-default: var(--color-text-strong);
   --component-chip-text-hover: var(--color-text-strong);
   --component-chip-text-active: var(--color-text-strong);
@@ -39,7 +39,7 @@
   --component-chip-border-radius-none: var(--traton-unit-0);
   --component-chip-border-radius-default: var(--traton-unit-2);
   --component-chip-border-radius-full: var(--traton-unit-24);
-  --component-chip-opacity-disabled: var(--traton-opacity-25%);
+  --component-chip-opacity-disabled: var(--traton-opacity-25);
   --component-chip-text-default: var(--color-text-strong);
   --component-chip-text-hover: var(--color-text-strong);
   --component-chip-text-active: var(--color-text-strong);
@@ -62,7 +62,7 @@
   --component-chip-border-radius-none: var(--scania-unit-0);
   --component-chip-border-radius-default: var(--scania-unit-24);
   --component-chip-border-radius-full: var(--scania-unit-9999);
-  --component-chip-opacity-disabled: var(--scania-opacity-25%);
+  --component-chip-opacity-disabled: var(--scania-opacity-25);
   --component-chip-text-default: var(--color-text-strong);
   --component-chip-text-hover: var(--color-text-strong);
   --component-chip-text-active: var(--color-text-strong);
@@ -85,7 +85,7 @@
   --component-chip-border-radius-none: var(--traton-unit-0);
   --component-chip-border-radius-default: var(--traton-unit-2);
   --component-chip-border-radius-full: var(--traton-unit-24);
-  --component-chip-opacity-disabled: var(--traton-opacity-25%);
+  --component-chip-opacity-disabled: var(--traton-opacity-25);
   --component-chip-text-default: var(--color-text-strong);
   --component-chip-text-hover: var(--color-text-strong);
   --component-chip-text-active: var(--color-text-strong);


### PR DESCRIPTION
CSS should use valid variable naming

--component-button-opacity-disabled: var(--scania-opacity-25);
--component-button-opacity-disabled: var(--traton-opacity-25)

## **Describe pull-request**  
CSS should use valid variable naming like above but current code with %

--component-button-opacity-disabled: var(--scania-opacity-25%);
--component-button-opacity-disabled: var(--traton-opacity-25%);


## **Issue Linking:**  
- **GitHub:** [Include issue link ](https://github.com/scania-digital-design-system/tegel/issues/1845)
