### PR TITLE
fix(button-icon): center icon inside button when button is icon only

### DIFF
--- a/packages/core/src/components/button/button.scss
+++ b/packages/core/src/components/button/button.scss
@@ -222,6 +222,9 @@ tds-button {
 
     &.only-icon::slotted([slot='icon']) {
       margin-left: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
   }
 }

--- a/packages/core/src/components/button/readme.md
+++ b/packages/core/src/components/button/readme.md
@@ -1,6 +1,12 @@
 # tds-button
 
-
+**NOTE:** When using the button with an icon only, each icon's real size is rendered considering the size + padding of the button.
+<br>
+- **Extra small** _(xs)_ → not possible to have icon inside;
+<br>
+- **Small** _(sm)_ → maximum size of the container for the icon is 16px;
+<br>
+- **Medium** _(md)_ & **Large** _(lg)_ → maximum size of the container for the icon is 20px;
 
 <!-- Auto Generated Below -->
 


### PR DESCRIPTION
## **Describe pull-request**  
This PR fixes a bug opened in GitHub where the icon was not centered inside the button.
A display flex + align items center + justify content center was added to the icon-only[slot=icon] css class in the button.css file to align it inside the button.

Some notes in the readme file for the button were also added to clear up to the user that there are maximum sizes to the icons for each button size.

## **Issue Linking:**  
- **GitHub:** #1909  
- **Loop:** [PI2617-16](https://scaniaazureservices.sharepoint.com/:fl:/r/contentstorage/CSP_5bac0fd3-2580-4d6c-9ac0-3a3058f9e4ce/Document%20Library/LoopAppData/PI2617%20Backlog.loop?d=waeb21d3f32db499b82faf27e88227ec6&csf=1&web=1&e=EqKVdK&nav=cz0lMkZjb250ZW50c3RvcmFnZSUyRkNTUF81YmFjMGZkMy0yNTgwLTRkNmMtOWFjMC0zYTMwNThmOWU0Y2UmZD1iJTIxMHctc1c0QWxiRTJhd0Rvd1dQbmt6bm5SbkE1Q2kwcEdpT0M1TUdTdHI1Z1JvOHl5TFJtV1JLQWVicjlNMXRSRCZmPTAxTzJURlZCWjdEV1pLNVdaU1RORVlGNlhTUDJFQ0U3V0cmYz0lMkYlM0ZtaW5pZmllZCUzRDc0NGNhMTdlLWJjMzEtNGUzMy1iMWY0LTUxNDI0MDczN2U3YyUyNnNlcSUzRDE1MTg0JmE9TG9vcEFwcCZwPSU0MGZsdWlkeCUyRmxvb3AtcGFnZS1jb250YWluZXImeD0lN0IlMjJ3JTIyJTNBJTIyVDBSVFVIeHpZMkZ1YVdGaGVuVnlaWE5sY25acFkyVnpMbk5vWVhKbGNHOXBiblF1WTI5dGZHSWhNSGN0YzFjMFFXeGlSVEpoZDBSdmQxZFFibXQ2Ym01U2JrRTFRMmt3Y0VkcFQwTTFUVWRUZEhJMVoxSnZPSGw1VEZKdFYxSkxRV1ZpY2psTk1YUlNSSHd3TVU4eVZFWldRakpOTkVGSFdWRkRWVFUyVWtaTVZGVlVWMFJKU3paQ1JUTXolMjIlMkMlMjJpJTIyJTNBJTIyNjUyYTZhZGItMjFkZS00ODMzLThiNTQtNTQ1MmYwOTIwY2I3JTIyJTdE)

## **How to test**  

1. Go to the Button page in the [React Demo before the fix](https://pr-317.d2vh2lmnzgzrkl.amplifyapp.com);
2. Verify that the last two buttons do not have the icon centered inside the button;
3. Go to the Button page in the [React Demo with the Beta release](https://pr-318.d2vh2lmnzgzrkl.amplifyapp.com);
4. Verify that the last two buttons are centered now with the fix;

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
Before fix:
<img width="126" height="73" alt="image" src="https://github.com/user-attachments/assets/d03a9ffb-902d-4ff4-9361-f24425fb626e" />

After fix: 
<img width="118" height="67" alt="image" src="https://github.com/user-attachments/assets/d0e2e950-01cd-4b51-8161-541affeffebe" />


## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
