### PR TITLE
chore(workflows): update node version to 22.22.1

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -11,7 +11,7 @@ on:
       nodeVersion:
         description: 'Node version'
         required: true
-        default: '22.13.0'
+        default: '22.22.1'
         type: string
 
       betaVersionSuffix:

--- a/.github/workflows/holy-grail.yml
+++ b/.github/workflows/holy-grail.yml
@@ -22,7 +22,7 @@ on:
       nodeVersion:
         description: 'Node version'
         required: true
-        default: '22.20.0'
+        default: '22.22.1'
         type: string
 
       tags:
@@ -46,7 +46,7 @@ on:
 
 env:
   VERSION: patch
-  NODE_VERSION: '22.20.0'
+  NODE_VERSION: '22.22.1'
   TAG: latest
 
 jobs:

--- a/.github/workflows/tegel-lite-release.yml
+++ b/.github/workflows/tegel-lite-release.yml
@@ -11,7 +11,7 @@ on:
       nodeVersion:
         description: 'Node version'
         required: true
-        default: '22.20.0'
+        default: '22.22.1'
         type: string
 
       version:


### PR DESCRIPTION
## **Describe pull-request**  
This PR updates the node version in the following workflows: "holy-grail", "beta-release", "tegel-lite-release". This update is required due to the lint-staged version update to 17.0.8: [PR-1978](https://github.com/scania-digital-design-system/tegel/pull/1978)


## **Issue Linking:**  
- **No issue:** 