### PR TITLE
chore(playwright): mount anonymous volume for fresh dependencies

### DIFF
--- a/packages/core/docker-test-runner.js
+++ b/packages/core/docker-test-runner.js
@@ -26,12 +26,14 @@ const args = [
   'host',
   '-v',
   `${pwd}:/work/`,
+  '-v',
+  '/work/node_modules/',
   '-w',
   '/work/',
   'mcr.microsoft.com/playwright:v1.60.0-jammy',
   '/bin/bash',
   '-c',
-  'npx playwright test && exit',
+  'npm ci && npx playwright test && exit',
 ];
 
 // Check if Docker is running


### PR DESCRIPTION
## **Describe pull-request**  

This PR solves issues that were experienced when running Playwright tests locally, using a Docker container.
The dependencies installed in our computers referenced a rollup that pointed to our machines' system architecture (MacOS), while the container needed a dependency that would point to its architecture (Linux).
Since the script used to run the docker container mounted a volume that pointed directly to our locally installed dependencies, it complained about the rollup package for its needed architecture not being installed.

The fix was to mount an anonymous volume for the dependencies installation folder (`node_modules`), so that the local one is not used. Then, before running Playwright, `npm ci` script is executed, which installs a fresh set of dependencies inside the container.

## **How to test**  

Pull this branch to your computer and check that the `npm run test` script is working again, and that all tests are passing, as expected. Executing the script should now not change the `node_modules` directory inside `packages/core`, as it uses its own set of dependencies.
