### PR TITLE
fix(motion): add initial values to collapse custom properties

### DIFF
--- a/motion/_animation.scss
+++ b/motion/_animation.scss
@@ -408,11 +408,13 @@
 @property --collapse-size {
   syntax: '<length-percentage>';
   inherits: false;
+  initial-value: 0px;
 }
 
 @property --collapse-width-size {
   syntax: '<length-percentage>';
   inherits: false;
+  initial-value: 0px;
 }
 
 @keyframes collapse-in {


### PR DESCRIPTION
## **Describe pull-request**
Adds required `initial-value` descriptors to the registered collapse custom properties in `motion/_animation.scss`.

This makes the generated Tegel CSS valid for `@property` rules using `syntax: '<length-percentage>'` and fixes failures in strict CSS tooling such as Lightning CSS / Vite CSS minification.

## **Issue Linking:**
- **No issue:** Fixes invalid `@property` output where `initial-value` is missing for typed custom properties.

## **How to test**
1. Run `npm ci` in `packages/core`.
2. Run `npm run build` in `packages/core`.
3. Verify `packages/core/dist/tegel/tegel.css` contains `initial-value:0px` for `--collapse-size` and `--collapse-width-size`.
4. Verify generated CSS can be minified by Lightning CSS.

## **Additional context**
`initial-value` is required for `@property` rules unless `syntax` is `"*"`. Tegel uses `syntax: '<length-percentage>'`, so the rules are invalid without an initial value.

Spec reference: https://www.w3.org/TR/css-properties-values-api-1/#at-property-rule

