### PR TITLE
fix(tl-footer): white Traton logotype in dark mode

### DIFF
--- a/packages/core/src/tegel-lite/components/tl-footer/_tl-footer-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-footer/_tl-footer-vars.scss
@@ -30,11 +30,13 @@
 }
 
 // Traton logotype — adapts to mode (light bg → black logo, dark bg → white logo)
+.traton .tds-mode-dark .tl-footer,
 .traton .tl-mode-dark .tl-footer {
   --component-footer-logotype-local: var(--traton-logotype-white-svg-local);
   --component-footer-logotype-cdn: var(--traton-logotype-white-svg);
 }
 
+.traton .tds-mode-light .tl-footer,
 .traton .tl-mode-light .tl-footer {
   --component-footer-logotype-local: var(--traton-logotype-black-svg-local);
   --component-footer-logotype-cdn: var(--traton-logotype-black-svg);


### PR DESCRIPTION
The tegel-lite footer only switched the Traton logotype to white under `.tl-mode-dark`, but Storybook (and tds-* contexts) apply `.tds-mode-dark`, so the rule never matched and the black logo showed in dark mode. Adds the `.tds-mode-dark`/`.tds-mode-light` selectors alongside the lite ones, mirroring the tl-card pattern.