### PR TITLE
Fix: change Prop handling from connectedCallback to componentWillLoad 

### DIFF
--- a/packages/core/src/components/banner/banner.tsx
+++ b/packages/core/src/components/banner/banner.tsx
@@ -66,11 +66,13 @@ export class TdsBanner {
     this.hidden = false;
   }
 
-  connectedCallback() {
-    if (this.variant === 'error') {
-      this.icon = 'error';
-    } else if (this.variant === 'information') {
-      this.icon = 'info';
+  componentWillLoad() {
+    if (this.icon === undefined) {
+      if (this.variant === 'error') {
+        this.icon = 'error';
+      } else if (this.variant === 'information') {
+        this.icon = 'info';
+      }
     }
   }
 

--- a/packages/core/src/components/footer/footer-group/footer-group.tsx
+++ b/packages/core/src/components/footer/footer-group/footer-group.tsx
@@ -43,7 +43,9 @@ export class TdsFooterGroup {
     if (!this.topPartGroup) {
       this.slotPosition = this.host.parentElement?.slot === 'end' ? 'end' : 'start';
     }
+  }
 
+  componentWillLoad() {
     if (!this.tdsListAriaLabel) {
       console.warn('Tegel Footer Group component: missing tdsListAriaLabel prop');
     }

--- a/packages/core/src/components/link/link.tsx
+++ b/packages/core/src/components/link/link.tsx
@@ -20,7 +20,7 @@ export class TdsLink {
   /** Displays the Link as a standalone component. Not part of a paragraph. */
   @Prop({ reflect: true }) standalone: boolean = false;
 
-  connectedCallback() {
+  componentWillLoad() {
     const links = this.host.querySelectorAll('a');
     if (links.length > 1) {
       console.warn('tds-link is only intended to wrap one <a> tag');

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -114,7 +114,7 @@ export class TdsModal {
     }
   }
 
-  private initializeWithProps() {
+  componentWillLoad() {
     if (this.closable === undefined) {
       this.closable = true;
     }
@@ -135,14 +135,6 @@ export class TdsModal {
         'Tegel Modal: Missing focus origin. Please provide either a "referenceEl" or a "selector" to ensure focus returns to the element that opened the modal. If the modal is opened programmatically, this message can be ignored.',
       );
     }
-  }
-
-  connectedCallback() {
-    this.initializeWithProps();
-  }
-
-  componentWillLoad() {
-    this.initializeWithProps();
   }
 
   disconnectedCallback() {

--- a/packages/core/src/components/popover-core/popover-core.tsx
+++ b/packages/core/src/components/popover-core/popover-core.tsx
@@ -160,6 +160,15 @@ export class TdsPopoverCore {
     }
   }
 
+  @Watch('selector')
+  onSelectorChanged(newValue: string, oldValue: string) {
+    if (newValue === oldValue) return;
+    if (newValue) {
+      this.disableLogic = false;
+      this.initialize({ referenceEl: this.referenceEl, trigger: this.trigger });
+    }
+  }
+
   private focusFirstElement() {
     // Try to find a focusable element inside the popover
     const focusableElements = this.host.querySelectorAll(
@@ -289,7 +298,8 @@ export class TdsPopoverCore {
     this.popperInstance?.destroy();
   }
 
-  connectedCallback() {
+  /* To enable initial loading of a component if user controls show prop */
+  componentWillLoad() {
     if (this.selector === undefined && this.referenceEl === undefined) {
       this.disableLogic = true;
       console.warn(
@@ -302,10 +312,7 @@ export class TdsPopoverCore {
       referenceEl: this.referenceEl,
       trigger: this.trigger,
     });
-  }
 
-  /* To enable initial loading of a component if user controls show prop */
-  componentWillLoad() {
     // Ensure initial visibility is handled properly
     if (this.show === true || this.defaultShow === true) {
       this.setIsShown(true);

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -527,6 +527,10 @@ export class TdsSlider {
   };
 
   componentWillLoad() {
+    if (this.readOnly && !this.tdsReadOnlyAriaLabel) {
+      console.warn('tds-slider: tdsReadOnlyAriaLabel is recommended when readonly is true');
+    }
+
     const numTicks = parseInt(this.ticks);
 
     if (numTicks > 0) {
@@ -610,10 +614,6 @@ export class TdsSlider {
   }
 
   connectedCallback() {
-    if (this.readOnly && !this.tdsReadOnlyAriaLabel) {
-      console.warn('tds-slider: tdsAriaLabel is reccomended when readonly is true');
-    }
-
     if (this.resetEventListenerAdded && this.formElement) {
       this.formElement.removeEventListener('reset', this.resetToInitialValue);
       this.resetEventListenerAdded = false;

--- a/packages/core/src/components/table/table-footer/table-footer.tsx
+++ b/packages/core/src/components/table/table-footer/table-footer.tsx
@@ -48,7 +48,7 @@ export class TdsTableFooter {
   @Prop() rowsPerPageValues: number[] = [10, 25, 50];
 
   /** Set rows per page dropdown open direction */
-  @Prop() rowsPerPageDropdownOpenDirection: 'up' | 'down' | 'auto' = 'auto';
+  @Prop({ reflect: true }) rowsPerPageDropdownOpenDirection: 'up' | 'down' | 'auto' = 'auto';
 
   /** Set rows per page dropdown aria label. */
   @Prop({ reflect: true }) rowsPerPageDropdownAriaLabel: string = 'Select rows per page';
@@ -60,7 +60,7 @@ export class TdsTableFooter {
   @Prop({ reflect: true }) cols: number | null = null;
 
   /** Sets the number of rows that should appear per page. <br/> If pagination is enabled, this value must be defined and controlled by the consumer of Tegel. <br/> Otherwise, it will default to the first element of the "rowsPerPageValues". */
-  @Prop({ mutable: true }) rowsPerPageValue?: number;
+  @Prop({ reflect: true, mutable: true }) rowsPerPageValue?: number;
 
   /** State that memorize number of columns to display colSpan correctly - set from parent level */
   @State() columnsNumber: number = 0;

--- a/packages/core/src/components/table/table-toolbar/table-toolbar.tsx
+++ b/packages/core/src/components/table/table-toolbar/table-toolbar.tsx
@@ -83,16 +83,17 @@ export class TdsTableToolbar {
   connectedCallback() {
     this.tableEl = this.host.closest('tds-table');
     this.tableId = this.tableEl?.tableId;
-
-    if (!this.tdsSearchAriaLabel) {
-      console.warn('tds-table-toolbar: tdsSearchAriaLabel is highly recommended for accessibility');
-    }
   }
 
   componentWillLoad() {
     relevantTableProps.forEach((tablePropName) => {
       this[tablePropName] = this.tableEl?.[tablePropName];
     });
+
+    // Only a rendered search input needs an accessible name; render() gates it on `filter`.
+    if (this.filter && !this.tdsSearchAriaLabel) {
+      console.warn('tds-table-toolbar: tdsSearchAriaLabel is highly recommended for accessibility');
+    }
   }
 
   handleSearch(event) {

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -98,7 +98,7 @@ export class TdsToast {
     }
   };
 
-  connectedCallback() {
+  componentWillLoad() {
     if (!this.tdsCloseAriaLabel) {
       console.warn('tds-toast: tdsCloseAriaLabel is required');
     }


### PR DESCRIPTION
## **Describe pull-request**  
This PR addresses the issues identified in #1992.  The stencil  Props were being handled in the connectedCallback function, before being initialised,  which resulted in a few problems:
 | Component | Problem | Severity |
|---|---|---|
| `tds-popover-core` | `Popover internal logic disabled…` | **functional — never opens** |
| `tds-toast` | False warning: `tdsCloseAriaLabel is required` | false warning only |
| `tds-table-toolbar` | False warning: `tdsSearchAriaLabel is highly recommended for accessibility` | false warning only |
| `tds-modal` | False warning: `Missing focus origin…` | false warning only |
| `tds-slider` | False warning: `tdsAriaLabel is reccomended when readonly is true` | false warning only |
| `tds-footer-group` | False warning: `missing tdsListAriaLabel prop` | false warning only |
| `tds-link` | No `aria-disabled` or `tabindex="-1"` attributes assigned | Accessibility issues |
| `tds-banner` | for variant `error` and `information`, no icon showed when icon is not defined by the user | Visual misalignments |

The solution for these issues, as suggested by our user @scanianick, was to move every prop handling/interaction from the function `connectedCallback` to the `componentWillLoad`, where the Props are already populated. 

----- 

> [!IMPORTANT]
> Another issue found while resolving this bug was two missing `{ reflect: true }` in the most recent `tds-table-footer` Props. This requirement of the `{ reflect: true }` is explained in #1800.

## **Issue Linking:**  
- **GitHub:** #1992   

## **How to test**
0. Check that there are many warnings currently in the [React demo page](https://react-demo.tegel.scania.com/about)
1. Checkout this branch
2. Build, pack and generate a tarball
3. Build the react package with this new tarball version
4. Pack the react package
5. Use the resulting tarball to test in the React demo page locally
6. When in the React demo page with this version, inspect the page in the several components and check that there are none of the above mentioned warnings