### PR TITLE
feat(card): brand-sensitive cover image background

### DIFF
--- a/packages/core/src/components/card/card.scss
+++ b/packages/core/src/components/card/card.scss
@@ -83,6 +83,11 @@
 
   .card-body-img {
     width: 100%;
+    background-color: var(--color-background-layer-03);
+  }
+
+  slot[name='body-image']::slotted(*) {
+    background-color: var(--color-background-layer-03);
   }
 
   .tds-divider {

--- a/packages/core/src/components/card/card.stories.tsx
+++ b/packages/core/src/components/card/card.stories.tsx
@@ -1,8 +1,13 @@
-import CardBodyImage from '../../stories/assets/image/card-img.png';
 import formatHtmlPreview from '../../stories/formatHtmlPreview';
 
 const CardThumbnailSVG = `data:image/svg+xml;utf8,${encodeURIComponent(
   `<svg xmlns='http://www.w3.org/2000/svg' width='36' height='36'></svg>`,
+)}`;
+
+// Transparent placeholder so the brand-adjusted `--color-background-layer-03`
+// background on `.card-body-img` shows through (and changes with the brand).
+const CardBodyImage = `data:image/svg+xml;utf8,${encodeURIComponent(
+  `<svg xmlns='http://www.w3.org/2000/svg' width='600' height='300'></svg>`,
 )}`;
 
 export default {

--- a/packages/core/src/tegel-lite/components/tl-card/tl-card.scss
+++ b/packages/core/src/tegel-lite/components/tl-card/tl-card.scss
@@ -80,6 +80,7 @@
   inline-size: 100%;
   block-size: auto;
   display: block;
+  background-color: var(--color-background-layer-03);
 }
 
 .tl-card__divider {

--- a/packages/core/src/tegel-lite/components/tl-card/tl-card.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-card/tl-card.stories.tsx
@@ -7,9 +7,9 @@ const thumbSVG = `data:image/svg+xml;utf8,${encodeURIComponent(`<svg xmlns='http
 
 // Transparent placeholder so the brand-adjusted `--color-background-layer-03`
 // background on `.tl-card__image` shows through (and changes with the brand).
-const bodyImgSVG = `data:image/svg+xml;utf8,${encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='600' height='300'>
-    <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='14' fill='#999'>Cover image</text>
-  </svg>`)}`;
+const bodyImgSVG = `data:image/svg+xml;utf8,${encodeURIComponent(
+  `<svg xmlns='http://www.w3.org/2000/svg' width='600' height='300'></svg>`,
+)}`;
 
 export default {
   title: 'Tegel Lite/Card',

--- a/packages/core/src/tegel-lite/components/tl-card/tl-card.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-card/tl-card.stories.tsx
@@ -5,9 +5,10 @@ const thumbSVG = `data:image/svg+xml;utf8,${encodeURIComponent(`<svg xmlns='http
     <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='10' fill='#999'></text>
   </svg>`)}`;
 
+// Transparent placeholder so the brand-adjusted `--color-background-layer-03`
+// background on `.tl-card__image` shows through (and changes with the brand).
 const bodyImgSVG = `data:image/svg+xml;utf8,${encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='600' height='300'>
-    <rect width='100%' height='100%' fill='#F2F2F2'/>
-    <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='14' fill='#999'></text>
+    <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='14' fill='#999'>Cover image</text>
   </svg>`)}`;
 
 export default {


### PR DESCRIPTION
Adds `--color-background-layer-03` as the background color of the card's body/cover image in both the regular tds-card and tegel-lite tl-card, so the cover area is brand-sensitive (shows behind transparent images and while loading).