### PR TITLE
fix(toast): render status icon at consistent size across variants

### DIFF
--- a/packages/core/src/components/toast/toast.scss
+++ b/packages/core/src/components/toast/toast.scss
@@ -76,6 +76,14 @@
   }
 
   tds-icon {
+    /* Pin the leading status icon to a fixed box so every variant (info /
+       success / warning / error) reserves the same width and height. Without
+       this the icon is a flex child with the default `flex-shrink: 1`, so its
+       box could vary between variants and shift the component width. */
+    box-sizing: content-box;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
     padding: 14px 0 0 12px;
   }
 


### PR DESCRIPTION
**Issue (Max Adolfsson, design):** The status icon appears to change size between toast variants (most visible on Warning), which shifts the component width.

**Fix:** Pin the leading status icon to a fixed 20×20 box so every variant reserves identical space (no width shift). Tegel Lite was already pinned.

**How to test:**
1. Storybook → Toast, cycle Information / Success / Warning / Error with the same text.
2. The icon size and total toast width should be identical across variants (Warning should now match the others).
