### PR TITLE
fix: add happydom detection in react-output-target runtime wrapper

### DIFF
--- a/packages/react/lib/runtime.ts
+++ b/packages/react/lib/runtime.ts
@@ -1,10 +1,10 @@
 /**
  * Custom runtime wrapper for @stencil/react-output-target.
  *
- * In JSDOM (vitest / jest), Stencil's lazy-loaded property-to-attribute
+ * In JSDOM/HappyDOM (vitest / jest), Stencil's lazy-loaded property-to-attribute
  * reflection never fires, so props set as JS properties via @lit/react's
  * createComponent are invisible to getAttribute(). This wrapper detects
- * JSDOM and adds a useLayoutEffect that explicitly syncs primitive props
+ * JSDOM/HappyDOM and adds a useLayoutEffect that explicitly syncs primitive props
  * to DOM attributes. In real browsers, the original component is returned
  * unchanged — zero runtime cost.
  */
@@ -16,9 +16,9 @@ import React from 'react';
 export type { EventName } from '@lit/react';
 export type { StencilReactComponent } from '@stencil/react-output-target/runtime';
 
-// ---------- JSDOM detection ----------
+// ---------- Test DOM detection ----------
 
-const isJsdom = typeof navigator !== 'undefined' && /jsdom/i.test(navigator.userAgent);
+const isTestDom = typeof navigator !== 'undefined' && /(jsdom|happydom)/i.test(navigator.userAgent);
 
 // ---------- Attribute helpers ----------
 
@@ -71,11 +71,11 @@ export const createComponent = <I extends HTMLElement, E extends EventNames = {}
   });
 
   // In real browsers Stencil's proxy handles reflection — return as-is.
-  if (!isJsdom) {
+  if (!isTestDom) {
     return OriginalComponent;
   }
 
-  // --- JSDOM wrapper ---
+  // --- Test DOM wrapper ---
   const { elementClass, events } = rest;
   const eventKeys = new Set(Object.keys(events ?? {}));
 


### PR DESCRIPTION
## Add happydom detection to custom runtime wrapper for react-output-target
Happy DOM is a popular environment alternative to JSDOM and it would be great if it is also supported in any custom solutions to fix tests.

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Open any react app using tegel and with component tests that verify attributes.
2. Change vitest environment to `happy-dom`
3. Run tests

Manually verified change works by changing wrapper directly in installed package in a react app using vitest + happydom.

## **Additional  comments**  
Would be great to have some demo applications in the same monorepo to test react/angular wrapper components without having to install the package locally in another project or do beta releases.
