### PR TITLE
fix(tl-toggle): associate label with input so clicking the label toggles the control

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-toggle/readme.md
+++ b/packages/core/src/tegel-lite/components/tl-toggle/readme.md
@@ -7,10 +7,12 @@ The Toggle component provides a switch input for binary on/off selections.
 ```html
 <div class="tl-toggle">
   <div class="tl-toggle__headline">Settings</div>
-  <input type="checkbox" class="tl-toggle__input tl-toggle__input--lg" />
-  <label class="tl-toggle__label">Enable feature</label>
+  <input type="checkbox" class="tl-toggle__input tl-toggle__input--lg" id="toggle-1" />
+  <label class="tl-toggle__label" for="toggle-1">Enable feature</label>
 </div>
 ```
+
+**Note:** Match the `for` attribute on the `<label>` to the `id` of the `<input>` so clicking the label text toggles the control (and to keep the label/control association accessible).
 
 <br />
 

--- a/packages/core/src/tegel-lite/components/tl-toggle/tl-toggle.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-toggle/tl-toggle.stories.tsx
@@ -77,10 +77,11 @@ const Template = ({ size, headline, label, checked, disabled }) =>
           class="tl-toggle__input ${
             size === 'Large' ? 'tl-toggle__input--lg' : 'tl-toggle__input--sm'
           }"
+          id="tl-toggle"
           ${checked ? 'checked' : ''}
           ${disabled ? 'disabled' : ''}
         />
-        <label class="tl-toggle__label">${label}</label>
+        <label class="tl-toggle__label" for="tl-toggle">${label}</label>
     </div>
   `);
 export const Default = Template.bind({});


### PR DESCRIPTION
**Issue (Max Adolfsson, design):** Clicking the toggle's label should flip it, like Checkbox and Radio Button.

**Fix:** The core `tds-toggle` already supports this (native `<input>` + `<label for>`, same as checkbox/radio). The gap was the Tegel Lite example, which was missing the `id`/`for` association — added it (and a readme note) to match `tl-checkbox`, so clicking the label works in the lite usage/demo.

**How to test:**
1. Storybook → Tegel Lite → Toggle: click the label text → it toggles.
2. Enable "Disabled", click the label → nothing happens.
3. (Reference) core Toggle story: clicking the label already toggles.
