### PR TITLE
Fix(side-menu): shows text when initial state is `collapsed`

### DIFF
--- a/packages/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/packages/core/src/components/side-menu/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -57,7 +57,7 @@ export class TdsSideMenuCollapseButton {
     this.collapsed = event.detail.collapsed;
   }
 
-  connectedCallback() {
+  componentWillLoad() {
     this.sideMenuEl = this.host.closest('tds-side-menu');
     this.collapsed = !!this.sideMenuEl?.collapsed;
   }

--- a/packages/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
@@ -28,7 +28,7 @@ export class TdsSideMenuDropdownListItem {
     this.collapsed = event.detail.collapsed;
   }
 
-  connectedCallback() {
+  componentWillLoad() {
     this.sideMenuEl = this.host.closest('tds-side-menu');
     this.collapsed = !!this.sideMenuEl?.collapsed;
   }

--- a/packages/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown-list/side-menu-dropdown-list.tsx
@@ -21,7 +21,7 @@ export class TdsSideMenuDropdownList {
     this.collapsed = event.detail.collapsed;
   }
 
-  connectedCallback() {
+  componentWillLoad() {
     this.sideMenuEl = this.host.closest('tds-side-menu');
     this.collapsed = !!this.sideMenuEl?.collapsed;
   }

--- a/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/packages/core/src/components/side-menu/side-menu-dropdown/side-menu-dropdown.tsx
@@ -87,7 +87,7 @@ export class TdsSideMenuDropdown {
     return this.collapsed ? this.hoverState?.isHovered : this.open;
   }
 
-  connectedCallback() {
+  componentWillLoad() {
     this.sideMenuEl = this.host.closest('tds-side-menu');
     this.collapsed = !!this.sideMenuEl?.collapsed;
     this.open = this.defaultOpen;

--- a/packages/core/src/components/side-menu/side-menu-item/side-menu-item.tsx
+++ b/packages/core/src/components/side-menu/side-menu-item/side-menu-item.tsx
@@ -76,7 +76,7 @@ export class TdsSideMenuItem {
     }
   }
 
-  connectedCallback() {
+  componentWillLoad() {
     // closest() will return null if side-menu-item is inside a shadowRoot that
     // does not contain a side-menu. This is the case for the side-menu-dropdown.
     this.sideMenuEl = this.host.closest('tds-side-menu');

--- a/packages/core/src/components/side-menu/side-menu.scss
+++ b/packages/core/src/components/side-menu/side-menu.scss
@@ -1,4 +1,4 @@
-//@import '../theme/core/spacing/vars';
+// @import '../theme/core/spacing/vars';
 @use '../../../../../grid-deprecated/vars' as *;
 @use '../../mixins/scrollbar' as *;
 @use '../../mixins/z-index' as *;
@@ -143,7 +143,7 @@ aside {
     overflow-y: auto;
   }
 
-  [role='navigation'] {
+  nav {
     height: 100%;
     display: flex;
     flex-direction: column;

--- a/packages/core/src/components/side-menu/side-menu.tsx
+++ b/packages/core/src/components/side-menu/side-menu.tsx
@@ -83,12 +83,15 @@ export class TdsSideMenu {
     }
   }
 
+  componentWillLoad() {
+    this.isCollapsed = this.collapsed;
+    this.initialCollapsedState = this.collapsed;
+  }
+
   connectedCallback() {
     this.matchesLgBreakpointMq = window.matchMedia(`(min-width: ${GRID_LG_BREAKPOINT}px)`);
     this.matchesLgBreakpointMq.addEventListener('change', this.handleMatchesLgBreakpointChange);
     this.isMobile = !this.matchesLgBreakpointMq.matches;
-    this.isCollapsed = this.collapsed;
-    this.initialCollapsedState = this.collapsed;
   }
 
   componentDidLoad() {
@@ -268,7 +271,7 @@ export class TdsSideMenu {
         >
           <slot name="overlay"></slot>
           <aside class={`menu`}>
-            <div role="navigation">
+            <nav>
               <slot name="close-button"></slot>
               <div class="tds-side-menu-wrapper">
                 <ul class={`tds-side-menu-list tds-side-menu-list-upper`}>
@@ -283,7 +286,7 @@ export class TdsSideMenu {
                 </ul>
               </div>
               <slot name="sticky-end"></slot>
-            </div>
+            </nav>
           </aside>
         </div>
       </Host>

--- a/packages/core/src/components/side-menu/test/collapse-true/index.html
+++ b/packages/core/src/components/side-menu/test/collapse-true/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Side Menu - Collapsible</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
+    <link rel="stylesheet" href="../../../../../dist/tegel/tegel.css" />
+    <script type="module">
+      import { defineCustomElements } from '../../../../../loader/index.es2017.js';
+      defineCustomElements();
+    </script>
+  </head>
+
+  <body>
+    <tds-side-menu aria-label="Side menu" id="demo-side-menu" persistent collapsed>
+      <tds-side-menu-item>
+        <button>
+          <tds-icon name="timer" size="24px" svg-title="timer"></tds-icon>
+          About us
+        </button>
+      </tds-side-menu-item>
+
+      <tds-side-menu-item>
+        <button>
+          <tds-icon name="truck" size="24px" svg-title="truck"></tds-icon>
+          Trucks
+        </button>
+      </tds-side-menu-item>
+
+      <tds-side-menu-dropdown default-open selected>
+        <tds-icon slot="icon" name="profile" size="24px" svg-title="profile"></tds-icon>
+        <span slot="label">Wheel types</span>
+        <tds-side-menu-dropdown-list>
+          <tds-side-menu-dropdown-list-item>
+            <a href="https://www.scania.com">Hub-centric wheel</a>
+          </tds-side-menu-dropdown-list-item>
+          <tds-side-menu-dropdown-list-item selected>
+            <a href="https://www.scania.com" aria-current="page">Rim wheel</a>
+          </tds-side-menu-dropdown-list-item>
+        </tds-side-menu-dropdown-list>
+      </tds-side-menu-dropdown>
+
+      <tds-side-menu-item>
+        <button>
+          <tds-icon name="star" size="24px" svg-title="star"></tds-icon>
+          Values
+        </button>
+      </tds-side-menu-item>
+
+      <tds-side-menu-collapse-button slot="sticky-end">Collapse</tds-side-menu-collapse-button>
+    </tds-side-menu>
+  </body>
+</html>

--- a/packages/core/src/components/side-menu/test/collapse-true/side-menu.e2e.ts
+++ b/packages/core/src/components/side-menu/test/collapse-true/side-menu.e2e.ts
@@ -1,0 +1,36 @@
+import { test } from 'stencil-playwright';
+import { expect } from '@playwright/test';
+import {
+  testConfigurations,
+  getTestDescribeText,
+  setupPage,
+} from '../../../../utils/testConfiguration';
+
+const componentTestPath = 'src/components/side-menu/test/collapse-true/index.html';
+const componentName = 'tds-side-menu';
+const testDescription = 'tds-side-menu-collapse-true';
+
+testConfigurations.basic.forEach((config) => {
+  test.describe.parallel(getTestDescribeText(config, testDescription), () => {
+    test.beforeEach(async ({ page }) => {
+      await setupPage(page, config, componentTestPath, componentName);
+    });
+
+    test('renders side-menu in collapsed initial state', async ({ page }) => {
+      const sideMenu = page.getByLabel('Side menu');
+      await expect(sideMenu).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    test('click collapse button to close the menu', async ({ page }) => {
+      const sideMenuCollapseButton = page
+        .locator('tds-side-menu-collapse-button')
+        .getByRole('button');
+      await expect(sideMenuCollapseButton).toHaveCount(1);
+      await expect(sideMenuCollapseButton).toBeVisible();
+      await sideMenuCollapseButton.click();
+
+      const sideMenu = page.getByLabel('Side menu');
+      await expect(sideMenu).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+});


### PR DESCRIPTION
## **Describe pull-request**  
This PR fixes a bug Tegel had related to the side-menu showing the text of each menu item when the initial state is `collapsed`. 

## **Issue Linking:**  
- **GitHub:** #1858 (please check the current behavior in the bug report)
- **Loop:** [PI2617-5](https://scaniaazureservices.sharepoint.com/:fl:/r/contentstorage/CSP_5bac0fd3-2580-4d6c-9ac0-3a3058f9e4ce/Document%20Library/LoopAppData/PI2617%20Backlog.loop?d=waeb21d3f32db499b82faf27e88227ec6&csf=1&web=1&e=zBfCZc&nav=cz0lMkZjb250ZW50c3RvcmFnZSUyRkNTUF81YmFjMGZkMy0yNTgwLTRkNmMtOWFjMC0zYTMwNThmOWU0Y2UmZD1iJTIxMHctc1c0QWxiRTJhd0Rvd1dQbmt6bm5SbkE1Q2kwcEdpT0M1TUdTdHI1Z1JvOHl5TFJtV1JLQWVicjlNMXRSRCZmPTAxTzJURlZCWjdEV1pLNVdaU1RORVlGNlhTUDJFQ0U3V0cmYz0lMkYlM0ZtaW5pZmllZCUzRDg3MmY3OGY4LTNkZmYtNDdlOC1hOTJhLTZkNDVmODQzOGRkYyUyNnNlcSUzRDI2OTA2JmE9TG9vcEFwcCZwPSU0MGZsdWlkeCUyRmxvb3AtcGFnZS1jb250YWluZXImeD0lN0IlMjJ3JTIyJTNBJTIyVDBSVFVIeHpZMkZ1YVdGaGVuVnlaWE5sY25acFkyVnpMbk5vWVhKbGNHOXBiblF1WTI5dGZHSWhNSGN0YzFjMFFXeGlSVEpoZDBSdmQxZFFibXQ2Ym01U2JrRTFRMmt3Y0VkcFQwTTFUVWRUZEhJMVoxSnZPSGw1VEZKdFYxSkxRV1ZpY2psTk1YUlNSSHd3TVU4eVZFWldRakpOTkVGSFdWRkRWVFUyVWtaTVZGVlVWMFJKU3paQ1JUTXolMjIlMkMlMjJpJTIyJTNBJTIyNjUyYTZhZGItMjFkZS00ODMzLThiNTQtNTQ1MmYwOTIwY2I3JTIyJTdE)

## **How to test**  
1. Go to this [StackBlitz](https://stackblitz.com/edit/vitejs-vite-mfat5g9w?file=src%2FApp.tsx) and verify that the collapsed prop is initially set as true, however the application renders the text in the side menu items and the collapse arrow is pointing to the wrong direction.
2. Go to this [StackBlitz](https://stackblitz.com/edit/vitejs-vite-kysgnyyt) containing a beta release of this branch and verify that the text no longer shows, that the collapsed prop is passed correctly, and the side menu is working as expected. 

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [x] I have added unit tests for my changes (if applicable)
- [x] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [x] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
### Before
<img width="503" height="506" alt="image" src="https://github.com/user-attachments/assets/90c9325a-0afa-4ed0-ac6d-ee601daa4108" />

### After
<img width="393" height="621" alt="image" src="https://github.com/user-attachments/assets/c3c07dde-c3a0-46b5-8ea4-40c30c6f02c5" />

