### PR TITLE
feat(radio-button): demo single disabled option in a group

### DIFF
--- a/packages/core/src/components/radio-button/radio-button.stories.tsx
+++ b/packages/core/src/components/radio-button/radio-button.stories.tsx
@@ -25,6 +25,17 @@ export default {
         type: 'text',
       },
     },
+    checkedIndex: {
+      name: 'Checked index',
+      description: 'Sets which Radio Button in the group is checked by index, or "none".',
+      control: {
+        type: 'radio',
+      },
+      options: [0, 1, 2, 'none'],
+      table: {
+        defaultValue: { summary: 0 },
+      },
+    },
     disabledIndex: {
       name: 'Disabled index',
       description:
@@ -40,11 +51,12 @@ export default {
   },
   args: {
     label: 'Label text',
+    checkedIndex: 0,
     disabledIndex: 'none',
   },
 };
 
-const Template = ({ label, disabledIndex }) =>
+const Template = ({ label, checkedIndex, disabledIndex }) =>
   formatHtmlPreview(`
   <style>
   .demo-fieldset-reset {
@@ -62,7 +74,7 @@ const Template = ({ label, disabledIndex }) =>
     radio-id="option-1"
     required=false
     ${disabledIndex === 0 || disabledIndex === 'all' ? 'disabled' : ''}
-    checked="true"
+    ${checkedIndex === 0 ? 'checked' : ''}
     tds-tab-index="0"
   >
     <div slot="label">
@@ -76,6 +88,7 @@ const Template = ({ label, disabledIndex }) =>
     radio-id="option-2"
     required=false
     ${disabledIndex === 1 || disabledIndex === 'all' ? 'disabled' : ''}
+    ${checkedIndex === 1 ? 'checked' : ''}
   >
     <div slot="label">
       ${label} 2
@@ -88,6 +101,7 @@ const Template = ({ label, disabledIndex }) =>
     radio-id="option-3"
     required=false
     ${disabledIndex === 2 || disabledIndex === 'all' ? 'disabled' : ''}
+    ${checkedIndex === 2 ? 'checked' : ''}
   >
     <div slot="label">
       ${label} 3
@@ -96,11 +110,51 @@ const Template = ({ label, disabledIndex }) =>
 
   </fieldset>
 
-  <!-- Script tag with eventlistener for demo purposes. -->
+  <!-- Script tag for demo purposes: keeps the selected Radio Button checked
+       across re-renders (e.g. when changing the disabled index) instead of
+       snapping back, since tds-radio-button doesn't sync its checked prop on
+       user interaction. -->
   <script>
-  document.addEventListener('tdsChange', (event) => {
-    console.log(event)
-  })
+  (function () {
+    var GROUP = 'rb-example';
+    var argIndex = ${checkedIndex === 'none' ? -1 : checkedIndex};
+
+    // The "Checked index" control wins whenever it changes; otherwise keep the
+    // user's last manual selection so unrelated re-renders don't reset it.
+    if (window.__tdsRbArg !== argIndex) {
+      window.__tdsRbArg = argIndex;
+      window.__tdsRbSelected = argIndex;
+    }
+
+    function radios() {
+      return Array.prototype.slice.call(
+        document.querySelectorAll('tds-radio-button[name="' + GROUP + '"]')
+      );
+    }
+
+    function applySelection() {
+      radios().forEach(function (el, index) {
+        el.checked = index === window.__tdsRbSelected;
+      });
+    }
+
+    // Remember manual selections made directly in the preview.
+    if (!window.__tdsRbBound) {
+      window.__tdsRbBound = true;
+      document.addEventListener('tdsChange', function (event) {
+        console.log(event);
+        var id = event.detail && event.detail.radioId;
+        var index = radios().findIndex(function (el) {
+          return el.getAttribute('radio-id') === id;
+        });
+        if (index !== -1) {
+          window.__tdsRbSelected = index;
+        }
+      });
+    }
+
+    customElements.whenDefined('tds-radio-button').then(applySelection);
+  })();
   </script>
   `);
 

--- a/packages/core/src/components/radio-button/radio-button.stories.tsx
+++ b/packages/core/src/components/radio-button/radio-button.stories.tsx
@@ -25,42 +25,44 @@ export default {
         type: 'text',
       },
     },
-    disabled: {
-      name: 'Disabled',
-      description: 'Disables the Radio Button.',
+    disabledIndex: {
+      name: 'Disabled index',
+      description:
+        'Disables a single Radio Button in the group by index, or the whole group with "all".',
       control: {
-        type: 'boolean',
+        type: 'radio',
       },
+      options: [0, 1, 2, 'none', 'all'],
       table: {
-        defaultValue: { summary: false },
+        defaultValue: { summary: 'none' },
       },
     },
   },
   args: {
     label: 'Label text',
-    disabled: false,
+    disabledIndex: 'none',
   },
 };
 
