### PR TITLE
fix(tds-modal): Modal not showing with show as true

### DIFF
--- a/packages/core/src/components/modal/modal.stories.tsx
+++ b/packages/core/src/components/modal/modal.stories.tsx
@@ -57,7 +57,8 @@ export default {
     },
     showModal: {
       name: 'Show Modal',
-      description: 'Toggles if the Modal is displayed.',
+      description:
+        'Allows the consumer of Tegel to control the open/close interaction or set the modal visibility when opening the page. If it is not set, then the modal has a fallback state for that interaction, defaulting to false.',
       control: {
         type: 'boolean',
       },

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -255,7 +255,6 @@ export class TdsModal {
 
   /** Runs whenever the modal is opened and updates it. */
   private onOpen() {
-    console.log('onOpen running...');
     // Focus immediately to preserve interaction modality for :focus-visible
     this.focusFirstElement();
 
@@ -313,11 +312,9 @@ export class TdsModal {
   };
 
   handleShow = () => {
-    console.log('handleShow running...');
     const showEvent = this.tdsOpen.emit();
     if (showEvent.defaultPrevented) return;
 
-    console.log('handleShow, after if -> return...');
     this.isShown = true;
     this.onOpen();
   };

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -45,8 +45,9 @@ export class TdsModal {
   /** Element that will show the Modal (takes priority over selector) */
   @Prop() referenceEl?: HTMLElement | null;
 
-  /** Controls whether the Modal is shown or not. If this is set hiding and showing
-   * will be decided by this prop and will need to be controlled from the outside. */
+  /** Controls whether the Modal is shown or not. <br/> This prop allows the consumer of Tegel to control
+   * the open/close interaction or set the modal visibility when opening the page. If it is not set, then
+   * the modal has a fallback state for that interaction, defaulting to false. */
   @Prop({ reflect: true }) show?: boolean;
 
   /** Shows or hides the close [X] button. */
@@ -113,7 +114,7 @@ export class TdsModal {
     }
   }
 
-  connectedCallback() {
+  private initializeWithProps() {
     if (this.closable === undefined) {
       this.closable = true;
     }
@@ -136,8 +137,12 @@ export class TdsModal {
     }
   }
 
+  connectedCallback() {
+    this.initializeWithProps();
+  }
+
   componentWillLoad() {
-    this.initializeModal();
+    this.initializeWithProps();
   }
 
   disconnectedCallback() {
@@ -250,6 +255,7 @@ export class TdsModal {
 
   /** Runs whenever the modal is opened and updates it. */
   private onOpen() {
+    console.log('onOpen running...');
     // Focus immediately to preserve interaction modality for :focus-visible
     this.focusFirstElement();
 
@@ -307,9 +313,11 @@ export class TdsModal {
   };
 
   handleShow = () => {
+    console.log('handleShow running...');
     const showEvent = this.tdsOpen.emit();
     if (showEvent.defaultPrevented) return;
 
+    console.log('handleShow, after if -> return...');
     this.isShown = true;
     this.onOpen();
   };

--- a/packages/core/src/components/modal/readme.md
+++ b/packages/core/src/components/modal/readme.md
@@ -1,21 +1,18 @@
 # tds-modal
 
-
 ### Usage with @scania/tegel-angular
+
 If you are using the `<tds-modal>` in an Angular environment and want to use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
 
 ```html
 <div #myReference>
   <tds-button text="Button"></tds-button>
 </div>
-<tds-modal [referenceEl]="myReference">
-  
-</tds-modal>
-
+<tds-modal [referenceEl]="myReference"> </tds-modal>
 ```
 
-
 ### Usage with @scania/tegel-react
+
 If you are using the `<TdsModal>` in an React environment and want to
 use the `referenceEl` prop rather than the `selector` the referenced element can't be a Tegel component. We recommend wrapping the element in a native HTMLElement and using that as the `referenceEl`. See example below:
 
@@ -24,7 +21,7 @@ use the `referenceEl` prop rather than the `selector` the referenced element can
   <TdsButton text="Button"></TdsButton>
 </div>
 <TdsModal referenceEl={myReference}>
-  
+
 </TdsModal>
 
 ```
@@ -51,92 +48,89 @@ This pattern avoids rendering hidden content upfront, improves performance and g
   </span>
 </tds-modal>
 
-    <script type="module">
-      import { defineCustomElements } from "@scania/tegel/loader";
-      defineCustomElements();
+<script type="module">
+  import { defineCustomElements } from '@scania/tegel/loader';
+  defineCustomElements();
 
-      const modal = document.querySelector("tds-modal");
+  const modal = document.querySelector('tds-modal');
 
-      // Use the isOpen method to check if the modal is already open
-      (async () => {
-        await modal.componentOnReady();
-        const isOpen = await modal.isOpen();
-        if (isOpen) {
-          fetchAndRenderBody();
-        }
-      })();
+  // Use the isOpen method to check if the modal is already open
+  (async () => {
+    await modal.componentOnReady();
+    const isOpen = await modal.isOpen();
+    if (isOpen) {
+      fetchAndRenderBody();
+    }
+  })();
 
-      // Add event listener for opening modal
-      modal.addEventListener("tdsOpen", () => {
-        console.log("Modal opened");
+  // Add event listener for opening modal
+  modal.addEventListener('tdsOpen', () => {
+    console.log('Modal opened');
 
-        // Fetch data and render it in the modal body
-        fetchAndRenderBody();
-      });
+    // Fetch data and render it in the modal body
+    fetchAndRenderBody();
+  });
 
-      // Add event listener for closing modal
-      modal.addEventListener("tdsClose", () => {
-        console.log("Modal closed");
+  // Add event listener for closing modal
+  modal.addEventListener('tdsClose', () => {
+    console.log('Modal closed');
 
-        // Remove the body content when the modal is closed
-        removeBodyContent();
-      });
+    // Remove the body content when the modal is closed
+    removeBodyContent();
+  });
 
-      function removeBodyContent() {
-        const bodyContent = modal.querySelector('[slot="body"]');
-        if (bodyContent) {
-          modal.removeChild(bodyContent);
-        }
-      }
+  function removeBodyContent() {
+    const bodyContent = modal.querySelector('[slot="body"]');
+    if (bodyContent) {
+      modal.removeChild(bodyContent);
+    }
+  }
 
-      async function fetchAndRenderBody() {
-        // Prevent multiple fetches if already rendered
-        if (modal.querySelector('[slot="body"]')) return;
+  async function fetchAndRenderBody() {
+    // Prevent multiple fetches if already rendered
+    if (modal.querySelector('[slot="body"]')) return;
 
-        const div = document.createElement("div");
-        div.slot = "body";
-        div.textContent = "Loading data...";
-        console.log("Loading data...");
-        modal.appendChild(div);
+    const div = document.createElement('div');
+    div.slot = 'body';
+    div.textContent = 'Loading data...';
+    console.log('Loading data...');
+    modal.appendChild(div);
 
-        try {
-          const res = await fetch(
-            "https://jsonplaceholder.typicode.com/posts/1"
-            );
-            const data = await res.json();
+    try {
+      const res = await fetch('https://jsonplaceholder.typicode.com/posts/1');
+      const data = await res.json();
 
-          // Add delay to simulate loading time
-          setTimeout(async () => {
-            div.innerHTML = `
+      // Add delay to simulate loading time
+      setTimeout(async () => {
+        div.innerHTML = `
             <h3>${data.title}</h3>
             <p>${data.body}</p>
           `;
-          }, 1000);
-        } catch (error) {
-          div.textContent = "Failed to load content";
-          console.error("API Error:", error);
-        }
-      }
-    </script>
+      }, 1000);
+    } catch (error) {
+      div.textContent = 'Failed to load content';
+      console.error('API Error:', error);
+    }
+  }
+</script>
 ```
-
 
 <!-- Auto Generated Below -->
 
 
 ## Properties
 
-| Property          | Attribute          | Description                                                                                                                                                 | Type                               | Default     |
-| ----------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------- |
-| `actionsPosition` | `actions-position` | Changes the position behaviour of the actions slot.                                                                                                         | `"static" \| "sticky"`             | `'static'`  |
-| `closable`        | `closable`         | Shows or hides the close [X] button.                                                                                                                        | `boolean`                          | `true`      |
-| `header`          | `header`           | Sets the header of the Modal.                                                                                                                               | `string \| undefined`              | `undefined` |
-| `prevent`         | `prevent`          | Disables closing Modal on clicking on overlay area.                                                                                                         | `boolean`                          | `false`     |
-| `referenceEl`     | --                 | Element that will show the Modal (takes priority over selector)                                                                                             | `HTMLElement \| null \| undefined` | `undefined` |
-| `selector`        | `selector`         | CSS selector for the element that will show the Modal.                                                                                                      | `string \| undefined`              | `undefined` |
-| `show`            | `show`             | Controls whether the Modal is shown or not. If this is set hiding and showing will be decided by this prop and will need to be controlled from the outside. | `boolean \| undefined`             | `undefined` |
-| `size`            | `size`             | Size of Modal                                                                                                                                               | `"lg" \| "md" \| "sm" \| "xs"`     | `'md'`      |
-| `tdsAlertDialog`  | `tds-alert-dialog` | Role of the modal component. Can be either 'alertdialog' for important messages that require immediate attention, or 'dialog' for regular messages.         | `"alertdialog" \| "dialog"`        | `'dialog'`  |
+| Property          | Attribute          | Description                                                                                                                                                                                                                                                                        | Type                               | Default     |
+| ----------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------- |
+| `actionsPosition` | `actions-position` | Changes the position behaviour of the actions slot.                                                                                                                                                                                                                                | `"static" \| "sticky"`             | `'static'`  |
+| `closable`        | `closable`         | Shows or hides the close [X] button.                                                                                                                                                                                                                                               | `boolean`                          | `true`      |
+| `header`          | `header`           | Sets the header of the Modal.                                                                                                                                                                                                                                                      | `string \| undefined`              | `undefined` |
+| `prevent`         | `prevent`          | Disables closing Modal on clicking on overlay area.                                                                                                                                                                                                                                | `boolean`                          | `false`     |
+| `referenceEl`     | --                 | Element that will show the Modal (takes priority over selector)                                                                                                                                                                                                                    | `HTMLElement \| null \| undefined` | `undefined` |
+| `selector`        | `selector`         | CSS selector for the element that will show the Modal.                                                                                                                                                                                                                             | `string \| undefined`              | `undefined` |
+| `show`            | `show`             | Controls whether the Modal is shown or not. <br/> This prop allows the consumer of Tegel to control the open/close interaction or set the modal visibility when opening the page. If it is not set, then the modal has a fallback state for that interaction, defaulting to false. | `boolean \| undefined`             | `undefined` |
+| `size`            | `size`             | Size of Modal                                                                                                                                                                                                                                                                      | `"lg" \| "md" \| "sm" \| "xs"`     | `'md'`      |
+| `tdsAlertDialog`  | `tds-alert-dialog` | Role of the modal component. Can be either 'alertdialog' for important messages that require immediate attention, or 'dialog' for regular messages.                                                                                                                                | `"alertdialog" \| "dialog"`        | `'dialog'`  |
 
 
 ## Events


### PR DESCRIPTION
## **Describe pull-request**  
This PR fixes a bug reported on [GitHub](https://github.com/scania-digital-design-system/tegel/issues/1860). 
This bug was introduced in version 1.48.0 and unintentionally introduced a breaking change.

The modal wasn't showing when the `show` prop was set as true, when first opening the page containing the modal.
More details can be seen in the issue itself, since it is very well reported. 

We understood that the issue stemmed from the fact that the verifications needed to change the state `isShown` were only being done on the `connectedCallback` function, and not on the `componentWillLoad` function. 
So we simply added the same verifications on both functions of the lifecycle of the component.

## **Issue Linking:**
- **Jira:** [CDEP-2064](https://jira.scania.com/browse/CDEP-2064)

## **How to test**
1. Go to the [React demo page](https://pr-307.d2vh2lmnzgzrkl.amplifyapp.com) with this beta release ([PR-307](https://github.com/scania-digital-design-system/tegel-react-demo/pull/307) from the tegel-react-demo)
2. Open the modal component page from the side menu
3. Verify that there is a modal opened at the start of the page

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Additional context**  
@patrikhultgren, if you'd like to check this one out and give feedback, feel free 😄 
