### PR TITLE
Feat(table-body-cell): add `verticalAlign` prop

### DIFF
--- a/packages/core/src/components/table/table-body-cell/readme.md
+++ b/packages/core/src/components/table/table-body-cell/readme.md
@@ -7,14 +7,15 @@
 
 ## Properties
 
-| Property         | Attribute         | Description                                                                                                          | Type                                                             | Default     |
-| ---------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ----------- |
-| `cellKey`        | `cell-key`        | Passing the same cell key for all body cells which is used in head cell enables features of text align and hovering  | `string \| undefined`                                            | `undefined` |
-| `cellValue`      | `cell-value`      | Value that will be presented as text inside a cell                                                                   | `number \| string \| undefined`                                  | `undefined` |
-| `colSpan`        | `col-span`        | Number of columns the cell should span.                                                                              | `number \| undefined`                                            | `undefined` |
-| `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                             | `boolean`                                                        | `false`     |
-| `rowSpan`        | `row-span`        | Number of rows the cell should span.                                                                                 | `number \| undefined`                                            | `undefined` |
-| `textAlign`      | `text-align`      | Setting for text align, default value "left". Other accepted values are "left", "start", "right", "end" or "center". | `"center" \| "end" \| "left" \| "right" \| "start" \| undefined` | `undefined` |
+| Property         | Attribute         | Description                                                                                                                  | Type                                                             | Default     |
+| ---------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ----------- |
+| `cellKey`        | `cell-key`        | Passing the same cell key for all body cells which is used in head cell enables features of text align and hovering          | `string \| undefined`                                            | `undefined` |
+| `cellValue`      | `cell-value`      | Value that will be presented as text inside a cell                                                                           | `number \| string \| undefined`                                  | `undefined` |
+| `colSpan`        | `col-span`        | Number of columns the cell should span.                                                                                      | `number \| undefined`                                            | `undefined` |
+| `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                                     | `boolean`                                                        | `false`     |
+| `rowSpan`        | `row-span`        | Number of rows the cell should span.                                                                                         | `number \| undefined`                                            | `undefined` |
+| `textAlign`      | `text-align`      | Setting for text align, default value "left". Other accepted values are "left", "start", "right", "end" or "center".         | `"center" \| "end" \| "left" \| "right" \| "start" \| undefined` | `undefined` |
+| `verticalAlign`  | `vertical-align`  | Setting for vertical alignment in the text of the cells, default value "top". Accepted values are "top", "bottom", "middle". | `"bottom" \| "middle" \| "top" \| undefined`                     | `undefined` |
 
 
 ## Slots

--- a/packages/core/src/components/table/table-body-cell/table-body-cell.scss
+++ b/packages/core/src/components/table/table-body-cell/table-body-cell.scss
@@ -13,7 +13,6 @@
   color: var(--tds-table-color);
   padding: var(--tds-spacing-element-16);
   min-width: 192px;
-  vertical-align: top;
   background-color: var(--row-bg);
   transition: background-color 200ms ease;
 }

--- a/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
+++ b/packages/core/src/components/table/table-body-cell/table-body-cell.tsx
@@ -6,6 +6,9 @@ const relevantTableProps: InternalTdsTablePropChange['changed'] = [
   'compactDesign',
   'noMinWidth',
 ];
+
+export type VerticalAlign = 'top' | 'bottom' | 'middle';
+
 /**
  * @slot <default> - <b>Unnamed slot.</b> For the cell contents.
  */
