### PR TITLE
fix(tegel-lite): map component vars for accordion + radio-button disabled

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-accordion/_tl-accordion-item.scss
+++ b/packages/core/src/tegel-lite/components/tl-accordion/_tl-accordion-item.scss
@@ -44,6 +44,8 @@
   }
 
   &--disabled {
+    opacity: var(--accordion-opacity-disabled);
+
     &:hover,
     &:active {
       background-color: transparent;
@@ -60,7 +62,7 @@
 .tl-accordion__title {
   flex-grow: 2;
   text-align: left;
-  color: var(--color-foreground-text-strong);
+  color: var(--accordion-text);
 
   .tl-accordion__item--disabled & {
     color: var(--accordion-text-disabled);

--- a/packages/core/src/tegel-lite/components/tl-radio-button/tl-radio-button.scss
+++ b/packages/core/src/tegel-lite/components/tl-radio-button/tl-radio-button.scss
@@ -114,6 +114,7 @@
   }
 
   .tl-radio-button:has(:disabled) & {
+    opacity: var(--radio-button-opacity-disabled);
     cursor: not-allowed;
   }
 }


### PR DESCRIPTION
## What

Wires tegel-lite accordion and radio-button styling through the component-level variables defined in their \`_*-vars.scss\` files, keeping them consistent with the new variable structure already used by the other migrated components (checkbox, toggle, block).

## Changes

**tl-accordion**
- **Title color** — \`.tl-accordion__title\` now uses \`var(--accordion-text)\` instead of the pre-migration \`var(--color-foreground-text-strong)\`. Both resolve to \`--color-text-strong\`, so **no visual change** — it just routes through the component var.
- **Disabled opacity** — \`--accordion-opacity-disabled\` was defined but never consumed. Disabled items now apply \`opacity: var(--accordion-opacity-disabled)\`.

**tl-radio-button**
- **Disabled label** — the label stayed at full opacity while the input dimmed. \`.tl-radio-button__label\` now applies \`opacity: var(--radio-button-opacity-disabled)\` on disabled, matching the checkbox label.

## Audit notes

A full vars ↔ styling mapping check of accordion, block, checkbox, radio-button and toggle was done. block, checkbox and toggle were already fully consistent. The accordion expanded-header background (\`--color-background-surface-100\`) was intentionally left as-is.

## Review note

Disabled accordion items now dim via both the \`--accordion-text-disabled\` color-swap and opacity. Worth a quick visual check; if too faint we can drop one of the two.