### PR TITLE
fix(link): order Storybook stories consistently with other components

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/charles.krook/Umain/Scania/tegel/node_modules

--- a/packages/core/node_modules
+++ b/packages/core/node_modules
@@ -1,0 +1,1 @@
+/Users/charles.krook/Umain/Scania/tegel/packages/core/node_modules

--- a/packages/core/src/components/link/link.stories.tsx
+++ b/packages/core/src/components/link/link.stories.tsx
@@ -80,8 +80,12 @@ const linkWithinTextTemplate = ({ disabled, underline }) =>
     It enables an efficient development process and ensures a premium experience across all of Scania's digital touchpoints.    
   </p>`);
 
-export const StandaloneLink = standaloneLinkTemplate.bind({});
-StandaloneLink.args = {
+// Standalone Link is the primary story. Named `Default` to match the
+// convention used by every other component (Button, Checkbox, Toggle, …):
+// the primary story is exported as `Default` so it leads the sidebar with the
+// global alphabetical `storySort`, ahead of the auto-generated Docs/Notes pages.
+export const Default = standaloneLinkTemplate.bind({});
+Default.args = {
   underline: false,
   disabled: false,
   iconEnabled: true,
@@ -89,7 +93,7 @@ StandaloneLink.args = {
 };
 
 // Additional argTypes for Standalone Link only
-StandaloneLink.argTypes = {
+Default.argTypes = {
   iconEnabled: {
     name: 'Icon Enabled',
     description: 'Toggle to enable or disable the icon as suffix.',

--- a/packages/core/src/tegel-lite/components/tl-link/tl-link.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-link/tl-link.stories.tsx
@@ -79,8 +79,12 @@ const linkWithinTextTemplate = ({ disabled, underline }) => {
   `);
 };
 
-export const StandaloneLink = standaloneLinkTemplate.bind({});
-StandaloneLink.args = {
+// Standalone Link is the primary story. Named `Default` to match the
+// convention used by every other component (Button, Checkbox, Toggle, …):
+// the primary story is exported as `Default` so it leads the sidebar with the
+// global alphabetical `storySort`, ahead of the auto-generated Docs/Notes pages.
+export const Default = standaloneLinkTemplate.bind({});
+Default.args = {
   underline: false,
   disabled: false,
   iconEnabled: true,
@@ -88,7 +92,7 @@ StandaloneLink.args = {
 };
 
 // Additional argTypes for Standalone Link only
-StandaloneLink.argTypes = {
+Default.argTypes = {
   iconEnabled: {
     name: 'Icon Enabled',
     description: 'Toggle to enable or disable the icon as suffix.',


### PR DESCRIPTION
**Issue (Max Adolfsson, design):** In Storybook the Link sidebar entries are ordered oddly (Docs/Notes vs the stories) compared to other components.

**Fix:** Renamed the primary Link story to `Default` (the convention every other component uses) so the global alphabetical storySort lists it first → Default, Link Within Text, Docs, Notes.

**How to test:**
1. Run Storybook → Components → Link.
2. The sidebar order should read: Default, Link Within Text, Docs, Notes — matching Button/Checkbox/Toggle.
