### PR TITLE
fix(tds-modal): set modal (dialog) name (from heading) for a11y purposes

### DIFF
--- a/packages/core/src/components/modal/modal.scss
+++ b/packages/core/src/components/modal/modal.scss
@@ -83,10 +83,7 @@ $modals: (
 
 @mixin modal-position {
   position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  inset: 0;
 }
 
 /* MODAL STYLING */
@@ -137,7 +134,7 @@ $modals: (
   }
 }
 
-//Width of Modals in different breakpoints
+// Width of Modals in different breakpoints
 @each $screen, $modals in $modals {
   @media (min-width: $screen) {
     @each $modal, $value in $modals {
@@ -164,11 +161,10 @@ $modals: (
 
 .header {
   @include modal-header;
-}
 
-.header,
-slot[name='header']::slotted(*) {
-  @include modal-header-title;
+  .header-text {
+    @include modal-header-title;
+  }
 }
 
 .body {

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -360,19 +360,17 @@ export class TdsModal {
     });
   }
 
+  private headerId = `tds-modal-header-${generateUniqueId()}`;
+  private bodyId = `tds-modal-body-${generateUniqueId()}`;
+
   render() {
     const usesHeaderSlot = hasSlot('header', this.host);
     const usesActionsSlot = hasSlot('actions', this.host);
 
-    const headerId = this.header ? `tds-modal-header-${generateUniqueId()}` : undefined;
-    const bodyId = `tds-modal-body-${generateUniqueId()}`;
+    const hasLabel = this.header || usesHeaderSlot;
 
     return (
       <Host
-        role={this.tdsAlertDialog}
-        aria-modal="true"
-        aria-describedby={bodyId}
-        aria-labelledby={headerId}
         class={{
           show: this.isShown,
           hide: !this.isShown,
@@ -381,11 +379,19 @@ export class TdsModal {
       >
         <div class="tds-modal-backdrop" />
         <div
+          role={this.tdsAlertDialog}
+          aria-modal="true"
+          aria-describedby={this.bodyId}
+          aria-labelledby={hasLabel ? this.headerId : undefined}
           class={`tds-modal tds-modal__actions-${this.actionsPosition} tds-modal-${this.size}`}
           tabindex="-1"
         >
-          <div id={headerId} class="header">
-            {this.header && <div class="header-text">{this.header}</div>}
+          <div class="header">
+            {this.header && (
+              <h1 id={this.headerId} class="header-text">
+                {this.header}
+              </h1>
+            )}
             {usesHeaderSlot && <slot name="header" />}
 
             {this.closable && (
@@ -399,7 +405,7 @@ export class TdsModal {
             )}
           </div>
 
-          <div id={bodyId} class="body">
+          <div id={this.bodyId} class="body">
             <slot name="body" />
           </div>
 


### PR DESCRIPTION
## **Describe pull-request**  
This fix occured during the development of some tests for the [modal PR](https://github.com/scania-digital-design-system/tegel/pull/1870). 
We noticed that the dialog/modal had not been receiving its correct aria-label. It was using aria-labelledby from an inner div. This basically had three issues:
- the name of a dialog should be derived from the heading of the dialog itself ([WCAG](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/dialog/));
- the div used to label it, which contained the header text itself, did not have any name since it did not have the appropriate role;
- since the Host was the one representing the modal, it was never able to access the inner elements which should be labelling it;

Our fix involves moving the element with role=dialog (aka the modal) inwards, and introducing the role heading with the modal title.

## **Issue Linking:**  
- **No issue:** This was an a11y problem that we encountered while doing some tests.  

## **How to test**  
1. Go to the current [Storybook](https://tds-storybook.tegel.scania.com/?path=/story/components-modal--default&args=prevent:!true) page for the modal component
2. Open a modal and inspect it
3. Verify that the `aria-labelledby` attribute is invalid.
4. Go to the [Storybook deployed in this PR](https://pr-1873.d3fazya28914g3.amplifyapp.com/) page for the modal component
5. Open the modal and inspect it
6. Verify that the a11y is correctly given by the title provided in the modal.


## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  

### Before:
<img width="640" height="645" alt="image" src="https://github.com/user-attachments/assets/64017d20-c279-4cc9-9284-4997eab00f51" />


### After:
<img width="644" height="706" alt="image" src="https://github.com/user-attachments/assets/88160770-e83a-4954-89e9-534deedbf6cc" />
