### PR TITLE
fix(tegel-lite): xs button font size + restore interactive story demos

### DIFF
--- a/packages/core/.storybook/preview.ts
+++ b/packages/core/.storybook/preview.ts
@@ -83,13 +83,16 @@ const toggleBrandDecorator: Decorator = (StoryFn, context) => {
   document.body.classList.add(`tds-mode-variant-${modeVariant}`);
 
   const story = StoryFn();
+  // Return a string so Storybook takes the innerHTML + simulatePageLoad code
+  // path in @storybook/html's renderToCanvas. That revives <script> tags in
+  // the story HTML (otherwise they're inert and demo JS in tegel-lite
+  // stories like accordion/dropdown/modal never executes).
+  if (typeof story === 'string') {
+    return `<div class="tds-mode-variant-${modeVariant}">${story}</div>`;
+  }
   const wrapper = document.createElement('div');
   wrapper.classList.add(`tds-mode-variant-${modeVariant}`);
-  if (typeof story === 'string') {
-    wrapper.innerHTML = story;
-  } else {
-    wrapper.appendChild(story);
-  }
+  wrapper.appendChild(story);
   return wrapper;
 };
 

--- a/packages/core/src/tegel-lite/components/tl-button/tl-button.scss
+++ b/packages/core/src/tegel-lite/components/tl-button/tl-button.scss
@@ -166,6 +166,7 @@
   &--xs {
     padding: var(--tds-spacing-element-4) var(--tds-spacing-element-8);
     height: 24px;
+    font-size: var(--detail-05-font-size);
   }
 
   &--sm {


### PR DESCRIPTION
## **Describe pull-request**  
tl-button XS font size: the --xs size modifier in [tl-button.scss](vscode-webview://1b4vbtfpek7qubnnqhbcdureiv43i6sr1acltmski0q95imj01d5/packages/core/src/tegel-lite/components/tl-button/tl-button.scss#L166-L170) only set padding and height, so XS buttons inherited the default font size and looked oversized for a 24px button. Added font-size: var(--detail-05-font-size) to match the rest of the size scale.

Story script execution: the brand-toggle decorator in [.storybook/preview.ts](vscode-webview://1b4vbtfpek7qubnnqhbcdureiv43i6sr1acltmski0q95imj01d5/packages/core/.storybook/preview.ts) always returned a div element. Storybook's HTML renderer only revives inline <script> tags when a story returns a string (the simulatePageLoad path); when it gets a Node, scripts inserted via innerHTML stay inert. As a result, demo JS in tl-accordion, tl-dropdown, tl-modal, tl-banner, tl-stepper, and tl-toast stopped running — the accordion no longer expanded on click. The decorator now returns a string when the story result is a string, falling back to the element path otherwise.


**Test plan**

- [ ]  In Storybook, open Tegel Lite / Button and confirm XS variant uses the smaller detail-05 font size

- [ ]  Open Tegel Lite / Accordion and confirm items toggle on click

- [ ]  Spot-check Modal, Banner, Toast, Stepper, Dropdown demos still work

- [ ]  Switch the Brand toolbar between Scania / TRATON — mode-variant class still applies on the wrapper

## **Issue Linking:**  
_Choose one of the following options_
- **Jira:** Add ticket number after `CDEP-`: [CDEP-](https://jira.scania.com/browse/CDEP-)
- **GitHub:** Include issue link  
- **No issue:** Describe the problem being solved.  

## **How to test**  
_Provide detailed steps for testing, including any necessary setup._
1. Go to...
2. Check in...
3. Run ...

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
