### PR TITLE
fix(tds-table-header): sync (deprecated) `allSelected` with `selected` Prop

### DIFF
--- a/packages/core/src/components/table/table-header/table-header.tsx
+++ b/packages/core/src/components/table/table-header/table-header.tsx
@@ -8,6 +8,7 @@ import {
   Listen,
   Element,
   Prop,
+  Watch,
 } from '@stencil/core';
 
 import { InternalTdsTablePropChange } from '../table/table';
@@ -129,6 +130,7 @@ export class TdsTableHeaderRow {
     relevantTableProps.forEach((tablePropName) => {
       this[tablePropName] = this.tableEl?.[tablePropName];
     });
+    this.onSelectedChange(this.selected);
   }
 
   componentWillRender() {
@@ -139,8 +141,14 @@ export class TdsTableHeaderRow {
     }
   }
 
+  @Watch('selected')
+  onSelectedChange(newValue?: boolean) {
+    if (newValue === undefined) return;
+    this.allSelected = newValue;
+  }
+
   async handleCheckboxChange(event) {
-    this.allSelected = event.detail.checked;
+    this.selected = event.detail.checked;
     this.tdsSelectAll.emit({
       tableId: this.tableId,
       checked: event.detail.checked,


### PR DESCRIPTION
## **Describe pull-request**  
This PR takes into account that `selected` is now the correct Prop to control the state of the checkbox, however still has under consideration the usage of `allSelected` (which is deprecated and will be removed soon). 
It now watches the `selected` Prop to update the value of the `allSelected`, in case any users are still using the `allSelected`.
Upon a checkbox click, the value changed is the `selected`, and not the `allSelected` anymore. 

This should fix a bug related to changing the `selected` value programmatically, and this being reflected visually.


> [!Note]
> This PR however does not fix any remaining buggy behaviour related to the `allSelected` Prop. If there were any bugs related to it, they will not be fixed by this. The user should use `selected` instead.

## **Issue Linking:**  
- **No issue;** Bug reported in Teams Support channel.

## **How to test**
1. Go to the [Angular Demo page with this beta release](https://pr-138.d24qjtb7na4hmr.amplifyapp.com/table)
2. Go to the Batch Actions table
3. Test and verify the behaviour by clicking the checkbox and using the "Set true" and "Set false" buttons