### PR TITLE
fix(navigation-tabs): padding preventing right position of button

### DIFF
--- a/packages/core/src/components/tabs/navigation-tabs/navigation-tabs.scss
+++ b/packages/core/src/components/tabs/navigation-tabs/navigation-tabs.scss
@@ -4,6 +4,8 @@
 :host {
   @include tds-box-sizing;
 
+  --padding-left: 0;
+
   display: flex;
   background-color: var(--tds-navigation-tabs-background);
   position: relative;
@@ -26,6 +28,7 @@
     overflow-x: scroll;
     scrollbar-width: none;
     gap: 16px;
+    padding-left: var(--padding-left);
 
     &::-webkit-scrollbar {
       display: none;
@@ -38,7 +41,7 @@
   }
 
   .scroll-left-button {
-    left: 0;
+    left: calc(0px - var(--padding-left));
     z-index: 1;
   }
 
@@ -74,10 +77,7 @@
     &:focus::before {
       content: '';
       position: absolute;
-      left: 3px;
-      right: 3px;
-      top: 3px;
-      bottom: 3px;
+      inset: 3px;
       @include tds-focus-state;
     }
 

--- a/packages/core/src/components/tabs/navigation-tabs/navigation-tabs.tsx
+++ b/packages/core/src/components/tabs/navigation-tabs/navigation-tabs.tsx
@@ -221,19 +221,12 @@ export class TdsNavigationTabs {
     }
   }
 
-  private applyCustomLeftPadding(): void {
-    if (this.navWrapperElement) {
-      this.navWrapperElement.style.paddingLeft = `${this.leftPadding}px`;
-    }
-  }
-
   private handleSlotChange(): void {
     this.initializeTabs();
     this.addEventListenerToTabs();
     this.initializeSelectedTab();
     this.updateScrollButtons();
     this.addResizeObserver();
-    this.applyCustomLeftPadding(); // Apply custom left padding to the wrapper
   }
 
   connectedCallback(): void {
@@ -258,13 +251,13 @@ export class TdsNavigationTabs {
       <Host
         role="tablist"
         class={{ [`tds-mode-variant-${this.modeVariant}`]: this.modeVariant !== null }}
+        style={{ '--padding-left': `${this.leftPadding}px` }}
       >
         <div
           class="wrapper"
           ref={(el) => {
             this.navWrapperElement = el as HTMLElement;
           }}
-          style={{ paddingLeft: `${this.leftPadding}px` }} // Set left padding directly here
         >
           <button
             aria-label={this.tdsScrollLeftAriaLabel}


### PR DESCRIPTION
## **Describe pull-request**  
This pull-request fixes an extra left-side spacing issue in `tds-navigation-tabs` when the left scroll chevron button becomes visible.

The component now uses the same left-padding strategy as `tds-inline-tabs`:
- Left padding is controlled through a host CSS variable (`--padding-left`)
- Wrapper uses `padding-left: var(--padding-left)`
- Left scroll button is offset with `left: calc(0px - var(--padding-left))`

It also removes redundant imperative padding logic in the component class.

## **Issue Linking:**  
- **No issue:** `tds-navigation-tabs` showed unintended extra left spacing when the left chevron appeared, causing inconsistent alignment compared to `tds-inline-tabs`.

## **How to test**  
1. Start the project/storybook for core components.
2. Open a view/story where `tds-navigation-tabs` has enough tabs to overflow horizontally.
3. Ensure `leftPadding` is set (default `32` or a custom value).
4. Scroll tabs to the right so the left chevron becomes visible.
5. Verify there is no extra left gap introduced when the left chevron appears.
6. Compare behavior with `tds-inline-tabs` and confirm alignment is consistent.
7. Optionally test different `leftPadding` values (e.g. `0`, `16`, `32`) and verify chevron positioning remains correct.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [x] Keyboard operability
- [x] Interactive elements have labels.
- [x] Storybook controls
- [x] Design/controls/props is aligned with other components 
- [x] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [x] Events

## **Screenshots**  
Before: Left chevron visibility in `tds-navigation-tabs` introduced extra left spacing.  
After: Left chevron appears without adding extra left spacing; behavior matches `tds-inline-tabs`.

## **Additional context**  
Implementation details:
- `navigation-tabs.scss`: introduced `--padding-left`, wrapper padding via variable, and left button offset compensation.
- `navigation-tabs.tsx`: removed redundant `applyCustomLeftPadding()` and moved padding value to host style variable.