### PR TITLE
fix(tl-datetime): add missing icon

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-datetime/readme.md
+++ b/packages/core/src/tegel-lite/components/tl-datetime/readme.md
@@ -9,16 +9,20 @@ The DateTime component provides a form input for date and time selection with su
   <label class="tl-datetime__label">Select date</label>
   <div class="tl-datetime__wrapper">
     <input class="tl-datetime__input" type="date" />
+    <span class="tl-icon tl-icon--calendar tl-icon--20 tl-datetime__icon" aria-hidden="true"></span>
   </div>
   <div class="tl-datetime__helper">Helper text</div>
 </div>
 ```
+
+Use `tl-icon--clock` instead of `tl-icon--calendar` when the input `type` is `time`.
 
 ## Required Stylesheets
 
 ```
 @scania/tegel-lite/global.css
 @scania/tegel-lite/tl-datetime.css
+@scania/tegel-lite/tl-icon.css
 ```
 
 ## Elements
@@ -27,9 +31,10 @@ The DateTime component provides a form input for date and time selection with su
 | ---------------------------- | ------------ | ------------------------------------- |
 | `.tl-datetime`               | `<div>`      | Main container (min-width 208px unless `--no-min-width`) |
 | `.tl-datetime__label`        | `<label>`    | Label for the input                   |
-| `.tl-datetime__wrapper`      | `<div>`      | Wrapper for input (icon generated via CSS) |
+| `.tl-datetime__wrapper`      | `<div>`      | Wrapper for input and icon            |
 | `.tl-datetime__input`        | `<input>`    | Input element (date/datetime-local/time) |
 | `.tl-datetime__label-inside` | `<label>`    | Label inside the input wrapper        |
+| `.tl-datetime__icon`         | `<span>`     | Calendar (or clock for `type="time"`) icon, positioned to the right of the input |
 | `.tl-datetime__helper`       | `<div>`      | Helper text container below input     |
 
 ## Modifiers

--- a/packages/core/src/tegel-lite/components/tl-datetime/readme.md
+++ b/packages/core/src/tegel-lite/components/tl-datetime/readme.md
@@ -34,7 +34,7 @@ Use `tl-icon--clock` instead of `tl-icon--calendar` when the input `type` is `ti
 | `.tl-datetime__wrapper`      | `<div>`      | Wrapper for input and icon            |
 | `.tl-datetime__input`        | `<input>`    | Input element (date/datetime-local/time) |
 | `.tl-datetime__label-inside` | `<label>`    | Label inside the input wrapper        |
-| `.tl-datetime__icon`         | `<span>`     | Calendar (or clock for `type="time"`) icon, positioned to the right of the input |
+| `.tl-datetime__icon`         | `<span>`     | Icon for the component. Clock icon for type="time" and calendar icon for the other types |
 | `.tl-datetime__helper`       | `<div>`      | Helper text container below input     |
 
 ## Modifiers

--- a/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.scss
+++ b/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.scss
@@ -55,43 +55,27 @@
   .tl-datetime:has(input:disabled) & {
     cursor: not-allowed;
   }
+}
 
-  /* CSS-generated icon */
-  &::after {
-    content: '';
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    right: 18px;
-    width: 20px;
-    height: 20px;
-    mask-repeat: no-repeat;
-    mask-position: center;
-    mask-size: 20px 20px;
-    background-color: var(--datetime-icon);
-    pointer-events: none;
+.tl-datetime__icon {
+  position: absolute;
+  top: 50%;
+  right: 18px;
+  transform: translateY(-50%);
+  color: var(--datetime-icon);
+  pointer-events: none;
 
-    /* Default: calendar icon for date/datetime inputs */
-    mask-image: var(--icon-calendar-svg);
-
-    /* Firefox - hide our custom icon since Firefox shows its own */
-    @supports (-moz-appearance: none) {
-      display: none;
-    }
+  /* Firefox shows its own native picker icon — hide ours to avoid a duplicate */
+  @supports (-moz-appearance: none) {
+    display: none;
   }
 
-  /* Change to clock icon for time input */
-  &:has(input[type='time'])::after {
-    mask-image: var(--icon-clock-svg);
+  .tl-datetime--error & {
+    color: var(--datetime-icon-error);
   }
 
-  .tl-datetime--error &::after {
-    background-color: var(--datetime-icon-error);
-  }
-
-  /* Disabled state */
-  .tl-datetime:has(input:disabled) &::after {
-    background-color: var(--datetime-icon-disabled);
+  .tl-datetime:has(input:disabled) & {
+    color: var(--datetime-icon-disabled);
   }
 }
 
@@ -116,7 +100,7 @@
     box-shadow: inset var(--datetime-box-shadow-focus);
   }
 
-  .tl-datetime:hover &:not(:focus):not(:disabled) {
+  .tl-datetime:hover &:not(:focus, :disabled) {
     box-shadow: inset var(--datetime-box-shadow-hover);
   }
 
@@ -128,7 +112,7 @@
     }
   }
 
-  .tl-datetime--error:hover &:not(:focus):not(:disabled) {
+  .tl-datetime--error:hover &:not(:focus, :disabled) {
     box-shadow: inset var(--datetime-box-shadow-error-hover);
   }
 

--- a/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.stories.tsx
@@ -132,10 +132,13 @@ const Template = ({
 
   const disabledAttr = disabled ? 'disabled' : '';
 
+  const iconName = typeLookup[type] === 'time' ? 'clock' : 'calendar';
+
   return formatHtmlPreview(`
     <!-- Required stylesheets:
       "@scania/tegel-lite/global.css"
       "@scania/tegel-lite/tl-datetime.css"
+      "@scania/tegel-lite/tl-icon.css"
     -->
 
   <div class="${classes}" style="width: calc(100vw - 40px); max-width: 400px;">
@@ -147,6 +150,7 @@ const Template = ({
         ${disabledAttr}
       />
       ${labelInside}
+      <span class="tl-icon tl-icon--${iconName} tl-icon--20 tl-datetime__icon" aria-hidden="true"></span>
     </div>
     ${helperHtml}
   </div>


### PR DESCRIPTION
## **Describe pull-request**  
Bug fix for Tegel Lite datetime component. It was missing it's icon, both calendar and the clock when type is time. This PR fixes that issue and updates the documentation for it.


## **How to test**  
1. Go to preview link and navigate to Tegel Lite -> datetime
2. Check that the icon is visible and when you change to type time, the icon should update to a clock. 
3. Check dark/light mode in Scania/TRATON

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
_Include before/after screenshots for UI changes._

## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
