### PR TITLE
fix(modal): override Scania dark-mode background to raised surface

### DIFF
--- a/packages/core/src/components/modal/modal-vars.scss
+++ b/packages/core/src/components/modal/modal-vars.scss
@@ -9,6 +9,19 @@ tds-modal {
   --tds-modal-text-color: var(--component-modal-text-title-default);
   --tds-modal-body-text-color: var(--component-modal-text-body-default);
   --tds-modal-icon-color: var(--component-modal-icon-dismiss-default);
-  --tds-modal-box-shadow: 0 3px 3px 0 var(--component-shadow-default, rgba(0, 0, 0, 0.15)),
-    0 -1px 1px 0 var(--component-shadow-base-modifier, rgba(0, 0, 0, 0.10));
+  --tds-modal-box-shadow:
+    0 3px 3px 0 var(--component-shadow-default, rgb(0, 0, 0, 0.15)),
+    0 -1px 1px 0 var(--component-shadow-base-modifier, rgb(0, 0, 0, 0.1));
+}
+
+// Workaround: the Figma-exported token maps the Scania dark modal surface to
+// layer-01 (page base) instead of layer-02 (the raised surface used by every
+// other theme/mode). Override at component level until the token is corrected
+// in Figma. Do not edit tokens/ directly.
+.tds-mode-dark tds-modal,
+.scania .tds-mode-dark tds-modal,
+.scania.tds-mode-dark tds-modal,
+.scania .tl-mode-dark tds-modal,
+.scania.tl-mode-dark tds-modal {
+  --tds-modal-background: var(--color-background-layer-02);
 }

--- a/packages/core/src/tegel-lite/components/tl-modal/_tl-modal-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-modal/_tl-modal-vars.scss
@@ -14,6 +14,20 @@
   --modal-text: var(--component-modal-text-title-default);
   --modal-body-text: var(--component-modal-text-body-default);
   --modal-cross-svg: var(--component-modal-icon-dismiss-default);
-  --modal-shadow: 0 3px 3px 0 var(--component-shadow-default, rgba(0, 0, 0, 0.15)),
-    0 -1px 1px 0 var(--component-shadow-base-modifier, rgba(0, 0, 0, 0.10));
+  --modal-shadow:
+    0 3px 3px 0 var(--component-shadow-default, rgb(0, 0, 0, 0.15)),
+    0 -1px 1px 0 var(--component-shadow-base-modifier, rgb(0, 0, 0, 0.1));
+}
+
+// Workaround: the Figma-exported token maps the Scania dark modal surface to
+// layer-01 (page base) instead of layer-02 (the raised surface used by every
+// other theme/mode). Override at component level until the token is corrected
+// in Figma. Do not edit tokens/ directly.
+.tl-mode-dark .tl-modal,
+.tl-mode-dark .tl-modal__overlay,
+.scania .tl-mode-dark .tl-modal,
+.scania.tl-mode-dark .tl-modal,
+.scania .tl-mode-dark .tl-modal__overlay,
+.scania.tl-mode-dark .tl-modal__overlay {
+  --modal-background: var(--color-background-layer-02);
 }


### PR DESCRIPTION
**Issue (Max Adolfsson, design):** In Scania dark mode the modal background is wrong — it blends into the page instead of sitting on a raised surface.

**Fix:** Override the modal background to the raised surface (`layer-02`) for Scania dark, at the component level (core + Tegel Lite).

**Note:** Root cause is the Figma token export mapping Scania-dark modal background to the page base (`layer-01`) instead of `layer-02` like every other theme/mode. Per our rule we don't hand-edit exported tokens, so this overrides at the component level — once the token is corrected in Figma, this override can be removed.

**How to test:**
1. Storybook → Modal, set theme to Scania + dark mode.
2. Open the modal — its surface should be a raised grey, clearly lighter than the page behind it.
3. Sanity-check Scania light, TRATON light, TRATON dark — unchanged. Check the Tegel Lite modal too.
