### PR TITLE
fix(tl-datetime): set TRATON empty-state text color to prevent Safari aqua fallback

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-datetime/_tl-datetime-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-datetime/_tl-datetime-vars.scss
@@ -5,21 +5,21 @@
   --datetime-background: var(--datetime-background-primary);
   --datetime-text: var(--color-foreground-text-strong);
   --datetime-icon: var(--color-foreground-icon-strong);
-  --datetime-placeholder: var(--color-foreground-text-subtle);
+  --datetime-placeholder: var(--color-text-subtle);
 
   // Disabled
   --datetime-background-disabled-primary: var(--color-background-layer-01);
   --datetime-background-disabled-secondary: var(--color-background-layer-02);
   --datetime-background-disabled: var(--datetime-background-disabled-primary);
   --datetime-text-disabled: var(--color-foreground-text-disabled);
-  --datetime-placeholder-disabled: var(--color-foreground-text-disabled);
+  --datetime-placeholder-disabled: var(--color-text-disabled);
   --datetime-label-disabled: var(--color-foreground-text-disabled);
   --datetime-icon-disabled: var(--color-foreground-text-disabled);
 
   // Label
   --datetime-label: var(--color-foreground-text-strong);
   --datetime-label-inside: var(--color-foreground-text-strong);
-  --datetime-placeholder-focus: var(--tds-grey-500);
+  --datetime-placeholder-focus: var(--color-text-subtle);
 
   // Highlight bar
   --datetime-highlight-bar: var(--color-foreground-border-accent-focus);

--- a/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.scss
+++ b/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.scss
@@ -129,6 +129,18 @@
     color: var(--datetime-placeholder-focus);
   }
 
+  /*
+   * Empty/default state: Safari renders the unset datetime placeholder
+   * (e.g. "yyyy/mm/dd") through ::-webkit-datetime-edit. Without an explicit
+   * color it falls back to the UA accent (aqua) — most visible on TRATON,
+   * where no theme rule overrides it. Set the placeholder color explicitly.
+   */
+  @supports selector(input::-webkit-datetime-edit) {
+    &:not(:focus)::-webkit-datetime-edit {
+      color: var(--datetime-placeholder);
+    }
+  }
+
   /* WebKit datetime fields */
   &::-webkit-datetime-edit-text {
     -webkit-text-fill-color: var(--datetime-text);

--- a/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.scss
+++ b/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.scss
@@ -139,8 +139,12 @@
    * to the placeholder colour. We only target the container + fields-wrapper,
    * not the individual sub-fields: when a value IS present Safari paints the
    * digits in the sub-field pseudos (e.g. ::-webkit-datetime-edit-year-field),
-   * which keep `--datetime-text` from the rules below — so a filled, unfocused
-   * value is not dimmed. Scoped to `:not(:focus)`.
+   * which keep `--datetime-text` from the rules below — so a filled value is
+   * not dimmed in either state. We cover both `:not(:focus)` and `:focus`:
+   * Safari keeps painting the empty placeholder through the container while the
+   * input is focused, so without the focused branch it falls back to the aqua
+   * UA accent again on focus. The focused branch uses the focus placeholder
+   * token to mirror the `::placeholder` rule above.
    */
   @supports selector(input::-webkit-datetime-edit) {
     &:not(:focus) {
@@ -148,6 +152,14 @@
       &::-webkit-datetime-edit-fields-wrapper {
         color: var(--datetime-placeholder);
         -webkit-text-fill-color: var(--datetime-placeholder);
+      }
+    }
+
+    &:focus {
+      &::-webkit-datetime-edit,
+      &::-webkit-datetime-edit-fields-wrapper {
+        color: var(--datetime-placeholder-focus);
+        -webkit-text-fill-color: var(--datetime-placeholder-focus);
       }
     }
   }

--- a/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.scss
+++ b/packages/core/src/tegel-lite/components/tl-datetime/tl-datetime.scss
@@ -130,14 +130,25 @@
   }
 
   /*
-   * Empty/default state: Safari renders the unset datetime placeholder
-   * (e.g. "yyyy/mm/dd") through ::-webkit-datetime-edit. Without an explicit
-   * color it falls back to the UA accent (aqua) — most visible on TRATON,
-   * where no theme rule overrides it. Set the placeholder color explicitly.
+   * Empty/default state: when no date is picked Safari renders the placeholder
+   * (e.g. "yyyy/mm/dd") through the ::-webkit-datetime-edit container and its
+   * -fields-wrapper. Safari ignores `color` on these pseudos and paints the
+   * text via `-webkit-text-fill-color`; with neither set it falls back to the
+   * UA accent (aqua) — most visible on TRATON, where no theme rule overrides
+   * it. Set both `color` (other engines) and `-webkit-text-fill-color` (Safari)
+   * to the placeholder colour. We only target the container + fields-wrapper,
+   * not the individual sub-fields: when a value IS present Safari paints the
+   * digits in the sub-field pseudos (e.g. ::-webkit-datetime-edit-year-field),
+   * which keep `--datetime-text` from the rules below — so a filled, unfocused
+   * value is not dimmed. Scoped to `:not(:focus)`.
    */
   @supports selector(input::-webkit-datetime-edit) {
-    &:not(:focus)::-webkit-datetime-edit {
-      color: var(--datetime-placeholder);
+    &:not(:focus) {
+      &::-webkit-datetime-edit,
+      &::-webkit-datetime-edit-fields-wrapper {
+        color: var(--datetime-placeholder);
+        -webkit-text-fill-color: var(--datetime-placeholder);
+      }
     }
   }
 


### PR DESCRIPTION
**Issue (Max Adolfsson, design):** In Safari the Datetime field shows aqua placeholder text in its empty/default state ("None", before a date is picked) under the TRATON theme. Scania looked OK.

**Root cause:** The tegel-lite placeholder variable pointed at `--color-foreground-text-subtle` — a token that **doesn't exist** in the published `@scania/tegel-lite` package (verified: 0 definitions in the compiled CSS). So the placeholder colour resolved to nothing and Safari fell back to its aqua UA default. (The earlier `color`-only attempt couldn't work for the same reason.)

**Fix (tegel-lite only):**
- Repoint `--datetime-placeholder` / `-disabled` / `-focus` at the real, brand-defined tokens (`--color-text-subtle` / `--color-text-disabled`) — the same ones lite text-field/textarea use.
- Also set `-webkit-text-fill-color` (not just `color`) on the empty-state `::-webkit-datetime-edit` + fields-wrapper, since Safari ignores `color` there. Scoped to `:not(:focus)` so a filled value isn't dimmed.

Core `tds-datetime` is unaffected (its token chain resolves for both brands). No `tokens/` files touched.

**How to test (in Safari):**
1. Storybook → Tegel Lite → Datetime, brand = TRATON, leave the field empty.
2. The "yyyy/mm/dd hh:mm" placeholder should be subtle grey — not aqua.
3. Switch to Scania (still correct); pick a date → the entered value shows in the normal strong colour (not dimmed).