@@ -27,6 +30,9 @@ export class TdsTableBodyCell {
   /** Setting for text align, default value "left". Other accepted values are "left", "start", "right", "end" or "center". */
   @Prop({ reflect: true }) textAlign?: TextAlign;
 
+  /** Setting for vertical alignment in the text of the cells, default value "top". Accepted values are "top", "bottom", "middle". */
+  @Prop({ reflect: true }) verticalAlign?: VerticalAlign;
+
   /** Number of columns the cell should span. */
   @Prop({ reflect: true }) colSpan?: number;
 
@@ -34,6 +40,8 @@ export class TdsTableBodyCell {
   @Prop({ reflect: true }) rowSpan?: number;
 
   @State() textAlignState: TextAlign | undefined = undefined;
+
+  @State() verticalAlignState: VerticalAlign | undefined = undefined;
 
   @State() activeSorting: boolean = false;
 
@@ -108,6 +116,10 @@ export class TdsTableBodyCell {
     if (this.textAlign) {
       this.textAlignState = this.textAlign;
     }
+
+    if (this.verticalAlign) {
+      this.verticalAlignState = this.verticalAlign;
+    }
   }
 
   render() {
@@ -121,6 +133,7 @@ export class TdsTableBodyCell {
 
     const dynamicStyles = {
       textAlign: this.textAlignState,
+      verticalAlign: this.verticalAlignState ?? 'top',
       // Conditionally set padding style
       padding: paddingStyle,
     };

--- a/packages/core/src/components/table/table-component-basic.stories.tsx
+++ b/packages/core/src/components/table/table-component-basic.stories.tsx
@@ -48,6 +48,18 @@ export default {
         defaultValue: { summary: 'left' },
       },
     },
+    cellVerticalAlignment: {
+      name: 'Text vertical alignment in cells',
+      description:
+        'Vertical content alignment inside body cells.<br/>This control change in the docs/demo from Storybook does not show a difference given the height of each cell is already being used in full. This is for cases where the height may be bigger.',
+      control: {
+        type: 'radio',
+      },
+      options: ['top', 'bottom', 'middle'],
+      table: {
+        defaultValue: { summary: 'top' },
+      },
+    },
     compactDesign: {
       name: 'Compact design',
       description: 'Enables compact design of the Table, rows with less height.',
@@ -173,6 +185,7 @@ export default {
     modeVariant: 'Inherit from parent',
     headerTextAlignment: 'left',
     cellTextAlignment: 'left',
+    cellVerticalAlignment: 'top',
     compactDesign: false,
     responsiveDesign: false,
     disablePadding: false,
@@ -192,6 +205,7 @@ const BasicTemplate = ({
   modeVariant,
   headerTextAlignment,
   cellTextAlignment,
+  cellVerticalAlignment,
   compactDesign,
   responsiveDesign,
   disablePadding,
@@ -216,43 +230,45 @@ const BasicTemplate = ({
     >
       <tds-table-header >
           <tds-header-cell cell-key='truck' cell-value='Truck type' disable-padding="${disableHeaderPadding}" ${
-    column1Width ? `custom-width="${column1Width}"` : ''
-  } text-align="${headerTextAlignment}"></tds-header-cell>
+            column1Width ? `custom-width="${column1Width}"` : ''
+          } text-align="${headerTextAlignment}"></tds-header-cell>
           <tds-header-cell cell-key='driver' cell-value='Driver name' disable-padding="${disableHeaderPadding}" ${
-    column2Width ? `custom-width="${column2Width}"` : ''
-  } text-align="${headerTextAlignment}"></tds-header-cell>
+            column2Width ? `custom-width="${column2Width}"` : ''
+          } text-align="${headerTextAlignment}"></tds-header-cell>
           <tds-header-cell cell-key='country' cell-value='Country' disable-padding="${disableHeaderPadding}" ${
-    column3Width ? `custom-width="${column3Width}"` : ''
-  } text-align="${headerTextAlignment}"></tds-header-cell>
+            column3Width ? `custom-width="${column3Width}"` : ''
+          } text-align="${headerTextAlignment}"></tds-header-cell>
           <tds-header-cell cell-key='mileage' cell-value='Mileage' disable-padding="${disableHeaderPadding}" ${
-    column4Width ? `custom-width="${column4Width}"` : ''
-  } text-align="${headerTextAlignment}"></tds-header-cell>
+            column4Width ? `custom-width="${column4Width}"` : ''
+          } text-align="${headerTextAlignment}"></tds-header-cell>
       </tds-table-header>
       <tds-table-body>
           ${[...Array(6)]
             .map(
               (_, index) => `
             <tds-table-body-row ${clickable ? 'clickable' : ''}>
-              <tds-body-cell cell-value="Test value ${
+              <tds-body-cell cell-value="Bigger text in this cell so that vertical alignment control effect in the docs can be noticeable, Test value ${
                 index % 2 === 0 ? '1' : '5'
               }" cell-key="truck" disable-padding="${disablePadding}" ${
                 cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }></tds-body-cell>
+              } ${cellVerticalAlignment ? `vertical-align="${cellVerticalAlignment}"` : ''}>
+                
+              </tds-body-cell>
               <tds-body-cell cell-value="Test value ${
                 index % 2 === 0 ? '2' : '6'
               }" cell-key="driver" disable-padding="${disablePadding}" ${
                 cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }></tds-body-cell>
+              } ${cellVerticalAlignment ? `vertical-align="${cellVerticalAlignment}"` : ''}></tds-body-cell>
               <tds-body-cell cell-value="Test value ${
                 index % 2 === 0 ? '3' : '7'
               }" cell-key="country" disable-padding="${disablePadding}" ${
                 cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }></tds-body-cell>
+              } ${cellVerticalAlignment ? `vertical-align="${cellVerticalAlignment}"` : ''}></tds-body-cell>
               <tds-body-cell cell-value="Test value ${
                 index % 2 === 0 ? '4' : '8'
               }" cell-key="mileage" disable-padding="${disablePadding}" ${
                 cellTextAlignment ? `text-align="${cellTextAlignment}"` : ''
-              }></tds-body-cell>
+              } ${cellVerticalAlignment ? `vertical-align="${cellVerticalAlignment}"` : ''}></tds-body-cell>
             </tds-table-body-row>
           `,
             )

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -24,7 +24,7 @@
 
 | Event     | Description                                                                                                                                              | Type                                                                                                                |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to implement custom-sorting logic. | `CustomEvent<{ tableId: string \| undefined; columnKey: string \| undefined; sortingDirection: "desc" \| "asc"; }>` |
+| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to implement custom-sorting logic. | `CustomEvent<{ tableId: string \| undefined; columnKey: string \| undefined; sortingDirection: "asc" \| "desc"; }>` |
 
 
 ## Slots


### PR DESCRIPTION
## **Describe pull-request**  
This PR comes from a Feature Request done in Development Support channel in Teams, where the user reported they wanted to be able to control the alignment of the text in the body cells. ([Link to the report message](https://teams.microsoft.com/l/message/19:5e33f67fe502441f914fbcdc6e2548f5@thread.skype/1777971568275?tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac&groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&parentMessageId=1777971568275&teamName=Tegel%20Design%20System&channelName=Development%20support%20-%20Tegel&createdTime=1777971568275)).
Before, the default vertical-align style was `top`. We kept that same behavior in case the user does not explicitly populate this new Prop, since we don't want to introduce any visual changes. 

We have added a new Prop as well as a new State, similar to the `textAlign` behavior, and injected the value of it in the `dynamicStyles` being applied to the `<td>`.

In order to be noticeable in Storybook that the control is actually doing something, we also added a larger text in some body cells for the Basic Table Story, so that in the Docs tab/ in a narrower window the change between `top`, `bottom`, `middle` is visually clear.  
Since if all the body cells in a row have the same height, the text will occupy it all and so there wouldn't exist any visual differences. 

## **Issue Linking:** 
- **Loop:** [PI2617-6](https://scaniaazureservices.sharepoint.com/:fl:/r/contentstorage/CSP_5bac0fd3-2580-4d6c-9ac0-3a3058f9e4ce/Document%20Library/LoopAppData/PI2617%20Backlog.loop?d=waeb21d3f32db499b82faf27e88227ec6&csf=1&web=1&e=0anOdh&nav=cz0lMkZjb250ZW50c3RvcmFnZSUyRkNTUF81YmFjMGZkMy0yNTgwLTRkNmMtOWFjMC0zYTMwNThmOWU0Y2UmZD1iJTIxMHctc1c0QWxiRTJhd0Rvd1dQbmt6bm5SbkE1Q2kwcEdpT0M1TUdTdHI1Z1JvOHl5TFJtV1JLQWVicjlNMXRSRCZmPTAxTzJURlZCWjdEV1pLNVdaU1RORVlGNlhTUDJFQ0U3V0cmYz0lMkYlM0ZtaW5pZmllZCUzRGQ1MWRjMWQwLTFkNTMtNDU2MS05ODhjLThlMGEzMGM3ZWM4YSUyNnNlcSUzRDI3MDE0JmE9TG9vcEFwcCZwPSU0MGZsdWlkeCUyRmxvb3AtcGFnZS1jb250YWluZXI%3D)

## **How to test**  
1. Go to [Storybook Basic Table](https://pr-1958.d3fazya28914g3.amplifyapp.com/?path=/story/components-table-basic--default);
2. Narrow the window/Go into the Docs tab;
3. Change the control Vertical Alignment to top/bottom/middle
4. Verify that the text in each cell moves accordingly.

## **Checklist before submission**
- [ ] Designer approves new design (if applicable)
- [ ] No accessibility violations in Storybook
- [ ] I have added unit tests for my changes (if applicable)
- [ ] All existing tests pass
- [ ] I have updated the documentation (if applicable)
- [ ] Not breaking production behavior
- [ ] Behavior available in Storybook with documented descriptions (if applicable)
- [ ] `npm run build:all` without errors

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Screenshots**  
### Before
(screenshot reported by user - defaults to top vertical alignment): 
<img width="908" height="230" alt="image" src="https://github.com/user-attachments/assets/2fb825bf-689e-4974-97fd-57be58fb0acd" />

### After
(our Storybook, with `vertical-align=middle`)
<img width="964" height="231" alt="image" src="https://github.com/user-attachments/assets/de669888-0515-4c67-bac0-ed2531bf66ea" />



## **Additional context**  
_Add any other context or feedback requests about the pull-request here._
