### PR TITLE
fix: add missing types to `EventEmitters`

### DIFF
--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -85,14 +85,14 @@ export class TdsDatetime {
   /** Listen to the focus state of the input */
   @State() focusInput: boolean = false;
 
-  /** Change event for the Datetime */
+  /** Change event for the Datetime, emits Event on change and object { name, value } on reset */
   @Event({
     eventName: 'tdsChange',
     composed: true,
     bubbles: true,
     cancelable: false,
   })
-  tdsChange!: EventEmitter;
+  tdsChange!: EventEmitter<Event | { name: string; value: string }>;
 
   /** Blur event for the Datetime */
   @Event({

--- a/packages/core/src/components/datetime/readme.md
+++ b/packages/core/src/components/datetime/readme.md
@@ -41,12 +41,12 @@ These issues stem from the use of the native HTML <code style="font-size: inheri
 
 ## Events
 
-| Event       | Description                   | Type                      |
-| ----------- | ----------------------------- | ------------------------- |
-| `tdsBlur`   | Blur event for the Datetime   | `CustomEvent<FocusEvent>` |
-| `tdsChange` | Change event for the Datetime | `CustomEvent<any>`        |
-| `tdsFocus`  | Focus event for the Datetime  | `CustomEvent<FocusEvent>` |
-| `tdsInput`  | Input event for the Datetime  | `CustomEvent<InputEvent>` |
+| Event       | Description                                                                              | Type                                                     |
+| ----------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `tdsBlur`   | Blur event for the Datetime                                                              | `CustomEvent<FocusEvent>`                                |
+| `tdsChange` | Change event for the Datetime, emits Event on change and object { name, value } on reset | `CustomEvent<Event \| { name: string; value: string; }>` |
+| `tdsFocus`  | Focus event for the Datetime                                                             | `CustomEvent<FocusEvent>`                                |
+| `tdsInput`  | Input event for the Datetime                                                             | `CustomEvent<InputEvent>`                                |
 
 
 ## Methods

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -92,7 +92,7 @@ export class TdsModal {
     cancelable: true,
     bubbles: true,
   })
-  tdsClose!: EventEmitter<object>;
+  tdsClose!: EventEmitter<Event>;
 
   /** Emits just before Modal is opened. */
   @Event({

--- a/packages/core/src/components/modal/readme.md
+++ b/packages/core/src/components/modal/readme.md
@@ -135,10 +135,10 @@ This pattern avoids rendering hidden content upfront, improves performance and g
 
 ## Events
 
-| Event      | Description                        | Type                  |
-| ---------- | ---------------------------------- | --------------------- |
-| `tdsClose` | Emits when the Modal is closed.    | `CustomEvent<object>` |
-| `tdsOpen`  | Emits just before Modal is opened. | `CustomEvent<void>`   |
+| Event      | Description                        | Type                 |
+| ---------- | ---------------------------------- | -------------------- |
+| `tdsClose` | Emits when the Modal is closed.    | `CustomEvent<Event>` |
+| `tdsOpen`  | Emits just before Modal is opened. | `CustomEvent<void>`  |
 
 
 ## Methods

--- a/packages/core/src/components/popover-core/popover-core.tsx
+++ b/packages/core/src/components/popover-core/popover-core.tsx
@@ -92,7 +92,7 @@ export class TdsPopoverCore {
     cancelable: false,
     bubbles: true,
   })
-  internalTdsShow!: EventEmitter<object>;
+  internalTdsShow!: EventEmitter<void>;
 
   /** @internal Close event. */
   @Event({
@@ -101,7 +101,7 @@ export class TdsPopoverCore {
     cancelable: false,
     bubbles: false,
   })
-  internalTdsClose!: EventEmitter<object>;
+  internalTdsClose!: EventEmitter<void>;
 
   @Listen('click', { target: 'window' })
   onAnyClick(event: MouseEvent) {

--- a/packages/core/src/components/table/table-header-cell/readme.md
+++ b/packages/core/src/components/table/table-header-cell/readme.md
@@ -24,7 +24,7 @@
 
 | Event     | Description                                                                                                                                              | Type                                                                                                                |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to implement custom-sorting logic. | `CustomEvent<{ tableId: string \| undefined; columnKey: string \| undefined; sortingDirection: "desc" \| "asc"; }>` |
+| `tdsSort` | Sends unique Table identifier, column key and sorting direction to the tds-table-body component, can also be listened to implement custom-sorting logic. | `CustomEvent<{ tableId: string \| undefined; columnKey: string \| undefined; sortingDirection: "asc" \| "desc"; }>` |
 
 
 ## Slots

--- a/packages/core/src/components/text-field/readme.md
+++ b/packages/core/src/components/text-field/readme.md
@@ -40,7 +40,7 @@
 | Event       | Description                                                               | Type                                                                                    |
 | ----------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
 | `tdsBlur`   | Blur event for the Text Field                                             | `CustomEvent<FocusEvent>`                                                               |
-| `tdsChange` | Change event for the Text Field                                           | `CustomEvent<any>`                                                                      |
+| `tdsChange` | Change event for the Text Field                                           | `CustomEvent<Event>`                                                                    |
 | `tdsError`  | Error event for the Text Field - emitted when value is clamped to min/max | `CustomEvent<{ originalValue: string; clampedValue: string; reason: "min" \| "max"; }>` |
 | `tdsFocus`  | Focus event for the Text Field                                            | `CustomEvent<FocusEvent>`                                                               |
 | `tdsInput`  | Input event for the Text Field                                            | `CustomEvent<InputEvent>`                                                               |

--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -103,7 +103,7 @@ export class TdsTextField {
     bubbles: true,
     cancelable: false,
   })
-  tdsChange!: EventEmitter;
+  tdsChange!: EventEmitter<Event>;
 
   handleChange(event: Event): void {
     this.tdsChange.emit(event);

--- a/packages/core/src/components/textarea/readme.md
+++ b/packages/core/src/components/textarea/readme.md
@@ -34,7 +34,7 @@
 | Event       | Description                   | Type                      |
 | ----------- | ----------------------------- | ------------------------- |
 | `tdsBlur`   | Blur event for the Textarea   | `CustomEvent<FocusEvent>` |
-| `tdsChange` | Change event for the Textarea | `CustomEvent<any>`        |
+| `tdsChange` | Change event for the Textarea | `CustomEvent<Event>`      |
 | `tdsFocus`  | Focus event for the Textarea  | `CustomEvent<FocusEvent>` |
 | `tdsInput`  | Input event for the Textarea  | `CustomEvent<InputEvent>` |
 

--- a/packages/core/src/components/textarea/textarea.tsx
+++ b/packages/core/src/components/textarea/textarea.tsx
@@ -80,9 +80,9 @@ export class TdsTextarea {
     bubbles: true,
     cancelable: false,
   })
-  tdsChange!: EventEmitter;
+  tdsChange!: EventEmitter<Event>;
 
-  handleChange(event): void {
+  handleChange(event: Event): void {
     this.tdsChange.emit(event);
   }
 


### PR DESCRIPTION
## **Describe pull-request**  
This PR addresses an issue raised by a user, where some of our Event Emitters were not typed, and that would lead to confusion when implementing Tegel. 
Types were added where they were missing, namely on `tds-datetime`, `tds-text-field`, `tds-modal`, `tds-textarea`, and `tds-popover-core`.  

## **Issue Linking:**  
- **No issue:** Issue raised in Teams Support channel

## **How to test**  
In general, just verify that no behaviour is broken in the components mentioned above. 
1. Go to Storybook,
2. Open datetime/modal/text field/textarea/popover menu or canvas,
3. Interact a bit and check that no behaviour is broken

## **Additional context**  
For the tds-datetime component, ideally we would only send the object `{ name, value }`, however this would most likely introduce breaking changes to the users, so we opted for having the EventEmitter typed with either that or an actual Event.