### PR TITLE
chore: remove angular packages from dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,13 +34,3 @@ updates:
       include: 'scope'
     labels:
       - 'dependencies'
-    ignore:
-      - dependency-name: '@angular/*'
-        update-types:
-          - 'version-update:semver-major'
-      - dependency-name: '@angular-devkit/*'
-        update-types:
-          - 'version-update:semver-major'
-      - dependency-name: 'ng-packagr'
-        update-types:
-          - 'version-update:semver-major'


### PR DESCRIPTION
## **Describe pull-request**  

This PR removes all Angular related dependencies from dependabot `ignore` list, to ensure that PRs with version upgrades for these dependencies are also created, like all the others.

## **Additional context**  

Now that the Angular package versions are already up-to-date, there is no need to have dependabot ignore them.
