### PR TITLE
fix(tl-footer): links should not be bold

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-footer/_footer-group.scss
+++ b/packages/core/src/tegel-lite/components/tl-footer/_footer-group.scss
@@ -33,7 +33,7 @@ $breakpoint-lg: 992px;
 }
 
 .tl-footer__link {
-  @include headline-07;
+  @include detail-02;
 
   color: var(--footer-top-links);
   text-decoration: none;
@@ -56,7 +56,6 @@ $breakpoint-lg: 992px;
     display: block;
     border-bottom: 1px solid var(--footer-top-divider);
     padding: 19.5px 40px;
-    font-weight: normal;
 
     &:hover {
       background-color: var(--footer-top-links-background-hover);

--- a/packages/core/src/tegel-lite/components/tl-footer/_footer-item.scss
+++ b/packages/core/src/tegel-lite/components/tl-footer/_footer-item.scss
@@ -3,7 +3,7 @@
 
 .tl-footer__main {
   .tl-footer__link {
-    @include headline-07;
+    @include detail-02;
 
     display: inline-block;
     color: var(--footer-main-links);


### PR DESCRIPTION
Aligns tegel-lite footer links with the regular tds-footer by using the detail-02 type style (normal weight) instead of headline-07 (bold). Both are 14px, so only the weight changes.