### PR TITLE
fix(card): lighter (discrete) body divider

### DIFF
--- a/packages/core/src/components/card/card-vars.scss
+++ b/packages/core/src/components/card/card-vars.scss
@@ -9,7 +9,7 @@ tds-card {
   --tds-card-headline: var(--component-card-text-title-default);
   --tds-card-sub-headline: var(--component-card-text-subtitle-default);
   --tds-card-body-color: var(--component-card-text-body-default);
-  --tds-card-divider: var(--color-border-soft);
+  --tds-card-divider: var(--color-border-discrete);
   --tds-card-icon-color: var(--component-card-text-title-default);
 }
 

--- a/packages/core/src/components/card/card-vars.scss
+++ b/packages/core/src/components/card/card-vars.scss
@@ -9,7 +9,6 @@ tds-card {
   --tds-card-headline: var(--component-card-text-title-default);
   --tds-card-sub-headline: var(--component-card-text-subtitle-default);
   --tds-card-body-color: var(--component-card-text-body-default);
-  --tds-card-divider: var(--color-border-discrete);
   --tds-card-icon-color: var(--component-card-text-title-default);
 }
 

--- a/packages/core/src/components/card/card.scss
+++ b/packages/core/src/components/card/card.scss
@@ -55,7 +55,9 @@
       tds-icon {
         cursor: pointer;
         margin-left: auto;
-        transition: transform 160ms ease-in-out, opacity 120ms ease-in-out;
+        transition:
+          transform 160ms ease-in-out,
+          opacity 120ms ease-in-out;
 
         &.rotated {
           transform: rotate(180deg);
@@ -92,13 +94,12 @@
 
   .tds-divider {
     margin: 16px 16px 0;
-    background-color: var(--tds-card-divider);
     height: 1px;
   }
 
   .card-body {
     display: block;
-    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 
   slot[name='body']::slotted(*) {

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -135,7 +135,7 @@ export class TdsCard {
           {usesBodyImageSlot && <slot name="body-image"></slot>}
           {this.bodyImg && <img class="card-body-img" src={this.bodyImg} alt={this.bodyImgAlt} />}
           {this.imagePlacement === 'above-header' && this.getCardHeader()}
-          {this.bodyDivider && <tds-divider></tds-divider>}
+          {this.bodyDivider && <tds-divider variant="discrete"></tds-divider>}
           {usesBodySlot && <slot name="body"></slot>}
         </div>
         {usesActionsSlot && <slot name={`actions`}></slot>}

--- a/packages/core/src/tegel-lite/components/tl-card/_tl-card-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-card/_tl-card-vars.scss
@@ -11,7 +11,7 @@
   --card-headline: var(--component-card-text-title-default);
   --card-sub-headline: var(--component-card-text-subtitle-default);
   --card-body-color: var(--component-card-text-body-default);
-  --card-divider: var(--color-border-soft);
+  --card-divider: var(--color-border-discrete);
   --card-icon-color: var(--component-card-text-title-default);
   --card-body-padding: 0 16px;
   --card-header-padding: 16px;


### PR DESCRIPTION
The regular tds-card body divider was too strong. Changes the card divider token from `--color-border-soft` to `--color-border-discrete` so the divider reads more discretely when enabled.