### PR TITLE
fix(header): add fallback variables when no brand class is specified

### DIFF
--- a/packages/core/src/components/header/header-vars.scss
+++ b/packages/core/src/components/header/header-vars.scss
@@ -53,6 +53,12 @@ tds-header {
   --tds-header-app-launcher-grid-hover-background: var(
     --component-header-background-menu-item-tile-hover
   );
+
+  /* Header Symbol */
+  --tds-header-logotype-local: var(--tds-background-image-scania-symbol-svg-local);
+  --tds-header-logotype-cdn: var(--tds-background-image-scania-symbol-svg);
+  --tds-header-brand-logo-size: 32px;
+  --tds-header-brand-item-width: unset;
 }
 
 .scania {

--- a/packages/core/src/tegel-lite/components/tl-header/_tl-header-vars.scss
+++ b/packages/core/src/tegel-lite/components/tl-header/_tl-header-vars.scss
@@ -27,6 +27,10 @@
   --header-item-user-id-padding: calc(var(--component-header-size-avatar-padding) * 1px);
   --header-item-user-id-image-size: calc(var(--component-header-size-avatar-default) * 1px);
 
+  .tl-header__title {
+    --header-title-font-weight: 400;
+  }
+
   /* Expandable header items */
   --header-item-background-opened: var(--component-header-background-nav-item-current-default);
   --header-item-background-opened-hover: var(--component-header-background-menu-item-link-hover);
@@ -62,6 +66,14 @@
   /* user id submenu items */
   --header-sub-menu-item-title-color: var(--component-header-text-title-default);
   --header-sub-menu-item-subtitle-color: var(--component-header-text-subtitle-default);
+
+  // Fallback to Scania logotype (white wordmark — header background is always dark blue)
+  .tl-header__brand {
+    --header-logotype-local: var(--tds-background-image-scania-symbol-svg-local);
+    --header-logotype-cdn: var(--tds-background-image-scania-symbol-svg);
+    --header-brand-logo-size: 32px;
+    --header-brand-item-width: 30px;
+  }
 }
 
 .scania {


### PR DESCRIPTION
## **Describe pull-request**  
This PR is a quick fix to add the missing fallback variables for the header component (header-vars.scss and tl-header-vars.scss), when no class is specified. 
If no class is specified, then the fallback brand should be Scania. 

Before this fix there were issues happening like the header symbol (Scania logo) not appearing if the developer didn't specify a brand class. Now this shouldn't happen anymore. 

## **Issue Linking:**  
- **No issue:** Just a quick fix for the issue mentioned above.   

## **How to test**  
### TEGEL & TEGEL LITE:
1. Go to Storybook Header Default page ([Tegel](https://pr-2012.d3fazya28914g3.amplifyapp.com/?path=/story/components-header--default)) ([Tegel Lite](https://pr-2012.d3fazya28914g3.amplifyapp.com/?path=/story/tegel-lite-header--default))
2. Inspect the page 
3. In the injected html tag inside the <iframe>, remove the class="scania"
4. Verify that the Scania logo doesn't disappear