### PR TITLE
feat(divider): all six Figma variants + rename dark-blue to expressive

### DIFF
--- a/packages/core/src/components/divider/divider-vars.scss
+++ b/packages/core/src/components/divider/divider-vars.scss
@@ -4,6 +4,6 @@ tds-divider {
   --tds-divider-background-soft: var(--component-divider-border-soft-default);
   --tds-divider-background-defined: var(--component-divider-border-defined-default);
   --tds-divider-background-strong: var(--component-divider-border-strong-default);
-  --tds-divider-background-dark-blue: var(--component-divider-border-expressive-default);
+  --tds-divider-background-expressive: var(--component-divider-border-expressive-default);
   --tds-divider-background: var(--tds-divider-background-subtle);
 }

--- a/packages/core/src/components/divider/divider.scss
+++ b/packages/core/src/components/divider/divider.scss
@@ -21,8 +21,12 @@
     background-color: var(--tds-divider-background-defined);
   }
 
-  &.dark-blue {
-    background-color: var(--tds-divider-background-dark-blue);
+  &.strong {
+    background-color: var(--tds-divider-background-strong);
+  }
+
+  &.expressive {
+    background-color: var(--tds-divider-background-expressive);
   }
 
   &.horizontal {

--- a/packages/core/src/components/divider/divider.stories.tsx
+++ b/packages/core/src/components/divider/divider.stories.tsx
@@ -51,7 +51,7 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Discrete', 'Subtle', 'Soft', 'Defined', 'Dark-Blue'],
+      options: ['Discrete', 'Subtle', 'Soft', 'Defined', 'Strong', 'Expressive'],
       table: {
         defaultValue: { summary: 'Subtle' },
       },

--- a/packages/core/src/components/divider/divider.tsx
+++ b/packages/core/src/components/divider/divider.tsx
@@ -9,9 +9,15 @@ export class Divider {
   /** Orientation of the Divider, horizontal if not specified. */
   @Prop({ reflect: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
 
-  /** Variant of the Divider, subtle if not specified. */
-  @Prop({ reflect: true }) variant: 'discrete' | 'subtle' | 'soft' | 'defined' | 'dark-blue' =
-    'subtle';
+  /** Variant of the Divider, subtle if not specified. `dark-blue` is a deprecated alias for `expressive`. */
+  @Prop({ reflect: true }) variant:
+    | 'discrete'
+    | 'subtle'
+    | 'soft'
+    | 'defined'
+    | 'strong'
+    | 'expressive'
+    | 'dark-blue' = 'subtle';
 
   render() {
     return (
@@ -28,7 +34,9 @@ export class Divider {
             'subtle': this.variant === 'subtle',
             'soft': this.variant === 'soft',
             'defined': this.variant === 'defined',
-            'dark-blue': this.variant === 'dark-blue',
+            'strong': this.variant === 'strong',
+            // `expressive` is the canonical name; `dark-blue` is kept as a deprecated alias.
+            'expressive': this.variant === 'expressive' || this.variant === 'dark-blue',
           }}
         />
       </Host>

--- a/packages/core/src/components/divider/readme.md
+++ b/packages/core/src/components/divider/readme.md
@@ -10,7 +10,7 @@
 | Property      | Attribute     | Description                                              | Type                                                           | Default        |
 | ------------- | ------------- | -------------------------------------------------------- | -------------------------------------------------------------- | -------------- |
 | `orientation` | `orientation` | Orientation of the Divider, horizontal if not specified. | `"horizontal" \| "vertical"`                                   | `'horizontal'` |
-| `variant`     | `variant`     | Variant of the Divider, subtle if not specified.         | `"dark-blue" \| "defined" \| "discrete" \| "soft" \| "subtle"` | `'subtle'`     |
+| `variant`     | `variant`     | Variant of the Divider, subtle if not specified. `dark-blue` is a deprecated alias for `expressive`. | `"dark-blue" \| "defined" \| "discrete" \| "expressive" \| "soft" \| "strong" \| "subtle"` | `'subtle'`     |
 
 
 ## Dependencies

--- a/packages/core/src/tegel-lite/components/tl-divider/readme.md
+++ b/packages/core/src/tegel-lite/components/tl-divider/readme.md
@@ -8,7 +8,7 @@ The Divider component creates a visual separator between content sections.
 <div class="tl-divider tl-divider--discrete tl-divider--horizontal"></div>
 ```
 
-**Note:** Both an orientation modifier (horizontal/vertical) and a variant modifier (discrete/expressive) should be applied.
+**Note:** Both an orientation modifier (horizontal/vertical) and a variant modifier (discrete/subtle/soft/defined/strong/expressive) should be applied.
 
 <br />
 
@@ -42,8 +42,12 @@ Apply these classes to the `.tl-divider` element.
 
 | Modifier                  | Description                     |
 | ------------------------- | ------------------------------- |
-| `.tl-divider--discrete`   | Subtle divider using discrete border color (default) |
-| `.tl-divider--expressive` | Prominent divider using strong border color |
+| `.tl-divider--discrete`   | Lightest divider using discrete border color (default) |
+| `.tl-divider--subtle`     | Subtle divider using subtle border color |
+| `.tl-divider--soft`       | Soft divider using soft border color |
+| `.tl-divider--defined`    | Defined divider using defined border color |
+| `.tl-divider--strong`     | Strong divider using strong border color |
+| `.tl-divider--expressive` | Most prominent divider using expressive border color |
 
 ----------------------------------------------
 

--- a/packages/core/src/tegel-lite/components/tl-divider/tl-divider.scss
+++ b/packages/core/src/tegel-lite/components/tl-divider/tl-divider.scss
@@ -6,12 +6,28 @@
 
   background-color: var(--divider-background);
 
-  &--expressive {
+  &--discrete {
+    background-color: var(--divider-background-discrete);
+  }
+
+  &--subtle {
+    background-color: var(--divider-background-subtle);
+  }
+
+  &--soft {
+    background-color: var(--divider-background-soft);
+  }
+
+  &--defined {
+    background-color: var(--divider-background-defined);
+  }
+
+  &--strong {
     background-color: var(--divider-background-strong);
   }
 
-  &--discrete {
-    background-color: var(--divider-background-discrete);
+  &--expressive {
+    background-color: var(--divider-background-expressive);
   }
 
   &--horizontal {

--- a/packages/core/src/tegel-lite/components/tl-divider/tl-divider.stories.tsx
+++ b/packages/core/src/tegel-lite/components/tl-divider/tl-divider.stories.tsx
@@ -12,7 +12,7 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Discrete', 'Expressive'],
+      options: ['Discrete', 'Subtle', 'Soft', 'Defined', 'Strong', 'Expressive'],
       table: {
         defaultValue: { summary: 'Discrete' },
       },
@@ -55,7 +55,7 @@ export default {
 
 const Template = ({ orientation, variant, width, height }) => {
   const orientationClass = orientation === 'Horizontal' ? 'horizontal' : 'vertical';
-  const variantClass = variant === 'Expressive' ? 'expressive' : 'discrete';
+  const variantClass = variant.toLowerCase();
   const style = orientation === 'Horizontal' ? `width: ${width}px;` : `height: ${height}px;`;
 
   return formatHtmlPreview(`


### PR DESCRIPTION
Aligns both tds-divider and tl-divider with the Figma variant set: Discrete, Subtle, Soft, Defined, Strong, Expressive (shown in Storybook and used in code). 'Dark-Blue' is renamed to 'Expressive'; the old `dark-blue` prop value is kept as a silent deprecated alias so existing usage doesn't break. tl-divider gains the four missing variants (subtle, soft, defined, strong) to match the regular component, and its `expressive` now correctly uses the expressive token.