-const Template = ({ label, disabled }) =>
+const Template = ({ label, disabledIndex }) =>
   formatHtmlPreview(`
   <style>
-  .demo-fieldset-reset { 
+  .demo-fieldset-reset {
     border: 0;
     margin: 0;
     min-width: 0;
-    padding: 0; 
+    padding: 0;
   }
 </style>
 
   <fieldset class="demo-fieldset-reset">
-  <tds-radio-button 
+  <tds-radio-button
     name="rb-example"
     value="option1"
     radio-id="option-1"
     required=false
-    ${disabled ? 'disabled' : ''}
-    checked="true" 
+    ${disabledIndex === 0 || disabledIndex === 'all' ? 'disabled' : ''}
+    checked="true"
     tds-tab-index="0"
   >
     <div slot="label">
@@ -73,13 +75,25 @@ const Template = ({ label, disabled }) =>
     value="option2"
     radio-id="option-2"
     required=false
-    ${disabled ? 'disabled' : ''} 
+    ${disabledIndex === 1 || disabledIndex === 'all' ? 'disabled' : ''}
   >
     <div slot="label">
       ${label} 2
     </div>
   </tds-radio-button>
-    
+
+  <tds-radio-button
+    name="rb-example"
+    value="option3"
+    radio-id="option-3"
+    required=false
+    ${disabledIndex === 2 || disabledIndex === 'all' ? 'disabled' : ''}
+  >
+    <div slot="label">
+      ${label} 3
+    </div>
+  </tds-radio-button>
+
   </fieldset>
 
   <!-- Script tag with eventlistener for demo purposes. -->

--- a/packages/core/src/tegel-lite/components/tl-radio-button/tl-radio-button.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-radio-button/tl-radio-button.stories.tsx
@@ -22,21 +22,22 @@ export default {
       control: {
         type: 'radio',
       },
-      options: [0, 1, 'none'],
+      options: [0, 1, 2, 'none'],
       table: {
         defaultValue: {
           summary: 0,
         },
       },
     },
-    disabled: {
-      name: 'Disabled',
+    disabledIndex: {
+      name: 'Disabled index',
       control: {
-        type: 'boolean',
+        type: 'radio',
       },
+      options: [0, 1, 2, 'none', 'all'],
       table: {
         defaultValue: {
-          summary: false,
+          summary: 'none',
         },
       },
     },
@@ -54,13 +55,13 @@ export default {
   },
   args: {
     label: 'Label text',
-    disabled: false,
+    disabledIndex: 'none',
     checkedIndex: 0,
     name: 'rb-example',
   },
 };
 
-const Template = ({ label, checkedIndex, disabled, name }) =>
+const Template = ({ label, checkedIndex, disabledIndex, name }) =>
   formatHtmlPreview(`
 <!-- Required stylesheets:
   "@scania/tegel-lite/global.css"
@@ -80,7 +81,7 @@ const Template = ({ label, checkedIndex, disabled, name }) =>
         id="${name}-1"
         value="option-1"
         ${checkedIndex === 0 ? 'checked' : ''}
-        ${disabled ? 'disabled' : ''}
+        ${disabledIndex === 0 || disabledIndex === 'all' ? 'disabled' : ''}
       />
       <label class="tl-radio-button__label" for="${name}-1">${label} 1</label>
     </div>
@@ -93,9 +94,22 @@ const Template = ({ label, checkedIndex, disabled, name }) =>
         id="${name}-2"
         value="option-2"
         ${checkedIndex === 1 ? 'checked' : ''}
-        ${disabled ? 'disabled' : ''}
+        ${disabledIndex === 1 || disabledIndex === 'all' ? 'disabled' : ''}
       />
       <label class="tl-radio-button__label" for="${name}-2">${label} 2</label>
+    </div>
+
+    <div class="tl-radio-button">
+      <input
+        class="tl-radio-button__input"
+        type="radio"
+        name="${name}"
+        id="${name}-3"
+        value="option-3"
+        ${checkedIndex === 2 ? 'checked' : ''}
+        ${disabledIndex === 2 || disabledIndex === 'all' ? 'disabled' : ''}
+      />
+      <label class="tl-radio-button__label" for="${name}-3">${label} 3</label>
     </div>
 </fieldset>
 `);


### PR DESCRIPTION
Adds a Storybook story to both the regular tds-radio-button and tegel-lite tl-radio-button showing a group where only one Radio Button is disabled while the others stay interactive.