### PR TITLE
fix(event): refer to dom event type to globalThis.event

### DIFF
--- a/packages/core/src/components/datetime/datetime.tsx
+++ b/packages/core/src/components/datetime/datetime.tsx
@@ -92,7 +92,7 @@ export class TdsDatetime {
     bubbles: true,
     cancelable: false,
   })
-  tdsChange!: EventEmitter<Event | { name: string; value: string }>;
+  tdsChange!: EventEmitter<globalThis.Event | { name: string; value: string }>;
 
   /** Blur event for the Datetime */
   @Event({

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -92,7 +92,7 @@ export class TdsModal {
     cancelable: true,
     bubbles: true,
   })
-  tdsClose!: EventEmitter<Event>;
+  tdsClose!: EventEmitter<globalThis.Event>;
 
   /** Emits just before Modal is opened. */
   @Event({

--- a/packages/core/src/components/text-field/text-field.tsx
+++ b/packages/core/src/components/text-field/text-field.tsx
@@ -103,7 +103,7 @@ export class TdsTextField {
     bubbles: true,
     cancelable: false,
   })
-  tdsChange!: EventEmitter<Event>;
+  tdsChange!: EventEmitter<globalThis.Event>;
 
   handleChange(event: Event): void {
     this.tdsChange.emit(event);

--- a/packages/core/src/components/textarea/textarea.tsx
+++ b/packages/core/src/components/textarea/textarea.tsx
@@ -80,7 +80,7 @@ export class TdsTextarea {
     bubbles: true,
     cancelable: false,
   })
-  tdsChange!: EventEmitter<Event>;
+  tdsChange!: EventEmitter<globalThis.Event>;
 
   handleChange(event: Event): void {
     this.tdsChange.emit(event);


### PR DESCRIPTION
## **Describe pull-request**  

This PR has the goal of solving typing errors on the `components.ts` file, that is generated by Stencil, for both Angular and React frameworks.

When the `EventEmitter` types were specified more explicitly, to `EventEmitter<Event>`, as the `Event` type clashes with the Stencil event type, there were type errors on this file, since the incorrect `Event` type was trying to be imported.

The fix was to explicitly added `globalThis.Event` on the affect `EventEmitter`s.

_For more info, check the [Stencil documentation](https://stenciljs.com/docs/events#event-decorator) (specifically, the yellow note on the `Event Decorator` section)._
